### PR TITLE
Extension settings backend port

### DIFF
--- a/extension/popup/popup-api.js
+++ b/extension/popup/popup-api.js
@@ -1,9 +1,9 @@
 import { normalizeRecommendation } from "./popup-helpers.js";
-
-const BACKEND_URL = "http://127.0.0.1:8420/api";
+import { getBackendBaseUrl } from "./popup-backend-config.js";
 
 async function requestJson(path, options = {}) {
-  const response = await fetch(`${BACKEND_URL}${path}`, options);
+  const backendUrl = await getBackendBaseUrl();
+  const response = await fetch(`${backendUrl}${path}`, options);
   if (!response.ok) {
     throw new Error(`${path} request failed: ${response.status}`);
   }
@@ -12,7 +12,8 @@ async function requestJson(path, options = {}) {
 
 export async function checkBackendStatus() {
   try {
-    const response = await fetch(`${BACKEND_URL}/health`, { method: "GET" });
+    const backendUrl = await getBackendBaseUrl();
+    const response = await fetch(`${backendUrl}/health`, { method: "GET" });
     return response.ok;
   } catch {
     return false;

--- a/extension/popup/popup-backend-config.js
+++ b/extension/popup/popup-backend-config.js
@@ -1,0 +1,100 @@
+export const DEFAULT_BACKEND_HOST = "127.0.0.1";
+export const DEFAULT_BACKEND_PORT = 8420;
+export const DEFAULT_BACKEND_BASE_PATH = "/api";
+
+const STORAGE_KEY = "popup_backend_endpoint";
+
+let inMemoryEndpoint = {
+  host: DEFAULT_BACKEND_HOST,
+  port: DEFAULT_BACKEND_PORT,
+  basePath: DEFAULT_BACKEND_BASE_PATH,
+};
+
+function getStorageLocal() {
+  return globalThis.chrome?.storage?.local ?? null;
+}
+
+function normalizePort(value) {
+  if (typeof value === "number" && Number.isInteger(value)) {
+    return value;
+  }
+  if (typeof value === "string" && value.trim() !== "") {
+    const parsed = Number.parseInt(value.trim(), 10);
+    if (Number.isInteger(parsed)) {
+      return parsed;
+    }
+  }
+  return null;
+}
+
+export function isValidBackendPort(value) {
+  const port = normalizePort(value);
+  return port !== null && port >= 1 && port <= 65535;
+}
+
+function sanitizeEndpoint(raw) {
+  const host = String(raw?.host ?? DEFAULT_BACKEND_HOST).trim() || DEFAULT_BACKEND_HOST;
+  const basePath = String(raw?.basePath ?? DEFAULT_BACKEND_BASE_PATH).trim() || DEFAULT_BACKEND_BASE_PATH;
+  const port = isValidBackendPort(raw?.port) ? normalizePort(raw.port) : DEFAULT_BACKEND_PORT;
+  return {
+    host,
+    port,
+    basePath: basePath.startsWith("/") ? basePath : `/${basePath}`,
+  };
+}
+
+async function storageGet(key) {
+  const storage = getStorageLocal();
+  if (storage == null || typeof storage.get !== "function") {
+    return {};
+  }
+  return new Promise((resolve) => {
+    try {
+      storage.get(key, (items) => {
+        resolve(items ?? {});
+      });
+    } catch {
+      resolve({});
+    }
+  });
+}
+
+async function storageSet(items) {
+  const storage = getStorageLocal();
+  if (storage == null || typeof storage.set !== "function") {
+    return;
+  }
+  await new Promise((resolve) => {
+    try {
+      storage.set(items, () => resolve(undefined));
+    } catch {
+      resolve(undefined);
+    }
+  });
+}
+
+export async function getBackendEndpointConfig() {
+  const items = await storageGet(STORAGE_KEY);
+  const endpoint = sanitizeEndpoint(items?.[STORAGE_KEY] ?? inMemoryEndpoint);
+  inMemoryEndpoint = endpoint;
+  return endpoint;
+}
+
+export async function getBackendBaseUrl() {
+  const endpoint = await getBackendEndpointConfig();
+  return `http://${endpoint.host}:${endpoint.port}${endpoint.basePath}`;
+}
+
+export async function updateBackendPort(port) {
+  if (!isValidBackendPort(port)) {
+    throw new Error("端口必须是 1-65535 的整数");
+  }
+  const current = await getBackendEndpointConfig();
+  const next = sanitizeEndpoint({
+    ...current,
+    port: normalizePort(port),
+  });
+  inMemoryEndpoint = next;
+  await storageSet({ [STORAGE_KEY]: next });
+  return next;
+}

--- a/extension/popup/popup-stream.js
+++ b/extension/popup/popup-stream.js
@@ -1,3 +1,5 @@
+import { getBackendBaseUrl } from "./popup-backend-config.js";
+
 const DEFAULT_BACKEND_URL = "http://127.0.0.1:8420/api";
 
 export function createRuntimeStreamUrl(backendUrl = DEFAULT_BACKEND_URL) {
@@ -9,7 +11,8 @@ export function createRuntimeStreamUrl(backendUrl = DEFAULT_BACKEND_URL) {
 }
 
 export function createRuntimeStreamClient({
-  backendUrl = DEFAULT_BACKEND_URL,
+  backendUrl = null,
+  getBackendUrl = getBackendBaseUrl,
   WebSocketImpl = globalThis.WebSocket,
   reconnectDelayMs = 2000,
   // v0.3.14+: cap reconnect delay so popup doesn't flood console with
@@ -47,28 +50,34 @@ export function createRuntimeStreamClient({
     if (stopped || typeof WebSocketImpl !== "function") {
       return;
     }
-    socket = new WebSocketImpl(createRuntimeStreamUrl(backendUrl));
-    socket.onopen = () => {
-      wasConnected = true;
-      currentReconnectDelay = reconnectDelayMs;
-      onConnect();
-    };
-    socket.onmessage = (event) => {
-      try {
-        const payload = JSON.parse(event.data);
-        onEvent(payload);
-      } catch {
-        // Ignore malformed payloads and keep the stream alive.
+    void (async () => {
+      const resolvedBackendUrl = backendUrl ?? await getBackendUrl();
+      if (stopped) {
+        return;
       }
-    };
-    socket.onclose = () => {
-      socket = null;
-      if (wasConnected) {
-        wasConnected = false;
-        onDisconnect();
-      }
-      scheduleReconnect();
-    };
+      socket = new WebSocketImpl(createRuntimeStreamUrl(resolvedBackendUrl));
+      socket.onopen = () => {
+        wasConnected = true;
+        currentReconnectDelay = reconnectDelayMs;
+        onConnect();
+      };
+      socket.onmessage = (event) => {
+        try {
+          const payload = JSON.parse(event.data);
+          onEvent(payload);
+        } catch {
+          // Ignore malformed payloads and keep the stream alive.
+        }
+      };
+      socket.onclose = () => {
+        socket = null;
+        if (wasConnected) {
+          wasConnected = false;
+          onDisconnect();
+        }
+        scheduleReconnect();
+      };
+    })();
   }
 
   function disconnect() {

--- a/extension/popup/popup.html
+++ b/extension/popup/popup.html
@@ -3845,6 +3845,10 @@
       <div class="settings-section">
         <h3><span class="section-icon">&#x2699;&#xFE0F;</span> 通用</h3>
         <div class="settings-field">
+          <label for="cfgBackendPort">后端端口</label>
+          <input id="cfgBackendPort" type="number" min="1" max="65535" step="1" placeholder="8420">
+        </div>
+        <div class="settings-field">
           <label for="cfgLanguage">语言</label>
           <select id="cfgLanguage">
             <option value="zh">中文</option>

--- a/extension/popup/popup.html
+++ b/extension/popup/popup.html
@@ -3853,6 +3853,10 @@
       <div class="settings-section">
         <h3><span class="section-icon">&#x2699;&#xFE0F;</span> 通用</h3>
         <div class="settings-field">
+          <label for="cfgBackendPort">后端端口</label>
+          <input id="cfgBackendPort" type="number" min="1" max="65535" step="1" placeholder="8420">
+        </div>
+        <div class="settings-field">
           <label for="cfgLanguage">语言</label>
           <select id="cfgLanguage">
             <option value="zh">中文</option>

--- a/extension/popup/popup.js
+++ b/extension/popup/popup.js
@@ -27,25 +27,27 @@ import {
 } from "./popup-helpers.js";
 import { createRuntimeStreamClient } from "./popup-stream.js";
 import {
+  getBackendEndpointConfig,
+  isValidBackendPort,
+  updateBackendPort,
+} from "./popup-backend-config.js";
+import {
   appendRecommendations,
   checkBackendStatus,
   fetchActivityFeed,
-  fetchChatTurn,
-  fetchChatTurns,
   fetchConfig,
   fetchPendingDelight,
   fetchPendingDelightBatch,
   fetchProfileSummary,
   fetchRecommendations,
   fetchRuntimeStatus,
-  fetchSourceShareSuggestion,
   markDelightSent,
   reportRecommendationClick,
   reshuffleRecommendations,
   refreshRecommendations,
   respondToDelight,
   respondToInterestProbe,
-  startChatTurn,
+  sendChatMessage,
   submitFeedback,
   updateConfig,
 } from "./popup-api.js";
@@ -152,10 +154,7 @@ const elements = {
 };
 
 let recommendationLoadCheckTimer = null;
-const CHAT_SESSION = "popup";
-const CHAT_POLL_INTERVAL_MS = 1200;
-const CHAT_POLL_DEADLINE_MS = 180_000;
-const activeChatPolls = new Map();
+let runtimeStreamClient = null;
 
 function setRefreshButtonState(loading, message = "") {
   state.refreshStatusMessage = message;
@@ -394,8 +393,6 @@ function updateDelightHead(updates) {
   if (state.activeDelights.length === 0) return;
   state.activeDelights[idx] = { ...state.activeDelights[idx], ...updates };
   syncDelightHead();
-  const bvid = state.activeDelights[idx]?.bvid;
-  if (bvid) persistDelightLocalState(bvid, updates);
 }
 
 function clearDelightQueue() {
@@ -421,6 +418,7 @@ function getRuntimeEventTone(event) {
 }
 
 function connectRuntimeStream() {
+  runtimeStreamClient?.disconnect?.();
   const client = createRuntimeStreamClient({
     onEvent(event) {
       state.runtimeEvent = event;
@@ -534,6 +532,7 @@ function connectRuntimeStream() {
     },
   });
   client.connect();
+  runtimeStreamClient = client;
 }
 
 function renderActivityHistory(items) {
@@ -1059,15 +1058,6 @@ function buildMessageCard(probe) {
     item.append(chips);
   }
 
-  if (probe.chat_status === "pending") {
-    item.append(createChatThinkingPlaceholder("阿B 正在思考这个方向"));
-  } else if (probe.chat_reply) {
-    const reply = document.createElement("div");
-    reply.className = "message-chat-reply";
-    reply.textContent = probe.chat_reply;
-    item.append(reply);
-  }
-
   const actions = document.createElement("div");
   actions.className = "message-actions";
 
@@ -1085,12 +1075,6 @@ function buildMessageCard(probe) {
   chatBtn.className = "probe-btn is-chat";
   chatBtn.textContent = "\u591A\u804A\u804A";
   chatBtn.addEventListener("click", () => expandInlineChat(item, probe.domain));
-
-  if (probe.chat_status === "pending") {
-    confirmBtn.disabled = true;
-    rejectBtn.disabled = true;
-    chatBtn.disabled = true;
-  }
 
   actions.append(confirmBtn, rejectBtn, chatBtn);
   item.append(actions);
@@ -1161,15 +1145,6 @@ function buildDelightCard(delight) {
     item.append(reason);
   }
 
-  if (delight.chat_status === "pending") {
-    item.append(createChatThinkingPlaceholder("阿B 正在品你这句话"));
-  } else if (delight.chat_reply) {
-    const reply = document.createElement("div");
-    reply.className = "message-chat-reply";
-    reply.textContent = delight.chat_reply;
-    item.append(reply);
-  }
-
   // Action buttons
   const actions = document.createElement("div");
   actions.className = "message-actions";
@@ -1198,13 +1173,6 @@ function buildDelightCard(delight) {
   chatBtn.className = "probe-btn is-chat";
   chatBtn.textContent = "\u804A\u4E00\u804A";
   chatBtn.addEventListener("click", () => expandDelightChat(item, delight));
-
-  if (delight.chat_status === "pending") {
-    viewBtn.disabled = true;
-    likeBtn.disabled = true;
-    dislikeBtn.disabled = true;
-    chatBtn.disabled = true;
-  }
 
   actions.append(viewBtn, likeBtn, dislikeBtn, chatBtn);
   item.append(actions);
@@ -1252,43 +1220,19 @@ function expandDelightChat(itemEl, delight) {
     const message = input.value.trim();
     if (!message) return;
     sendBtn.disabled = true;
-    const turnId = createClientTurnId("delight");
     const thinking = createChatThinkingPlaceholder("\u963fB \u6b63\u5728\u54c1\u4f60\u8fd9\u53e5\u8bdd");
     itemEl.append(thinking);
     try {
-      const turn = await startChatTurn({
-        turnId,
-        session: CHAT_SESSION,
-        scope: "delight",
-        subjectId: delight.bvid,
-        subjectTitle: delight.title || "",
-        message,
-      });
+      const result = await respondToDelight(delight.bvid, "chat", delight.title, message);
+      const reply = result?.reply || "\u6536\u5230\u4E86\uFF0C\u6211\u4F1A\u7EE7\u7EED\u89C2\u5BDF\u3002";
+      thinking.remove();
+      const replyEl = document.createElement("div");
+      replyEl.className = "message-chat-reply";
+      replyEl.textContent = reply;
+      itemEl.append(replyEl);
       const ca = itemEl.querySelector(".message-chat-area");
       if (ca) ca.remove();
-      const showReply = (nextTurn) => {
-        thinking.remove();
-        const replyEl = document.createElement("div");
-        replyEl.className = "message-chat-reply";
-        replyEl.textContent =
-          nextTurn.reply || "\u6536\u5230\u4E86\uFF0C\u6211\u4F1A\u7EE7\u7EED\u89C2\u5BDF\u3002";
-        itemEl.append(replyEl);
-        applyTurnToMessage(nextTurn);
-        applyTurnToDelight(nextTurn);
-        setTimeout(() => { dismissMessageByBvid(delight.bvid); itemEl.remove(); renderMessagesEmptyIfNeeded(); }, 4000);
-      };
-      if (turn.status === "completed" || turn.status === "failed") {
-        showReply(turn);
-      } else {
-        applyTurnToMessage(turn);
-        pollChatTurnUntilSettled(turn.turn_id, {
-          onUpdate(nextTurn) {
-            if (nextTurn.status === "completed" || nextTurn.status === "failed") {
-              showReply(nextTurn);
-            }
-          },
-        });
-      }
+      setTimeout(() => { dismissMessageByBvid(delight.bvid); itemEl.remove(); renderMessagesEmptyIfNeeded(); }, 4000);
     } catch (err) {
       console.error("Delight chat failed:", err);
       thinking.remove();
@@ -1384,7 +1328,6 @@ async function sendInlineChat(itemEl, domain, input, sendBtn) {
   if (!message) return;
 
   sendBtn.disabled = true;
-  const turnId = createClientTurnId("probe");
 
   // Show a thinking placeholder so the user knows we\u2019re waiting
   // on the LLM. The composer\u2019s send button alone going gray
@@ -1394,46 +1337,27 @@ async function sendInlineChat(itemEl, domain, input, sendBtn) {
   itemEl.append(thinking);
 
   try {
-    const turn = await startChatTurn({
-      turnId,
-      session: CHAT_SESSION,
-      scope: "probe",
-      subjectId: domain,
-      subjectTitle: domain,
-      message,
-    });
+    const result = await respondToInterestProbe(domain, "chat", message);
+    const reply = result?.reply || result?.message || "\u6536\u5230\u4E86\uFF0C\u6211\u4F1A\u7ED3\u5408\u8FD9\u4E2A\u65B9\u5411\u7EE7\u7EED\u89C2\u5BDF\u3002";
+
+    thinking.remove();
+
+    // Show reply
+    const replyEl = document.createElement("div");
+    replyEl.className = "message-chat-reply";
+    replyEl.textContent = reply;
+    itemEl.append(replyEl);
 
     // Remove chat area, show result, then remove card after delay
     const chatArea = itemEl.querySelector(".message-chat-area");
     if (chatArea) chatArea.remove();
 
-    const showReply = (nextTurn) => {
-      thinking.remove();
-      const replyEl = document.createElement("div");
-      replyEl.className = "message-chat-reply";
-      replyEl.textContent =
-        nextTurn.reply || "\u6536\u5230\u4E86\uFF0C\u6211\u4F1A\u7ED3\u5408\u8FD9\u4E2A\u65B9\u5411\u7EE7\u7EED\u89C2\u5BDF\u3002";
-      itemEl.append(replyEl);
-      applyTurnToMessage(nextTurn);
-      setTimeout(() => {
-        removeMessageFromState(domain);
-        itemEl.remove();
-        renderMessagesEmptyIfNeeded();
-      }, 4000);
-    };
-
-    if (turn.status === "completed" || turn.status === "failed") {
-      showReply(turn);
-    } else {
-      applyTurnToMessage(turn);
-      pollChatTurnUntilSettled(turn.turn_id, {
-        onUpdate(nextTurn) {
-          if (nextTurn.status === "completed" || nextTurn.status === "failed") {
-            showReply(nextTurn);
-          }
-        },
-      });
-    }
+    // Remove from messages after showing reply
+    setTimeout(() => {
+      removeMessageFromState(domain);
+      itemEl.remove();
+      renderMessagesEmptyIfNeeded();
+    }, 4000);
   } catch (err) {
     console.error("Inline chat failed:", err);
     thinking.remove();
@@ -2130,14 +2054,12 @@ function renderProfileSummary(summary) {
   renderRecentAwareness(elements.profileRecentAwareness, summary.recent_awareness);
 }
 
-function appendChatMessage(role, content, { turnId = "", part = "" } = {}) {
+function appendChatMessage(role, content) {
   if (!(elements.chatMessages instanceof HTMLElement)) {
     return null;
   }
   const item = document.createElement("div");
   item.className = `chat-message${role === "你" ? " user" : ""}`;
-  if (turnId) item.dataset.turnId = turnId;
-  if (part) item.dataset.part = part;
 
   const label = document.createElement("span");
   label.className = "chat-role";
@@ -2157,16 +2079,12 @@ function appendChatMessage(role, content, { turnId = "", part = "" } = {}) {
 // wait for the dialogue endpoint. Returns the bubble element so the
 // submit handler can swap it for the real reply (or an error) once
 // the request resolves.
-function appendChatThinkingPlaceholder(turnId = "") {
+function appendChatThinkingPlaceholder() {
   if (!(elements.chatMessages instanceof HTMLElement)) {
     return null;
   }
   const item = document.createElement("div");
   item.className = "chat-message chat-thinking";
-  if (turnId) {
-    item.dataset.turnId = turnId;
-    item.dataset.part = "assistant";
-  }
 
   const label = document.createElement("span");
   label.className = "chat-role";
@@ -2202,245 +2120,6 @@ function replaceChatThinkingPlaceholder(placeholder, content) {
   }
   if (elements.chatMessages instanceof HTMLElement) {
     elements.chatMessages.scrollTop = elements.chatMessages.scrollHeight;
-  }
-}
-
-const DELIGHT_LOCAL_STATE_KEY = "openbiliclaw_delight_local";
-// Fields added locally (not from backend) that must survive a panel reload.
-const DELIGHT_PERSIST_FIELDS = [
-  "chat_draft",
-  "chat_reply",
-  "chat_turn_id",
-  "state",
-  "response_message",
-  "expanded",
-  "composer_open",
-];
-
-function persistDelightLocalState(bvid, updates) {
-  const relevant = Object.fromEntries(
-    Object.entries(updates).filter(([k]) => DELIGHT_PERSIST_FIELDS.includes(k)),
-  );
-  if (Object.keys(relevant).length === 0) return;
-  try {
-    const raw =
-      localStorage.getItem(DELIGHT_LOCAL_STATE_KEY) ||
-      sessionStorage.getItem(DELIGHT_LOCAL_STATE_KEY);
-    const all = raw ? JSON.parse(raw) : {};
-    all[bvid] = { ...(all[bvid] ?? {}), ...relevant };
-    localStorage.setItem(DELIGHT_LOCAL_STATE_KEY, JSON.stringify(all));
-  } catch {
-    // silent fallback
-  }
-}
-
-function createClientTurnId(prefix = "turn") {
-  const random = globalThis.crypto?.randomUUID?.() || `${Date.now()}-${Math.random()}`;
-  return `${prefix}-${String(random).replace(/[^a-zA-Z0-9_-]/g, "")}`;
-}
-
-function findChatTurnElement(turnId, part) {
-  if (!(elements.chatMessages instanceof HTMLElement) || !turnId) {
-    return null;
-  }
-  return elements.chatMessages.querySelector(
-    `[data-turn-id="${CSS.escape(turnId)}"][data-part="${CSS.escape(part)}"]`,
-  );
-}
-
-function renderChatTurn(turn) {
-  if (!turn?.turn_id || !(elements.chatMessages instanceof HTMLElement)) {
-    return;
-  }
-  const userPart = findChatTurnElement(turn.turn_id, "user");
-  if (!userPart) {
-    appendChatMessage("你", turn.message || "", {
-      turnId: turn.turn_id,
-      part: "user",
-    });
-  }
-
-  const assistantPart = findChatTurnElement(turn.turn_id, "assistant");
-  const status = String(turn.status || "pending");
-  if (status === "completed") {
-    if (assistantPart instanceof HTMLElement) {
-      replaceChatThinkingPlaceholder(assistantPart, turn.reply || "");
-    } else {
-      appendChatMessage("助手", turn.reply || "", {
-        turnId: turn.turn_id,
-        part: "assistant",
-      });
-    }
-    return;
-  }
-  if (status === "failed") {
-    const message = turn.reply || "刚刚没发出去，换个说法再试试。";
-    if (assistantPart instanceof HTMLElement) {
-      replaceChatThinkingPlaceholder(assistantPart, message);
-    } else {
-      appendChatMessage("助手", message, {
-        turnId: turn.turn_id,
-        part: "assistant",
-      });
-    }
-    return;
-  }
-  if (!assistantPart) {
-    appendChatThinkingPlaceholder(turn.turn_id);
-  }
-}
-
-function applyTurnToDelight(turn) {
-  if (!turn || turn.scope !== "delight" || !turn.subject_id) return;
-  const idx = state.activeDelights.findIndex((item) => item?.bvid === turn.subject_id);
-  if (idx < 0) return;
-  const updates = {
-    chat_turn_id: turn.turn_id,
-    expanded: true,
-  };
-  if (turn.status === "completed") {
-    Object.assign(updates, {
-      state: "chatted",
-      response_message: "这句已经记下，后面会更会试探。",
-      chat_reply: turn.reply || "",
-      chat_draft: "",
-      composer_open: false,
-    });
-  } else if (turn.status === "failed") {
-    Object.assign(updates, {
-      state: "pending",
-      response_message: "这句还没发出去，稍后再试。",
-      composer_open: true,
-    });
-  } else {
-    Object.assign(updates, {
-      state: "chatting",
-      response_message: "阿B 正在品你这句话。",
-      composer_open: false,
-    });
-  }
-  state.activeDelights[idx] = { ...state.activeDelights[idx], ...updates };
-  persistDelightLocalState(turn.subject_id, updates);
-  syncDelightHead();
-}
-
-function applyTurnToMessage(turn) {
-  if (!turn || !turn.subject_id) return;
-  const type = turn.scope === "delight" ? "delight" : "interest.probe";
-  const idx = state.messages.findIndex((item) => {
-    const itemType = item?.type || "interest.probe";
-    return (
-      itemType === type &&
-      (type === "delight" ? item.bvid === turn.subject_id : item.domain === turn.subject_id)
-    );
-  });
-  if (idx < 0) return;
-  state.messages[idx] = {
-    ...state.messages[idx],
-    chat_turn_id: turn.turn_id,
-    chat_status: turn.status,
-    chat_reply: turn.status === "completed" ? turn.reply || "" : state.messages[idx].chat_reply || "",
-  };
-}
-
-function pollChatTurnUntilSettled(turnId, { onUpdate, onDone } = {}) {
-  if (!turnId || activeChatPolls.has(turnId)) return;
-  const startedAt = Date.now();
-
-  async function tick() {
-    try {
-      const turn = await fetchChatTurn(turnId);
-      onUpdate?.(turn);
-      if (turn.status === "completed" || turn.status === "failed") {
-        activeChatPolls.delete(turnId);
-        await onDone?.(turn);
-        return;
-      }
-    } catch {
-      // Keep polling until the deadline; reload recovery is best-effort
-      // while the backend or network is temporarily unavailable.
-    }
-    if (Date.now() - startedAt > CHAT_POLL_DEADLINE_MS) {
-      activeChatPolls.delete(turnId);
-      return;
-    }
-    const timeoutId = window.setTimeout(tick, CHAT_POLL_INTERVAL_MS);
-    activeChatPolls.set(turnId, timeoutId);
-  }
-
-  activeChatPolls.set(turnId, 0);
-  void tick();
-}
-
-async function refreshAfterChatTurn() {
-  await refreshProfileSummaryAfterInteraction({
-    onProfileStart() {
-      setChatStatus(getSubmissionProgressMessage("chat", "refreshing_profile"), "info");
-    },
-    onActivityStart() {
-      setChatStatus(getSubmissionProgressMessage("chat", "refreshing_activity"), "info");
-    },
-    onDone() {
-      setChatStatus(getSubmissionProgressMessage("chat", "success"), "success");
-    },
-  });
-}
-
-async function hydrateChatHistory() {
-  if (!(elements.chatMessages instanceof HTMLElement) || !state.online) {
-    return;
-  }
-  try {
-    const payload = await fetchChatTurns({ session: CHAT_SESSION, scope: "chat", limit: 50 });
-    elements.chatMessages.replaceChildren();
-    for (const turn of payload.items || []) {
-      renderChatTurn(turn);
-      if (turn.status === "pending") {
-        pollChatTurnUntilSettled(turn.turn_id, {
-          onUpdate: renderChatTurn,
-          onDone: refreshAfterChatTurn,
-        });
-      }
-    }
-  } catch {
-    // History is opportunistic; core panel loading should continue offline.
-  }
-}
-
-async function syncScopedChatTurns() {
-  if (!state.online) return;
-  try {
-    const [delightTurns, probeTurns] = await Promise.all([
-      fetchChatTurns({ session: CHAT_SESSION, scope: "delight", limit: 80 }),
-      fetchChatTurns({ session: CHAT_SESSION, scope: "probe", limit: 80 }),
-    ]);
-    for (const turn of delightTurns.items || []) {
-      applyTurnToDelight(turn);
-      applyTurnToMessage(turn);
-      if (turn.status === "pending") {
-        pollChatTurnUntilSettled(turn.turn_id, {
-          onUpdate(nextTurn) {
-            applyTurnToDelight(nextTurn);
-            applyTurnToMessage(nextTurn);
-            renderDelightSlot();
-            renderMessagesList();
-          },
-        });
-      }
-    }
-    for (const turn of probeTurns.items || []) {
-      applyTurnToMessage(turn);
-      if (turn.status === "pending") {
-        pollChatTurnUntilSettled(turn.turn_id, {
-          onUpdate(nextTurn) {
-            applyTurnToMessage(nextTurn);
-            renderMessagesList();
-          },
-        });
-      }
-    }
-  } catch {
-    // Scoped turn hydration is best-effort; backend fetches on init heal it.
   }
 }
 
@@ -2557,7 +2236,6 @@ function renderDelightSlot() {
 
   const delight = head;
   const isHandled = uiState.handled;
-  const isChatting = delight.state === "chatting";
   const isExpanded = Boolean(delight.expanded);
 
   // Banner with thumbnail. Collapsed = ~64px row showing thumbnail +
@@ -2719,7 +2397,7 @@ function renderDelightSlot() {
         });
         renderDelightSlot();
         setTimeout(() => {
-          if (state.activeDelights[state.delightCurrentIndex]?.bvid === delight.bvid) {
+          if (state.activeDelights[0]?.bvid === delight.bvid) {
             shiftDelightQueue();
             renderDelightSlot();
           }
@@ -2771,7 +2449,7 @@ function renderDelightSlot() {
       },
     );
 
-    if (isHandled || isChatting) {
+    if (isHandled) {
       rejectButton.disabled = true;
       likeButton.disabled = true;
     }
@@ -2789,7 +2467,7 @@ function renderDelightSlot() {
       input.placeholder = "说说你为什么想点开，或者哪里还拿不准";
       input.value = delight.chat_draft || "";
       input.addEventListener("input", () => {
-        if (state.activeDelights[state.delightCurrentIndex]?.bvid === delight.bvid) {
+        if (state.activeDelights[0]?.bvid === delight.bvid) {
           updateDelightHead({ chat_draft: input.value });
         }
       });
@@ -2808,75 +2486,38 @@ function renderDelightSlot() {
             return;
           }
           submit.disabled = true;
-          const turnId = createClientTurnId("delight");
-          updateDelightHead({
-            state: "chatting",
-            response_message: "阿B 正在品你这句话。",
-            chat_turn_id: turnId,
-            chat_draft: draft,
-            composer_open: false,
-            expanded: true,
-          });
-          renderDelightSlot();
+          // Show animated thinking dots so the user knows the LLM
+          // is working — a static "正在整理…" line wasn't enough
+          // signal during the 5-30s delight chat round-trip.
           status.replaceChildren();
           status.append(
             createChatThinkingPlaceholder("阿B 正在品你这句话"),
           );
           try {
-            const turn = await startChatTurn({
-              turnId,
-              session: CHAT_SESSION,
-              scope: "delight",
-              subjectId: delight.bvid,
-              subjectTitle: delight.title || "",
-              message: draft,
-            });
-            applyTurnToDelight(turn);
-            applyTurnToMessage(turn);
-            renderDelightSlot();
-            if (turn.status === "completed") {
-              setHint("这句记下了，后面的惊喜推荐会继续学。", "success");
-            } else if (turn.status === "pending") {
-              pollChatTurnUntilSettled(turn.turn_id, {
-                onUpdate(nextTurn) {
-                  applyTurnToDelight(nextTurn);
-                  applyTurnToMessage(nextTurn);
-                  renderDelightSlot();
-                },
-                async onDone(doneTurn) {
-                  if (doneTurn.status === "completed") {
-                    setHint("这句记下了，后面的惊喜推荐会继续学。", "success");
-                  }
-                  await refreshProfileSummaryAfterInteraction({
-                    onProfileStart() {
-                      setHint("正在同步画像。", "info");
-                    },
-                    onActivityStart() {
-                      setHint("画像已同步，正在刷新最近动态。", "info");
-                    },
-                  });
-                },
-              });
-            }
-            if (turn.status === "completed" || turn.status === "failed") {
-              await refreshProfileSummaryAfterInteraction({
-                onProfileStart() {
-                  setHint("正在同步画像。", "info");
-                },
-                onActivityStart() {
-                  setHint("画像已同步，正在刷新最近动态。", "info");
-                },
-              });
-            }
-          } catch {
-            submit.disabled = false;
+            const payload = await sendChatMessage(
+              `我想聊聊一条惊喜推荐。\n标题：${delight.title}\n理由：${delight.delight_reason}\n我的想法：${draft}`,
+            );
             updateDelightHead({
-              state: "pending",
-              response_message: "这句还没发出去，稍后再试。",
-              composer_open: true,
+              state: "chatted",
+              response_message: "这句已经记下，后面会更会试探。",
+              chat_reply: payload.reply,
+              chat_draft: "",
+              composer_open: false,
               expanded: true,
             });
+            setHint("这句记下了，后面的惊喜推荐会继续学。", "success");
             renderDelightSlot();
+            await refreshProfileSummaryAfterInteraction({
+              onProfileStart() {
+                setHint("正在同步画像。", "info");
+              },
+              onActivityStart() {
+                setHint("画像已同步，正在刷新最近动态。", "info");
+              },
+            });
+          } catch {
+            submit.disabled = false;
+            status.textContent = "这句还没发出去，稍后再试。";
           }
         },
       );
@@ -3363,7 +3004,6 @@ async function loadProfileSummary({ force = false } = {}) {
   // its WebSocket pushes via ``probed_domains``, so already-pushed
   // probes won't re-arrive on reconnect).
   hydrateInboxFromSpeculations(state.profile?.speculative_interests);
-  void syncScopedChatTurns();
   state.profileLoaded = true;
   renderProfileSummary(state.profile);
   maybeLoadMoreCognitionHistory();
@@ -3540,34 +3180,10 @@ async function initializeRecommendations() {
     clearDelightQueue();
     for (const item of delightResult.value) {
       pushDelightCandidate(item);
-      if (!state.messages.some((m) => m.type === "delight" && m.bvid === item.bvid)) {
-        state.messages.push({ ...item, type: "delight" });
-      }
-    }
-    // Restore local-only delight state (chat_reply, draft, composer, etc.)
-    // that survives a Chrome side-panel reload.
-    try {
-      const raw =
-        localStorage.getItem(DELIGHT_LOCAL_STATE_KEY) ||
-        sessionStorage.getItem(DELIGHT_LOCAL_STATE_KEY);
-      if (raw) {
-        const localState = JSON.parse(raw);
-        for (let i = 0; i < state.activeDelights.length; i++) {
-          const bvid = state.activeDelights[i]?.bvid;
-          if (bvid && localState[bvid]) {
-            state.activeDelights[i] = { ...state.activeDelights[i], ...localState[bvid] };
-          }
-        }
-        syncDelightHead();
-      }
-    } catch {
-      // Ignore corrupt or inaccessible sessionStorage.
     }
   }
   renderPoolStatus(state.runtimeStatus);
   renderDelightSlot();
-  updateMessageBadge();
-  await syncScopedChatTurns();
   await loadActivityFeed();
 
   if (recommendationResult.status === "fulfilled") {
@@ -3726,9 +3342,8 @@ function bindChat() {
       return;
     }
 
-    const turnId = createClientTurnId("chat");
-    appendChatMessage("你", message, { turnId, part: "user" });
-    const thinkingPlaceholder = appendChatThinkingPlaceholder(turnId);
+    appendChatMessage("你", message);
+    const thinkingPlaceholder = appendChatThinkingPlaceholder();
     elements.chatInput.value = "";
     elements.chatSendButton.disabled = true;
     elements.chatSendButton.textContent = "发送中...";
@@ -3741,38 +3356,31 @@ function bindChat() {
     }, 2500);
 
     try {
-      const turn = await startChatTurn({
-        turnId,
-        session: CHAT_SESSION,
-        scope: "chat",
-        message,
-      });
+      const payload = await sendChatMessage(message);
       clearSlowStatusTimer();
-      renderChatTurn(turn);
-      setHint("收到，阿B 正在整理。", "success");
-      if (turn.status === "completed" || turn.status === "failed") {
-        await refreshAfterChatTurn();
+      if (thinkingPlaceholder) {
+        replaceChatThinkingPlaceholder(thinkingPlaceholder, payload.reply);
       } else {
-        pollChatTurnUntilSettled(turn.turn_id, {
-          onUpdate: renderChatTurn,
-          async onDone(doneTurn) {
-            if (doneTurn.status === "completed") {
-              setHint("这句记下了。", "success");
-            }
-            await refreshAfterChatTurn();
-          },
-        });
-        setChatStatus(getSubmissionProgressMessage("chat", "waiting_reply"), "info");
+        appendChatMessage("助手", payload.reply);
       }
+      setHint("收到，这句记下了。", "success");
+      await refreshProfileSummaryAfterInteraction({
+        onProfileStart() {
+          setChatStatus(getSubmissionProgressMessage("chat", "refreshing_profile"), "info");
+        },
+        onActivityStart() {
+          setChatStatus(getSubmissionProgressMessage("chat", "refreshing_activity"), "info");
+        },
+        onDone() {
+          setChatStatus(getSubmissionProgressMessage("chat", "success"), "success");
+        },
+      });
     } catch {
       clearSlowStatusTimer();
       if (thinkingPlaceholder) {
         replaceChatThinkingPlaceholder(thinkingPlaceholder, "刚刚没发出去，换个说法再试试。");
       } else {
-        appendChatMessage("助手", "刚刚没发出去，换个说法再试试。", {
-          turnId,
-          part: "assistant",
-        });
+        appendChatMessage("助手", "刚刚没发出去，换个说法再试试。");
       }
       setChatStatus(getSubmissionProgressMessage("chat", "error"), "error");
       setHint("聊天接口这会儿没接上，先看看本地后端是不是开着。", "error");
@@ -3794,6 +3402,7 @@ function bindSettings() {
   const toast = document.getElementById("settingsToast");
   const issuesContainer = document.getElementById("settingsIssues");
   const providerSelect = document.getElementById("cfgLlmProvider");
+  const backendPortInput = document.getElementById("cfgBackendPort");
 
   if (!gearBtn || !overlay || !backBtn || !saveBtn) return;
 
@@ -3876,39 +3485,16 @@ function bindSettings() {
     }
   }
 
-  const setVal = (id, val) => {
-    const el = document.getElementById(id);
-    if (el) el.value = val ?? "";
-  };
-
-  const getVal = (id) => {
-    const el = document.getElementById(id);
-    return el ? el.value : "";
-  };
-
-  const getInt = (id, fallback) => {
-    const raw = getVal(id);
-    if (raw === "") return fallback;
-    const parsed = parseInt(raw, 10);
-    return Number.isFinite(parsed) ? parsed : fallback;
-  };
-
-  const getFloat = (id, fallback) => {
-    const raw = getVal(id);
-    if (raw === "") return fallback;
-    const parsed = parseFloat(raw);
-    return Number.isFinite(parsed) ? parsed : fallback;
-  };
-
-  const checked = (id, fallback = false) => {
-    const el = document.getElementById(id);
-    return el ? el.checked : fallback;
-  };
-
   function populateForm(cfg) {
     // LLM
     providerSelect.value = cfg.llm?.default_provider || "openai";
     showProviderFields(providerSelect.value);
+
+    // Provider fields
+    const setVal = (id, val) => {
+      const el = document.getElementById(id);
+      if (el) el.value = val || "";
+    };
 
     setVal("cfgOpenaiKey", cfg.llm?.openai?.api_key);
     setVal("cfgOpenaiModel", cfg.llm?.openai?.model);
@@ -3965,8 +3551,6 @@ function bindSettings() {
     if (sourcesBrowserHeaded) {
       sourcesBrowserHeaded.checked = cfg.sources?.browser?.headed === true;
     }
-    const xhsEnabled = document.getElementById("cfgXhsEnabled");
-    if (xhsEnabled) xhsEnabled.checked = cfg.sources?.xiaohongshu?.enabled !== false;
     setVal("cfgXhsDailySearchBudget", cfg.sources?.xiaohongshu?.daily_search_budget);
     setVal("cfgXhsDailyCreatorBudget", cfg.sources?.xiaohongshu?.daily_creator_budget);
     setVal("cfgXhsTaskInterval", cfg.sources?.xiaohongshu?.task_interval_seconds);
@@ -3977,8 +3561,6 @@ function bindSettings() {
     setVal("cfgDouyinDailyHotBudget", cfg.sources?.douyin?.daily_hot_budget);
     setVal("cfgDouyinDailyFeedBudget", cfg.sources?.douyin?.daily_feed_budget);
     setVal("cfgDouyinRequestInterval", cfg.sources?.douyin?.request_interval_seconds);
-    const youtubeEnabled = document.getElementById("cfgYoutubeEnabled");
-    if (youtubeEnabled) youtubeEnabled.checked = cfg.sources?.youtube?.enabled === true;
 
     // General
     const lang = document.getElementById("cfgLanguage");
@@ -3998,7 +3580,6 @@ function bindSettings() {
     setVal("cfgPoolShareBilibili", cfg.scheduler?.pool_source_shares?.bilibili);
     setVal("cfgPoolShareXhs", cfg.scheduler?.pool_source_shares?.xiaohongshu);
     setVal("cfgPoolShareDouyin", cfg.scheduler?.pool_source_shares?.douyin);
-    setVal("cfgPoolShareYoutube", cfg.scheduler?.pool_source_shares?.youtube);
     setVal("cfgSpeculationInterval", cfg.scheduler?.speculation_interval_minutes);
     setVal("cfgSpeculationTtl", cfg.scheduler?.speculation_ttl_days);
     setVal("cfgSpeculationCooldown", cfg.scheduler?.speculation_cooldown_days);
@@ -4023,7 +3604,36 @@ function bindSettings() {
     renderIssues(cfg.issues);
   }
 
+  async function populateBackendEndpoint() {
+    if (!(backendPortInput instanceof HTMLInputElement)) {
+      return;
+    }
+    const endpoint = await getBackendEndpointConfig();
+    backendPortInput.value = String(endpoint.port);
+  }
+
   function collectForm() {
+    const getVal = (id) => {
+      const el = document.getElementById(id);
+      return el ? el.value : "";
+    };
+    const getInt = (id, fallback) => {
+      const raw = getVal(id);
+      if (raw === "") return fallback;
+      const parsed = parseInt(raw, 10);
+      return Number.isFinite(parsed) ? parsed : fallback;
+    };
+    const getFloat = (id, fallback) => {
+      const raw = getVal(id);
+      if (raw === "") return fallback;
+      const parsed = parseFloat(raw);
+      return Number.isFinite(parsed) ? parsed : fallback;
+    };
+    const checked = (id, fallback = false) => {
+      const el = document.getElementById(id);
+      return el ? el.checked : fallback;
+    };
+
     return {
       language: getVal("cfgLanguage"),
       data_dir: getVal("cfgDataDir"),
@@ -4100,7 +3710,6 @@ function bindSettings() {
           headed: checked("cfgSourcesBrowserHeaded"),
         },
         xiaohongshu: {
-          enabled: checked("cfgXhsEnabled", true),
           daily_search_budget: getInt("cfgXhsDailySearchBudget", 30),
           daily_creator_budget: getInt("cfgXhsDailyCreatorBudget", 10),
           task_interval_seconds: getInt("cfgXhsTaskInterval", 45),
@@ -4114,9 +3723,6 @@ function bindSettings() {
           daily_feed_budget: getInt("cfgDouyinDailyFeedBudget", 30),
           request_interval_seconds: getInt("cfgDouyinRequestInterval", 2),
         },
-        youtube: {
-          enabled: checked("cfgYoutubeEnabled"),
-        },
       },
       scheduler: {
         enabled: checked("cfgSchedulerEnabled", true),
@@ -4127,7 +3733,6 @@ function bindSettings() {
           bilibili: getInt("cfgPoolShareBilibili", 8),
           xiaohongshu: getInt("cfgPoolShareXhs", 1),
           douyin: getInt("cfgPoolShareDouyin", 1),
-          youtube: getInt("cfgPoolShareYoutube", 1),
         },
         speculation_interval_minutes: getInt("cfgSpeculationInterval", 10),
         speculation_ttl_days: getInt("cfgSpeculationTtl", 3),
@@ -4160,6 +3765,7 @@ function bindSettings() {
     overlay.hidden = false;
     toast.hidden = true;
     issuesContainer.innerHTML = "";
+    await populateBackendEndpoint();
     try {
       const cfg = await fetchConfig();
       populateForm(cfg);
@@ -4172,45 +3778,19 @@ function bindSettings() {
     overlay.hidden = true;
   });
 
-  const suggestBtn = document.getElementById("cfgSuggestPoolShares");
-  if (suggestBtn) {
-    suggestBtn.addEventListener("click", async () => {
-      suggestBtn.disabled = true;
-      toast.hidden = true;
-      try {
-        const suggestion = await fetchSourceShareSuggestion({
-          enabled_sources: {
-            bilibili: true,
-            xiaohongshu: checked("cfgXhsEnabled", true),
-            douyin: checked("cfgDouyinEnabled"),
-            youtube: checked("cfgYoutubeEnabled"),
-          },
-          configured_shares: {
-            bilibili: getInt("cfgPoolShareBilibili", 8),
-            xiaohongshu: getInt("cfgPoolShareXhs", 1),
-            douyin: getInt("cfgPoolShareDouyin", 1),
-            youtube: getInt("cfgPoolShareYoutube", 1),
-          },
-        });
-        const shares = suggestion?.suggested_shares || {};
-        if (shares.bilibili !== undefined) setVal("cfgPoolShareBilibili", shares.bilibili);
-        if (shares.xiaohongshu !== undefined) setVal("cfgPoolShareXhs", shares.xiaohongshu);
-        if (shares.douyin !== undefined) setVal("cfgPoolShareDouyin", shares.douyin);
-        if (shares.youtube !== undefined) setVal("cfgPoolShareYoutube", shares.youtube);
-        showToast("已按已有信号填入建议比例，保存后生效。", "success");
-      } catch (err) {
-        showToast(`生成建议失败: ${err.message}`, "error");
-      } finally {
-        suggestBtn.disabled = false;
-      }
-    });
-  }
-
   saveBtn.addEventListener("click", async () => {
     saveBtn.disabled = true;
     saveBtn.textContent = "保存中...";
     toast.hidden = true;
     try {
+      const backendPort = backendPortInput instanceof HTMLInputElement
+        ? backendPortInput.value.trim()
+        : "";
+      if (!isValidBackendPort(backendPort)) {
+        showToast("后端端口必须是 1-65535 的整数。", "error");
+        return;
+      }
+      await updateBackendPort(backendPort);
       const data = collectForm();
       const result = await updateConfig(data);
       if (result.config) {
@@ -4218,6 +3798,10 @@ function bindSettings() {
       }
       const tone = result.reloaded ? "success" : "warning";
       showToast(result.message || "配置已保存。", tone);
+      connectRuntimeStream();
+      state.online = await checkBackendStatus();
+      setStatus(state.online);
+      void initializeRecommendations();
     } catch (err) {
       showToast(`保存失败: ${err.message}`, "error");
     } finally {
@@ -4245,7 +3829,6 @@ async function initializePopup() {
   );
   setHint("先看看本地后端连上没。");
   await initializeRecommendations();
-  await hydrateChatHistory();
   // Always fetch profile-summary on startup so the messages inbox is
   // populated regardless of which tab the user lands on.  Without this
   // the inbox stays empty until the user manually opens the profile

--- a/extension/popup/popup.js
+++ b/extension/popup/popup.js
@@ -27,6 +27,11 @@ import {
 } from "./popup-helpers.js";
 import { createRuntimeStreamClient } from "./popup-stream.js";
 import {
+  getBackendEndpointConfig,
+  isValidBackendPort,
+  updateBackendPort,
+} from "./popup-backend-config.js";
+import {
   appendRecommendations,
   checkBackendStatus,
   fetchActivityFeed,
@@ -149,6 +154,7 @@ const elements = {
 };
 
 let recommendationLoadCheckTimer = null;
+let runtimeStreamClient = null;
 
 function setRefreshButtonState(loading, message = "") {
   state.refreshStatusMessage = message;
@@ -412,6 +418,7 @@ function getRuntimeEventTone(event) {
 }
 
 function connectRuntimeStream() {
+  runtimeStreamClient?.disconnect?.();
   const client = createRuntimeStreamClient({
     onEvent(event) {
       state.runtimeEvent = event;
@@ -525,6 +532,7 @@ function connectRuntimeStream() {
     },
   });
   client.connect();
+  runtimeStreamClient = client;
 }
 
 function renderActivityHistory(items) {
@@ -3394,6 +3402,7 @@ function bindSettings() {
   const toast = document.getElementById("settingsToast");
   const issuesContainer = document.getElementById("settingsIssues");
   const providerSelect = document.getElementById("cfgLlmProvider");
+  const backendPortInput = document.getElementById("cfgBackendPort");
 
   if (!gearBtn || !overlay || !backBtn || !saveBtn) return;
 
@@ -3595,6 +3604,14 @@ function bindSettings() {
     renderIssues(cfg.issues);
   }
 
+  async function populateBackendEndpoint() {
+    if (!(backendPortInput instanceof HTMLInputElement)) {
+      return;
+    }
+    const endpoint = await getBackendEndpointConfig();
+    backendPortInput.value = String(endpoint.port);
+  }
+
   function collectForm() {
     const getVal = (id) => {
       const el = document.getElementById(id);
@@ -3748,6 +3765,7 @@ function bindSettings() {
     overlay.hidden = false;
     toast.hidden = true;
     issuesContainer.innerHTML = "";
+    await populateBackendEndpoint();
     try {
       const cfg = await fetchConfig();
       populateForm(cfg);
@@ -3765,6 +3783,14 @@ function bindSettings() {
     saveBtn.textContent = "保存中...";
     toast.hidden = true;
     try {
+      const backendPort = backendPortInput instanceof HTMLInputElement
+        ? backendPortInput.value.trim()
+        : "";
+      if (!isValidBackendPort(backendPort)) {
+        showToast("后端端口必须是 1-65535 的整数。", "error");
+        return;
+      }
+      await updateBackendPort(backendPort);
       const data = collectForm();
       const result = await updateConfig(data);
       if (result.config) {
@@ -3772,6 +3798,10 @@ function bindSettings() {
       }
       const tone = result.reloaded ? "success" : "warning";
       showToast(result.message || "配置已保存。", tone);
+      connectRuntimeStream();
+      state.online = await checkBackendStatus();
+      setStatus(state.online);
+      void initializeRecommendations();
     } catch (err) {
       showToast(`保存失败: ${err.message}`, "error");
     } finally {

--- a/extension/tests/popup-api.test.ts
+++ b/extension/tests/popup-api.test.ts
@@ -320,3 +320,42 @@ test("updateConfig sends PUT with embedding config", async () => {
   assert.equal(result.ok, true);
   assert.equal(result.reloaded, true);
 });
+
+test("fetchConfig uses backend port configured in chrome.storage.local", async () => {
+  const originalChrome = (globalThis as any).chrome;
+  const calls: Array<{ url: string; options: any }> = [];
+
+  (globalThis as any).chrome = {
+    storage: {
+      local: {
+        get(_key: string, callback: (items: Record<string, unknown>) => void) {
+          callback({
+            popup_backend_endpoint: {
+              host: "127.0.0.1",
+              port: 9527,
+              basePath: "/api",
+            },
+          });
+        },
+      },
+    },
+  };
+
+  globalThis.fetch = async (url: any, options: any) => {
+    calls.push({ url, options });
+    return {
+      ok: true,
+      async json() {
+        return { language: "zh" };
+      },
+    };
+  };
+
+  try {
+    await fetchConfig();
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].url, "http://127.0.0.1:9527/api/config?reveal_keys=true");
+  } finally {
+    (globalThis as any).chrome = originalChrome;
+  }
+});

--- a/extension/tests/popup-api.test.ts
+++ b/extension/tests/popup-api.test.ts
@@ -5,13 +5,9 @@ import {
   appendRecommendations,
   fetchPendingDelight,
   fetchActivityFeed,
-  fetchChatTurn,
-  fetchChatTurns,
   fetchConfig,
   fetchProfileSummary,
-  fetchSourceShareSuggestion,
   reshuffleRecommendations,
-  startChatTurn,
   updateConfig,
 } from "../popup/popup-api.js";
 
@@ -279,88 +275,6 @@ test("fetchConfig sends GET to /config with reveal_keys", async () => {
   assert.equal(result.llm.embedding.similarity_threshold, 0.85);
 });
 
-test("fetchSourceShareSuggestion loads source-share recommendation", async () => {
-  const calls: Array<{ url: string; options: any }> = [];
-  globalThis.fetch = async (url: any, options: any) => {
-    calls.push({ url, options });
-    return {
-      ok: true,
-      async json() {
-        return {
-          event_counts: { bilibili: 9, youtube: 4 },
-          enabled_sources: { bilibili: true, youtube: true },
-          suggested_shares: { bilibili: 8, youtube: 5 },
-        };
-      },
-    };
-  };
-
-  const result = await fetchSourceShareSuggestion();
-
-  assert.equal(calls.length, 1);
-  assert.equal(
-    calls[0].url,
-    "http://127.0.0.1:8420/api/config/source-share-suggestion",
-  );
-  assert.equal(calls[0].options.method, "GET");
-  assert.equal(result.suggested_shares.youtube, 5);
-});
-
-test("fetchSourceShareSuggestion posts current settings overrides when provided", async () => {
-  const calls: Array<{ url: string; options: any }> = [];
-  globalThis.fetch = async (url: any, options: any) => {
-    calls.push({ url, options });
-    return {
-      ok: true,
-      async json() {
-        return {
-          event_counts: { bilibili: 9, youtube: 4 },
-          enabled_sources: { bilibili: true, youtube: true },
-          suggested_shares: { bilibili: 6, youtube: 4 },
-        };
-      },
-    };
-  };
-
-  const result = await fetchSourceShareSuggestion({
-    enabled_sources: {
-      bilibili: true,
-      xiaohongshu: false,
-      douyin: false,
-      youtube: true,
-    },
-    configured_shares: {
-      bilibili: 6,
-      xiaohongshu: 2,
-      douyin: 1,
-      youtube: 2,
-    },
-  });
-
-  assert.equal(calls.length, 1);
-  assert.equal(
-    calls[0].url,
-    "http://127.0.0.1:8420/api/config/source-share-suggestion",
-  );
-  assert.equal(calls[0].options.method, "POST");
-  assert.equal(calls[0].options.headers["Content-Type"], "application/json");
-  assert.deepEqual(JSON.parse(calls[0].options.body), {
-    enabled_sources: {
-      bilibili: true,
-      xiaohongshu: false,
-      douyin: false,
-      youtube: true,
-    },
-    configured_shares: {
-      bilibili: 6,
-      xiaohongshu: 2,
-      douyin: 1,
-      youtube: 2,
-    },
-  });
-  assert.equal(result.suggested_shares.youtube, 4);
-});
-
 test("updateConfig sends PUT with embedding config", async () => {
   const calls: Array<{ url: string; options: any }> = [];
   globalThis.fetch = async (url: any, options: any) => {
@@ -407,97 +321,41 @@ test("updateConfig sends PUT with embedding config", async () => {
   assert.equal(result.reloaded, true);
 });
 
-test("startChatTurn posts durable chat turn metadata", async () => {
+test("fetchConfig uses backend port configured in chrome.storage.local", async () => {
+  const originalChrome = (globalThis as any).chrome;
   const calls: Array<{ url: string; options: any }> = [];
-  globalThis.fetch = async (url: any, options: any) => {
-    calls.push({ url, options });
-    return {
-      ok: true,
-      async json() {
-        return {
-          turn_id: "turn-abc",
-          session: "popup",
-          scope: "delight",
-          subject_id: "BV1DL",
-          subject_title: "复杂系统入门",
-          message: "我想聊聊这条",
-          reply: "",
-          status: "pending",
-          error: "",
-          created_at: "2026-05-15 10:00:00",
-          updated_at: "2026-05-15 10:00:00",
-        };
-      },
-    };
-  };
 
-  const result = await startChatTurn({
-    turnId: "turn-abc",
-    session: "popup",
-    scope: "delight",
-    subjectId: "BV1DL",
-    subjectTitle: "复杂系统入门",
-    message: "我想聊聊这条",
-  });
-
-  assert.equal(calls.length, 1);
-  assert.equal(calls[0].url, "http://127.0.0.1:8420/api/chat/turns");
-  assert.equal(calls[0].options.method, "POST");
-  assert.equal(calls[0].options.headers["Content-Type"], "application/json");
-  assert.deepEqual(JSON.parse(calls[0].options.body), {
-    turn_id: "turn-abc",
-    session: "popup",
-    scope: "delight",
-    subject_id: "BV1DL",
-    subject_title: "复杂系统入门",
-    message: "我想聊聊这条",
-  });
-  assert.equal(result.status, "pending");
-});
-
-test("fetchChatTurn and fetchChatTurns read durable chat state", async () => {
-  const calls: Array<{ url: string; options: any }> = [];
-  globalThis.fetch = async (url: any, options: any) => {
-    calls.push({ url, options });
-    return {
-      ok: true,
-      async json() {
-        if (String(url).endsWith("/api/chat/turns/turn-abc")) {
-          return {
-            turn_id: "turn-abc",
-            session: "popup",
-            scope: "chat",
-            message: "你好",
-            reply: "你好，我在。",
-            status: "completed",
-          };
-        }
-        return {
-          items: [
-            {
-              turn_id: "turn-abc",
-              session: "popup",
-              scope: "chat",
-              message: "你好",
-              reply: "你好，我在。",
-              status: "completed",
+  (globalThis as any).chrome = {
+    storage: {
+      local: {
+        get(_key: string, callback: (items: Record<string, unknown>) => void) {
+          callback({
+            popup_backend_endpoint: {
+              host: "127.0.0.1",
+              port: 9527,
+              basePath: "/api",
             },
-          ],
-        };
+          });
+        },
+      },
+    },
+  };
+
+  globalThis.fetch = async (url: any, options: any) => {
+    calls.push({ url, options });
+    return {
+      ok: true,
+      async json() {
+        return { language: "zh" };
       },
     };
   };
 
-  const turn = await fetchChatTurn("turn-abc");
-  const history = await fetchChatTurns({ session: "popup", scope: "chat", limit: 10 });
-
-  assert.equal(calls[0].url, "http://127.0.0.1:8420/api/chat/turns/turn-abc");
-  assert.equal(calls[0].options.method, "GET");
-  assert.equal(
-    calls[1].url,
-    "http://127.0.0.1:8420/api/chat/turns?session=popup&scope=chat&limit=10",
-  );
-  assert.equal(calls[1].options.method, "GET");
-  assert.equal(turn.reply, "你好，我在。");
-  assert.equal(history.items[0].turn_id, "turn-abc");
+  try {
+    await fetchConfig();
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].url, "http://127.0.0.1:9527/api/config?reveal_keys=true");
+  } finally {
+    (globalThis as any).chrome = originalChrome;
+  }
 });

--- a/extension/tests/popup-settings.test.ts
+++ b/extension/tests/popup-settings.test.ts
@@ -7,6 +7,7 @@ test("settings page exposes advanced config fields from backend schema", () => {
   const popupHtml = readFileSync(resolve("popup", "popup.html"), "utf8");
   const popupJs = readFileSync(resolve("popup", "popup.js"), "utf8");
   const expectedIds = [
+    "cfgBackendPort",
     "cfgDataDir",
     "cfgDeepseekReasoning",
     "cfgOpenrouterReferer",

--- a/extension/tests/popup-stream.test.ts
+++ b/extension/tests/popup-stream.test.ts
@@ -15,6 +15,10 @@ test("createRuntimeStreamUrl converts backend http url to websocket runtime stre
     createRuntimeStreamUrl("https://api.example.com/api"),
     "wss://api.example.com/api/runtime-stream",
   );
+  assert.equal(
+    createRuntimeStreamUrl("http://127.0.0.1:9527/api"),
+    "ws://127.0.0.1:9527/api/runtime-stream",
+  );
 });
 
 class FakeWebSocket {


### PR DESCRIPTION

## Title
feat(extension): 支持在插件设置页配置本地后端端口，避免 Hyper-V/WSL/Docker 端口冲突

## 背景
在 Windows 启用 Hyper-V / 网络虚拟化（NA）后，常见本地端口容易被系统组件、WSL、Docker 等占用，导致插件默认连接 `127.0.0.1:8420` 时出现连接失败或不稳定。  
为降低开发环境冲突风险，插件侧新增“可配置端口”能力，允许使用更高且不常见的端口（如 `18080`、`19090`、`13000`）。

## 变更摘要
本 PR 在浏览器插件设置页新增“后端端口”配置项，并将 popup 的 API 请求与 runtime-stream 连接从硬编码地址改为动态读取本地配置。

核心行为：
- 默认端口保持 `8420`（兼容现有用户）。
- 设置页可修改端口，范围校验为 `1-65535`。
- 保存后立即生效：重连 runtime-stream，并刷新在线状态/推荐数据。
- 端口配置仅作用于插件连接地址，不写入后端 `config.toml`。

## 具体改动
- 新增 `popup-backend-config.js`：
  - 统一管理 backend endpoint（`host=127.0.0.1`、`port=8420`、`basePath=/api`）。
  - 使用 `chrome.storage.local` 持久化，异常场景回退内存默认值。
  - 提供端口校验与更新能力。
- `popup-api.js`：
  - 所有请求改为动态读取 backend base URL。
- `popup-stream.js`：
  - runtime-stream 连接地址改为动态 backend URL。
- `popup.html` + `popup.js`：
  - 设置页新增“后端端口”输入项。
  - 打开设置页时回填当前端口。
  - 保存时先做端口校验，非法值阻止保存并提示。
  - 保存成功后自动重连并刷新状态。

## 测试
已补充并通过以下测试：
- `tests/popup-settings.test.ts`
  - 校验新增 `cfgBackendPort` 字段已在 HTML 和 JS 中接线。
- `tests/popup-api.test.ts`
  - 新增基于 `chrome.storage.local` 自定义端口的请求地址断言。
- `tests/popup-stream.test.ts`
  - 新增非默认端口下 runtime-stream URL 生成断言。

执行命令：
```bash
node --test --experimental-strip-types tests/popup-api.test.ts tests/popup-stream.test.ts tests/popup-settings.test.ts
```
结果：16 passed。

## 使用建议（开发环境）
在 Windows（Hyper-V/WSL/Docker 并存）开发环境中，建议将插件端口改为高位且不常见端口，例如：
- `18080`
- `19090`
- `13000`

并确保后端服务与插件使用同一端口。