### PR TITLE
feat(extension): make backend port configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,11 @@
 
 ---
 
-## 📌 v0.3.71 重要更新（2026-05-16）
+## 📌 v0.3.72 重要更新（2026-05-16）
 
-- **🦊 Firefox 140+ 本地构建支持** —— `extension-v0.3.23` 新增 `manifest.firefox.json`，用 Firefox `sidebar_action` 承载同一套 popup UI；`npm run build:firefox` / `npm run package:firefox` 可生成 `dist-firefox/` 和 Firefox 专用 zip，manifest 已声明 AMO 所需的数据收集类别。
-- **📦 扩展打包更稳** —— Chrome / Firefox 打包脚本都会先删除同名旧 zip 再压缩，避免重复本地打包时把已经删除的旧文件残留进 release 资产。
+- **🔌 浏览器插件后端端口可配置** —— 设置页新增「后端端口」（默认 `8420`，仅接受 `1-65535` 的完整整数），适合 Windows Hyper-V / WSL / Docker 占用默认端口时改用 `18080` / `19090` 等高位端口，并用 `openbiliclaw start --port <同一端口>` 启动后端。
+- **🧩 插件全链路走统一后端 endpoint** —— popup、service worker、cookie 同步、XHS / Douyin / YouTube 任务派发和调试中继都通过共享 helper 解析当前端口；manifest 本地权限同步放宽到 `127.0.0.1/*` / `localhost/*`。
+- **🙏 致谢社区贡献** —— 感谢 [@addtion99](https://github.com/addtion99) 在 [#8](https://github.com/whiteguo233/OpenBiliClaw/pull/8) 提出端口可配置需求并给出 popup 侧实现思路。
 
 完整变更详见 [docs/changelog.md](docs/changelog.md)。
 
@@ -490,7 +491,7 @@ OpenBiliClaw/
 
 ## 📜 更新日志
 
-最新版本：**v0.3.71: Firefox 扩展构建与打包补强（2026-05-16）**。README 顶部保留最新重要更新；完整历史见 [docs/changelog.md](docs/changelog.md)，发布包见 [GitHub Releases](https://github.com/whiteguo233/OpenBiliClaw/releases)。
+最新版本：**v0.3.72: 浏览器插件后端端口可配置（2026-05-16）**。README 顶部保留最新重要更新；完整历史见 [docs/changelog.md](docs/changelog.md)，发布包见 [GitHub Releases](https://github.com/whiteguo233/OpenBiliClaw/releases)。
 
 ## 🗺️ 后续规划
 
@@ -510,6 +511,10 @@ OpenBiliClaw 的目标是做你的**全网个性化内容入口**——从 B 站
 ## 🤝 贡献
 
 欢迎贡献！请查看 [开发指南](docs/contributing.md) 了解如何参与。
+
+## 🙏 致谢
+
+- 感谢 [@addtion99](https://github.com/addtion99) 在 [#8](https://github.com/whiteguo233/OpenBiliClaw/pull/8) 提出浏览器插件后端端口可配置需求，并给出 popup 侧实现思路。
 
 ## ⭐ Star History
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -17,10 +17,11 @@
 
 ---
 
-## 📌 v0.3.71 Highlights (2026-05-16)
+## 📌 v0.3.72 Highlights (2026-05-16)
 
-- **🦊 Firefox 140+ local build support** — `extension-v0.3.23` adds `manifest.firefox.json`, uses Firefox `sidebar_action` for the same popup UI, and `npm run build:firefox` / `npm run package:firefox` produce `dist-firefox/` plus a Firefox-specific zip. The Firefox manifest declares the data-collection categories required by AMO.
-- **📦 Safer extension packaging** — both Chrome and Firefox package scripts remove any existing same-name zip before compressing, so repeated local packaging cannot leave deleted stale files inside release assets.
+- **🔌 Configurable extension backend port** — the settings page now has a "backend port" field (default `8420`, complete integers only, `1-65535`) for Windows Hyper-V / WSL / Docker setups where the default local port is already reserved. Pick a high port such as `18080` or `19090`, then start the backend with `openbiliclaw start --port <same port>`.
+- **🧩 One backend endpoint path across the extension** — popup requests, service worker requests, cookie sync, XHS / Douyin / YouTube task dispatchers, and debug relays all resolve the current port through shared helpers; local manifest permissions now cover `127.0.0.1/*` and `localhost/*`.
+- **🙏 Community credit** — thanks to [@addtion99](https://github.com/addtion99) for proposing configurable backend ports and the popup-side implementation idea in [#8](https://github.com/whiteguo233/OpenBiliClaw/pull/8).
 
 Full changelog: [docs/changelog.md](docs/changelog.md).
 
@@ -427,7 +428,7 @@ OpenBiliClaw/
 
 ## 📜 Release History
 
-Latest: **v0.3.71: Firefox extension build and packaging hardening (2026-05-16)**. The top highlight callout keeps the current release visible; full history lives in [docs/changelog.md](docs/changelog.md), with packages on [GitHub Releases](https://github.com/whiteguo233/OpenBiliClaw/releases).
+Latest: **v0.3.72: configurable browser-extension backend port (2026-05-16)**. The top highlight callout keeps the current release visible; full history lives in [docs/changelog.md](docs/changelog.md), with packages on [GitHub Releases](https://github.com/whiteguo233/OpenBiliClaw/releases).
 
 ## 🗺️ Roadmap
 
@@ -441,6 +442,10 @@ OpenBiliClaw aims to be your **personalized entry point to the entire web**. Sta
 ## 🤝 Contributing
 
 Contributions welcome! See the [Contributing Guide](docs/contributing.md) to get started.
+
+## 🙏 Acknowledgements
+
+- Thanks to [@addtion99](https://github.com/addtion99) for proposing configurable browser-extension backend ports and sharing the popup-side implementation idea in [#8](https://github.com/whiteguo233/OpenBiliClaw/pull/8).
 
 ## ⭐ Star History
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,17 @@
 
 ---
 
+## v0.3.72: 浏览器插件后端端口可配置（2026-05-16）
+
+- 浏览器插件设置页新增「后端端口」字段（默认 `8420`，范围 `1-65535`）。Windows 启用 Hyper-V / WSL / Docker 后常见本地端口会被系统组件占用，导致 `openbiliclaw start` 默认 `8420` 启动失败；现在用户可改成 `18080` / `19090` / `13000` 等高位端口，并用 `openbiliclaw start --port <同一端口>` 启动后端即可继续使用插件。端口保存到 `chrome.storage.local`，不写入后端 `config.toml`。
+- 新增 `extension/src/shared/backend-endpoint.ts` + `extension/popup/popup-backend-config.js` 共用 helper。`apiUrl()` / `wsUrl()` / `getBackendBaseUrl()` 在每次调用时解析当前端口，所以保存新端口后无需重载插件即可生效；service worker 通过 `chrome.storage.onChanged` 收到端口变更后会立即关闭旧 `runtime-stream` WebSocket 并按新 origin 重连。
+- 同步收敛了之前散在 ~10 处的硬编码 `127.0.0.1:8420`：service worker、cookie 同步、xhs / dy / yt 任务派发、`_debug/log` 中继、抖音内容脚本现在都走 `apiUrl()` 统一解析。
+- `manifest.json` / `manifest.firefox.json` 的 `host_permissions` 从固定 `127.0.0.1:8420/*` 放宽到 `127.0.0.1/*` + `localhost/*`，否则浏览器会在 manifest 层直接 block 非 `8420` 端口的请求；其他平台的 `*.bilibili.com` / `*.xiaohongshu.com` / `*.douyin.com` / `*.youtube.com` 权限完全不变。
+- 浏览器插件版本提升到 v0.3.24，Chrome / Edge / Brave 走 `openbiliclaw-extension-v0.3.24.zip`，Firefox 140+ 走 `openbiliclaw-extension-v0.3.24-firefox.zip`。
+- 致谢 [@addtion99 #8](https://github.com/whiteguo233/OpenBiliClaw/pull/8) 提出端口可配置的需求并给出 popup 侧实现思路；本次以最小回归方式重做，扩展到 service-worker / dispatcher 全链路并补齐 manifest 权限。
+
+---
+
 ## v0.3.71: Firefox 扩展构建与打包补强（2026-05-16）
 
 - Eval-batch 负样本锚定：`discovery/engine.ContentDiscoveryEngine._evaluate_batch` 现在每批前通过新 `_get_negative_exemplars()` 从事件层拉最近 8 条 negative 标题（来自 `soul/negative_exemplars.py` 的 recency-weighted 去重列表，半衰期 14d，标题超过 80 字会带 `…` 截断），引擎内部有 5 分钟 / `latest_event_id` 双失效 TTL 缓存避免 back-to-back batch 重复查 SQLite；batch 评分缓存 key 也带最新 event id，确保新 quick-exit / explicit-negative 出现后不会继续复用旧分数。`build_batch_content_evaluation_prompt` 新增可选 `negative_examples` kwarg，在 `<source_context>` 与 `<content_batch>` 之间插入块，并在 `_BATCH_CONTENT_EVALUATION_SYSTEM_PROMPT` 永久加入两条规则（10 / 11）让 LLM 按话术 / 商业意图 / 标题结构层面 pattern-match 候选与示例，而不是关键词重叠。配合上文事件满意度信号，分类先跑、负样本池自动建立，evaluator 不需要等到 `satisfaction_filter_enabled` 打开就能开始压制"同款保姆级全攻略 / 同款月入过万钓贴"类候选。Cold-start 用户（没有 negative 分类事件）保持 user prompt 字节形态不变，cache prefix 不被打断。

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,7 +6,7 @@
 
 ## v0.3.72: 浏览器插件后端端口可配置（2026-05-16）
 
-- 浏览器插件设置页新增「后端端口」字段（默认 `8420`，范围 `1-65535`）。Windows 启用 Hyper-V / WSL / Docker 后常见本地端口会被系统组件占用，导致 `openbiliclaw start` 默认 `8420` 启动失败；现在用户可改成 `18080` / `19090` / `13000` 等高位端口，并用 `openbiliclaw start --port <同一端口>` 启动后端即可继续使用插件。端口保存到 `chrome.storage.local`，不写入后端 `config.toml`。
+- 浏览器插件设置页新增「后端端口」字段（默认 `8420`，仅接受 `1-65535` 的完整十进制整数）。Windows 启用 Hyper-V / WSL / Docker 后常见本地端口会被系统组件占用，导致 `openbiliclaw start` 默认 `8420` 启动失败；现在用户可改成 `18080` / `19090` / `13000` 等高位端口，并用 `openbiliclaw start --port <同一端口>` 启动后端即可继续使用插件。端口保存到 `chrome.storage.local`，不写入后端 `config.toml`。
 - 新增 `extension/src/shared/backend-endpoint.ts` + `extension/popup/popup-backend-config.js` 共用 helper。`apiUrl()` / `wsUrl()` / `getBackendBaseUrl()` 在每次调用时解析当前端口，所以保存新端口后无需重载插件即可生效；service worker 通过 `chrome.storage.onChanged` 收到端口变更后会立即关闭旧 `runtime-stream` WebSocket 并按新 origin 重连。
 - 同步收敛了之前散在 ~10 处的硬编码 `127.0.0.1:8420`：service worker、cookie 同步、xhs / dy / yt 任务派发、`_debug/log` 中继、抖音内容脚本现在都走 `apiUrl()` 统一解析。
 - `manifest.json` / `manifest.firefox.json` 的 `host_permissions` 从固定 `127.0.0.1:8420/*` 放宽到 `127.0.0.1/*` + `localhost/*`，否则浏览器会在 manifest 层直接 block 非 `8420` 端口的请求；其他平台的 `*.bilibili.com` / `*.xiaohongshu.com` / `*.douyin.com` / `*.youtube.com` 权限完全不变。

--- a/docs/modules/extension.md
+++ b/docs/modules/extension.md
@@ -33,6 +33,7 @@
 | 抖音热点任务 | ✅ | 后端可派发 `hot` 任务；插件用后台 tab 打开 `/hot/{sentence_id}`，从跳转后的 `/video/{aweme_id}` 取 seed aweme，并通过 MAIN-world related bridge 签名 `/aweme/v1/web/aweme/related/`，回传 `dy_hot` 候选供 `dy-plugin-hot-related` discovery 使用 |
 | 抖音首页推荐流任务 | ✅ | 后端可派发 `feed` 任务；插件用后台 tab 在已登录抖音首页通过 MAIN-world feed bridge 签名 `/aweme/v1/web/tab/feed/`，回传 `dy_feed` 候选供 `dy-plugin-feed` discovery 使用 |
 | YouTube 初始化画像任务 | ✅ | 后端可派发 `bootstrap_profile` 任务；插件依次访问 `/feed/history`、`/feed/channels`、`/playlist?list=LL`，从 DOM 读取观看历史 / 订阅 / 点赞并用 `partial` 分批回传给 `/api/sources/yt/task-result` |
+| 后端端口可配置 | ✅ | 设置页「后端端口」字段保存到 `chrome.storage.local`，popup / service worker / 任务派发 / cookie 同步 / 调试中继全部经 `apiUrl()`/`wsUrl()` 解析当前端口；端口变更后 service worker 通过 `chrome.storage.onChanged` 立即重连 `runtime-stream`，无需重载插件 |
 
 ## 目录结构
 
@@ -74,6 +75,7 @@ extension/
 │   │   ├── dy-fetch-tap.ts       # MAIN-world 抖音 fetch tap + API harvester
 │   │   └── xhs-token-sniffer.ts  # MAIN-world fetch/XHR sniffer，捞 xsec_token
 │   └── shared/
+│       ├── backend-endpoint.ts # 共用后端 origin / apiUrl() / wsUrl() + chrome.storage 持久化端口
 │       ├── behavior.ts        # createBehaviorEvent / DOM snapshot kernel
 │       ├── types.ts           # BehaviorEvent + PlatformAdapter 接口
 │       └── platforms/
@@ -237,6 +239,7 @@ CLI 入口：
 `popup/` 目录当前承载 side panel 页面，已具备：
 
 - 后端连接状态检查
+- 设置页「后端端口」（默认 `8420`）由 `popup-backend-config.js` 写入 `chrome.storage.local`；popup 自身的 `/api/...` HTTP 请求与 `runtime-stream` WebSocket，以及 service worker / cookie 同步 / 各源任务派发都通过 `apiUrl()` / `wsUrl()` 在调用时解析当前端口，service worker 通过 `chrome.storage.onChanged` 同步收到变更并立即重连。端口不会写入后端 `config.toml`，需要用户自行 `openbiliclaw start --port <同一端口>` 启动后端
 - 从 `/api/recommendations` 拉取推荐列表
 - 设置页会通过 `/api/config` 读取并保存后端配置，保存后请求后端热重载；当前覆盖 LLM provider/key/model、DeepSeek reasoning、OpenRouter headers、per-module LLM override、B 站浏览器、通用 source 浏览器、小红书 / 抖音 / YouTube source 开关、小红书 / 抖音 source 预算、数据目录、SQLite 路径、调度、自动更新、候选池平台配比、猜测兴趣参数和日志清理参数
 - 设置页的“按已有信号建议比例”会把当前页面上尚未保存的平台开关和比例一并 POST 到 `/api/config/source-share-suggestion`，按本地事件库的平台分布填入 B 站 / 小红书 / 抖音 / YouTube 占比，用户仍需点击保存才写入 `config.toml`

--- a/docs/modules/extension.md
+++ b/docs/modules/extension.md
@@ -33,7 +33,7 @@
 | 抖音热点任务 | ✅ | 后端可派发 `hot` 任务；插件用后台 tab 打开 `/hot/{sentence_id}`，从跳转后的 `/video/{aweme_id}` 取 seed aweme，并通过 MAIN-world related bridge 签名 `/aweme/v1/web/aweme/related/`，回传 `dy_hot` 候选供 `dy-plugin-hot-related` discovery 使用 |
 | 抖音首页推荐流任务 | ✅ | 后端可派发 `feed` 任务；插件用后台 tab 在已登录抖音首页通过 MAIN-world feed bridge 签名 `/aweme/v1/web/tab/feed/`，回传 `dy_feed` 候选供 `dy-plugin-feed` discovery 使用 |
 | YouTube 初始化画像任务 | ✅ | 后端可派发 `bootstrap_profile` 任务；插件依次访问 `/feed/history`、`/feed/channels`、`/playlist?list=LL`，从 DOM 读取观看历史 / 订阅 / 点赞并用 `partial` 分批回传给 `/api/sources/yt/task-result` |
-| 后端端口可配置 | ✅ | 设置页「后端端口」字段保存到 `chrome.storage.local`，popup / service worker / 任务派发 / cookie 同步 / 调试中继全部经 `apiUrl()`/`wsUrl()` 解析当前端口；端口变更后 service worker 通过 `chrome.storage.onChanged` 立即重连 `runtime-stream`，无需重载插件 |
+| 后端端口可配置 | ✅ | 设置页「后端端口」字段仅接受 `1-65535` 的完整十进制整数并保存到 `chrome.storage.local`，popup / service worker / 任务派发 / cookie 同步 / 调试中继全部经 `apiUrl()`/`wsUrl()` 解析当前端口；端口变更后 service worker 通过 `chrome.storage.onChanged` 立即重连 `runtime-stream`，无需重载插件 |
 
 ## 目录结构
 
@@ -239,7 +239,7 @@ CLI 入口：
 `popup/` 目录当前承载 side panel 页面，已具备：
 
 - 后端连接状态检查
-- 设置页「后端端口」（默认 `8420`）由 `popup-backend-config.js` 写入 `chrome.storage.local`；popup 自身的 `/api/...` HTTP 请求与 `runtime-stream` WebSocket，以及 service worker / cookie 同步 / 各源任务派发都通过 `apiUrl()` / `wsUrl()` 在调用时解析当前端口，service worker 通过 `chrome.storage.onChanged` 同步收到变更并立即重连。端口不会写入后端 `config.toml`，需要用户自行 `openbiliclaw start --port <同一端口>` 启动后端
+- 设置页「后端端口」（默认 `8420`，仅接受 `1-65535` 的完整十进制整数）由 `popup-backend-config.js` 写入 `chrome.storage.local`；popup 自身的 `/api/...` HTTP 请求与 `runtime-stream` WebSocket，以及 service worker / cookie 同步 / 各源任务派发都通过 `apiUrl()` / `wsUrl()` 在调用时解析当前端口，service worker 通过 `chrome.storage.onChanged` 同步收到变更并立即重连。端口不会写入后端 `config.toml`，需要用户自行 `openbiliclaw start --port <同一端口>` 启动后端
 - 从 `/api/recommendations` 拉取推荐列表
 - 设置页会通过 `/api/config` 读取并保存后端配置，保存后请求后端热重载；当前覆盖 LLM provider/key/model、DeepSeek reasoning、OpenRouter headers、per-module LLM override、B 站浏览器、通用 source 浏览器、小红书 / 抖音 / YouTube source 开关、小红书 / 抖音 source 预算、数据目录、SQLite 路径、调度、自动更新、候选池平台配比、猜测兴趣参数和日志清理参数
 - 设置页的“按已有信号建议比例”会把当前页面上尚未保存的平台开关和比例一并 POST 到 `/api/config/source-share-suggestion`，按本地事件库的平台分布填入 B 站 / 小红书 / 抖音 / YouTube 占比，用户仍需点击保存才写入 `config.toml`

--- a/extension/manifest.firefox.json
+++ b/extension/manifest.firefox.json
@@ -35,8 +35,8 @@
         "*://*.xiaohongshu.com/*",
         "*://*.douyin.com/*",
         "*://*.youtube.com/*",
-        "http://127.0.0.1:8420/*",
-        "http://localhost:8420/*"
+        "http://127.0.0.1/*",
+        "http://localhost/*"
     ],
     "background": {
         "scripts": [

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 3,
     "name": "OpenBiliClaw",
-    "version": "0.3.23",
+    "version": "0.3.24",
     "description": "跨平台内容发现 AI Agent — 行为采集、画像与智能推荐",
     "permissions": [
         "activeTab",
@@ -18,8 +18,8 @@
         "*://*.xiaohongshu.com/*",
         "*://*.douyin.com/*",
         "*://*.youtube.com/*",
-        "http://127.0.0.1:8420/*",
-        "http://localhost:8420/*"
+        "http://127.0.0.1/*",
+        "http://localhost/*"
     ],
     "background": {
         "service_worker": "dist/background/service-worker.js"

--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openbiliclaw-extension",
-  "version": "0.3.23",
+  "version": "0.3.24",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openbiliclaw-extension",
-      "version": "0.3.23",
+      "version": "0.3.24",
       "devDependencies": {
         "@types/chrome": "^0.1.29",
         "esbuild": "^0.25.10",

--- a/extension/package.json
+++ b/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openbiliclaw-extension",
-  "version": "0.3.23",
+  "version": "0.3.24",
   "private": true,
   "type": "module",
   "scripts": {

--- a/extension/popup/popup-api.js
+++ b/extension/popup/popup-api.js
@@ -1,9 +1,9 @@
 import { normalizeRecommendation } from "./popup-helpers.js";
-
-const BACKEND_URL = "http://127.0.0.1:8420/api";
+import { getBackendBaseUrl } from "./popup-backend-config.js";
 
 async function requestJson(path, options = {}) {
-  const response = await fetch(`${BACKEND_URL}${path}`, options);
+  const backendUrl = await getBackendBaseUrl();
+  const response = await fetch(`${backendUrl}${path}`, options);
   if (!response.ok) {
     throw new Error(`${path} request failed: ${response.status}`);
   }
@@ -12,7 +12,8 @@ async function requestJson(path, options = {}) {
 
 export async function checkBackendStatus() {
   try {
-    const response = await fetch(`${BACKEND_URL}/health`, { method: "GET" });
+    const backendUrl = await getBackendBaseUrl();
+    const response = await fetch(`${backendUrl}/health`, { method: "GET" });
     return response.ok;
   } catch {
     return false;

--- a/extension/popup/popup-backend-config.js
+++ b/extension/popup/popup-backend-config.js
@@ -42,28 +42,27 @@ function getStorageOnChanged() {
   }
 }
 
-export function isValidBackendPort(value) {
+function parseBackendPort(value) {
   if (typeof value === "number" && Number.isInteger(value)) {
-    return value >= 1 && value <= 65535;
+    return value >= 1 && value <= 65535 ? value : null;
   }
   if (typeof value === "string" && value.trim() !== "") {
-    const parsed = Number.parseInt(value.trim(), 10);
-    return Number.isInteger(parsed) && parsed >= 1 && parsed <= 65535;
+    const trimmed = value.trim();
+    if (!/^[0-9]+$/.test(trimmed)) {
+      return null;
+    }
+    const parsed = Number(trimmed);
+    return Number.isInteger(parsed) && parsed >= 1 && parsed <= 65535 ? parsed : null;
   }
-  return false;
+  return null;
+}
+
+export function isValidBackendPort(value) {
+  return parseBackendPort(value) !== null;
 }
 
 function coercePort(value) {
-  if (typeof value === "number" && Number.isInteger(value) && value >= 1 && value <= 65535) {
-    return value;
-  }
-  if (typeof value === "string" && value.trim() !== "") {
-    const parsed = Number.parseInt(value.trim(), 10);
-    if (Number.isInteger(parsed) && parsed >= 1 && parsed <= 65535) {
-      return parsed;
-    }
-  }
-  return DEFAULT_BACKEND_PORT;
+  return parseBackendPort(value) ?? DEFAULT_BACKEND_PORT;
 }
 
 function sanitizeEndpoint(raw) {

--- a/extension/popup/popup-backend-config.js
+++ b/extension/popup/popup-backend-config.js
@@ -1,0 +1,204 @@
+/**
+ * OpenBiliClaw popup — configurable backend endpoint.
+ *
+ * Mirrors src/shared/backend-endpoint.ts for popup modules (which load
+ * straight from popup/ as native JS, not via the esbuild bundle). Both
+ * sides read & write the same chrome.storage.local key, so a change in
+ * the popup is picked up by the service worker via chrome.storage.onChanged.
+ *
+ * Default port is 8420 (unchanged). Users can override to dodge port
+ * conflicts on Windows (Hyper-V / WSL / Docker reserve random local
+ * ports — 18080, 19090, 13000 are common safe choices).
+ */
+
+export const DEFAULT_BACKEND_HOST = "127.0.0.1";
+export const DEFAULT_BACKEND_PORT = 8420;
+export const BACKEND_ENDPOINT_STORAGE_KEY = "popup_backend_endpoint";
+
+const DEFAULT_ENDPOINT = {
+  host: DEFAULT_BACKEND_HOST,
+  port: DEFAULT_BACKEND_PORT,
+};
+
+let cached = { ...DEFAULT_ENDPOINT };
+let initialized = false;
+let initPromise = null;
+let storageListenerInstalled = false;
+const subscribers = new Set();
+
+function getStorageLocal() {
+  try {
+    return globalThis.chrome?.storage?.local ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function getStorageOnChanged() {
+  try {
+    return globalThis.chrome?.storage?.onChanged ?? null;
+  } catch {
+    return null;
+  }
+}
+
+export function isValidBackendPort(value) {
+  if (typeof value === "number" && Number.isInteger(value)) {
+    return value >= 1 && value <= 65535;
+  }
+  if (typeof value === "string" && value.trim() !== "") {
+    const parsed = Number.parseInt(value.trim(), 10);
+    return Number.isInteger(parsed) && parsed >= 1 && parsed <= 65535;
+  }
+  return false;
+}
+
+function coercePort(value) {
+  if (typeof value === "number" && Number.isInteger(value) && value >= 1 && value <= 65535) {
+    return value;
+  }
+  if (typeof value === "string" && value.trim() !== "") {
+    const parsed = Number.parseInt(value.trim(), 10);
+    if (Number.isInteger(parsed) && parsed >= 1 && parsed <= 65535) {
+      return parsed;
+    }
+  }
+  return DEFAULT_BACKEND_PORT;
+}
+
+function sanitizeEndpoint(raw) {
+  if (typeof raw !== "object" || raw === null) {
+    return { ...DEFAULT_ENDPOINT };
+  }
+  const hostRaw = typeof raw.host === "string" ? raw.host.trim() : "";
+  return {
+    host: hostRaw || DEFAULT_BACKEND_HOST,
+    port: coercePort(raw.port),
+  };
+}
+
+async function loadFromStorage() {
+  const storage = getStorageLocal();
+  if (typeof storage?.get !== "function") {
+    return { ...cached };
+  }
+  return new Promise((resolve) => {
+    try {
+      storage.get(BACKEND_ENDPOINT_STORAGE_KEY, (items) => {
+        const stored = items?.[BACKEND_ENDPOINT_STORAGE_KEY];
+        resolve(stored === undefined ? { ...cached } : sanitizeEndpoint(stored));
+      });
+    } catch {
+      resolve({ ...cached });
+    }
+  });
+}
+
+function installStorageChangeListener() {
+  if (storageListenerInstalled) return;
+  const onChanged = getStorageOnChanged();
+  if (typeof onChanged?.addListener !== "function") return;
+  try {
+    onChanged.addListener((changes, area) => {
+      if (area !== "local") return;
+      const change = changes?.[BACKEND_ENDPOINT_STORAGE_KEY];
+      if (!change) return;
+      const next = sanitizeEndpoint(change.newValue);
+      cached = next;
+      initialized = true;
+      for (const cb of subscribers) {
+        try {
+          cb(next);
+        } catch {
+          // Ignore subscriber failures so peers still get notified.
+        }
+      }
+    });
+    storageListenerInstalled = true;
+  } catch {
+    // chrome.storage.onChanged unavailable (tests).
+  }
+}
+
+async function ensureLoaded() {
+  if (initialized) return cached;
+  if (initPromise) return initPromise;
+  initPromise = (async () => {
+    const endpoint = await loadFromStorage();
+    cached = endpoint;
+    initialized = true;
+    installStorageChangeListener();
+    return endpoint;
+  })();
+  return initPromise;
+}
+
+export async function getBackendEndpointConfig() {
+  return ensureLoaded();
+}
+
+export async function getBackendOrigin() {
+  const ep = await ensureLoaded();
+  return `http://${ep.host}:${ep.port}`;
+}
+
+export async function getBackendBaseUrl() {
+  const ep = await ensureLoaded();
+  return `http://${ep.host}:${ep.port}/api`;
+}
+
+export async function getBackendWsBaseUrl() {
+  const ep = await ensureLoaded();
+  return `ws://${ep.host}:${ep.port}/api`;
+}
+
+export async function updateBackendPort(value) {
+  if (!isValidBackendPort(value)) {
+    throw new Error("端口必须是 1-65535 的整数");
+  }
+  const port = coercePort(value);
+  const endpoint = { host: cached.host || DEFAULT_BACKEND_HOST, port };
+  cached = endpoint;
+  initialized = true;
+  const storage = getStorageLocal();
+  if (typeof storage?.set === "function") {
+    await new Promise((resolve) => {
+      try {
+        storage.set({ [BACKEND_ENDPOINT_STORAGE_KEY]: endpoint }, () => resolve(undefined));
+      } catch {
+        resolve(undefined);
+      }
+    });
+  }
+  // Same context's onChanged does not fire for its own writes; notify
+  // local subscribers synchronously.
+  for (const cb of subscribers) {
+    try {
+      cb(endpoint);
+    } catch {
+      // ignore
+    }
+  }
+  return endpoint;
+}
+
+export function onBackendEndpointChange(callback) {
+  subscribers.add(callback);
+  installStorageChangeListener();
+  void ensureLoaded();
+  return () => {
+    subscribers.delete(callback);
+  };
+}
+
+/**
+ * Test-only: reset module state so a test can stub a fresh
+ * chrome.storage.local without inheriting the previous test's cache.
+ */
+export function __resetBackendEndpointForTests() {
+  cached = { ...DEFAULT_ENDPOINT };
+  initialized = false;
+  initPromise = null;
+  storageListenerInstalled = false;
+  subscribers.clear();
+}

--- a/extension/popup/popup-stream.js
+++ b/extension/popup/popup-stream.js
@@ -1,3 +1,5 @@
+import { getBackendBaseUrl } from "./popup-backend-config.js";
+
 const DEFAULT_BACKEND_URL = "http://127.0.0.1:8420/api";
 
 export function createRuntimeStreamUrl(backendUrl = DEFAULT_BACKEND_URL) {
@@ -9,7 +11,12 @@ export function createRuntimeStreamUrl(backendUrl = DEFAULT_BACKEND_URL) {
 }
 
 export function createRuntimeStreamClient({
-  backendUrl = DEFAULT_BACKEND_URL,
+  // ``backendUrl`` stays as a test-only override. Production callers
+  // omit it and ``resolveBackendUrl`` reads the configured endpoint at
+  // each (re)connect, so a settings-page port change rebinds the WS to
+  // the new origin without a full popup reload.
+  backendUrl = null,
+  resolveBackendUrl = getBackendBaseUrl,
   WebSocketImpl = globalThis.WebSocket,
   reconnectDelayMs = 2000,
   // v0.3.14+: cap reconnect delay so popup doesn't flood console with
@@ -43,11 +50,8 @@ export function createRuntimeStreamClient({
     );
   }
 
-  function connect() {
-    if (stopped || typeof WebSocketImpl !== "function") {
-      return;
-    }
-    socket = new WebSocketImpl(createRuntimeStreamUrl(backendUrl));
+  function attachSocket(nextSocket) {
+    socket = nextSocket;
     socket.onopen = () => {
       wasConnected = true;
       currentReconnectDelay = reconnectDelayMs;
@@ -69,6 +73,30 @@ export function createRuntimeStreamClient({
       }
       scheduleReconnect();
     };
+  }
+
+  function connect() {
+    if (stopped || typeof WebSocketImpl !== "function") {
+      return;
+    }
+    if (backendUrl != null) {
+      // Synchronous path preserves tests that drive the client with an
+      // explicit backendUrl and a fake WebSocket constructor — they
+      // expect socket creation on the same tick as connect().
+      attachSocket(new WebSocketImpl(createRuntimeStreamUrl(backendUrl)));
+      return;
+    }
+    void (async () => {
+      let resolved;
+      try {
+        resolved = await resolveBackendUrl();
+      } catch {
+        scheduleReconnect();
+        return;
+      }
+      if (stopped) return;
+      attachSocket(new WebSocketImpl(createRuntimeStreamUrl(resolved)));
+    })();
   }
 
   function disconnect() {

--- a/extension/popup/popup.html
+++ b/extension/popup/popup.html
@@ -3853,6 +3853,13 @@
       <div class="settings-section">
         <h3><span class="section-icon">&#x2699;&#xFE0F;</span> 通用</h3>
         <div class="settings-field">
+          <label for="cfgBackendPort">后端端口</label>
+          <input id="cfgBackendPort" type="number" min="1" max="65535" step="1" placeholder="8420">
+          <p class="settings-hint">
+            默认 8420。仅在本地端口被 Hyper-V / WSL / Docker 占用时修改，并用 <code>openbiliclaw start --port &lt;同一端口&gt;</code> 启动后端。
+          </p>
+        </div>
+        <div class="settings-field">
           <label for="cfgLanguage">语言</label>
           <select id="cfgLanguage">
             <option value="zh">中文</option>

--- a/extension/popup/popup.js
+++ b/extension/popup/popup.js
@@ -27,6 +27,11 @@ import {
 } from "./popup-helpers.js";
 import { createRuntimeStreamClient } from "./popup-stream.js";
 import {
+  getBackendEndpointConfig,
+  isValidBackendPort,
+  updateBackendPort,
+} from "./popup-backend-config.js";
+import {
   appendRecommendations,
   checkBackendStatus,
   fetchActivityFeed,
@@ -152,6 +157,7 @@ const elements = {
 };
 
 let recommendationLoadCheckTimer = null;
+let runtimeStreamClient = null;
 const CHAT_SESSION = "popup";
 const CHAT_POLL_INTERVAL_MS = 1200;
 const CHAT_POLL_DEADLINE_MS = 180_000;
@@ -421,6 +427,9 @@ function getRuntimeEventTone(event) {
 }
 
 function connectRuntimeStream() {
+  // Disconnect any previous client first so a settings-page port change
+  // doesn't leave a zombie WebSocket against the old origin.
+  runtimeStreamClient?.disconnect?.();
   const client = createRuntimeStreamClient({
     onEvent(event) {
       state.runtimeEvent = event;
@@ -534,6 +543,7 @@ function connectRuntimeStream() {
     },
   });
   client.connect();
+  runtimeStreamClient = client;
 }
 
 function renderActivityHistory(items) {
@@ -3794,8 +3804,19 @@ function bindSettings() {
   const toast = document.getElementById("settingsToast");
   const issuesContainer = document.getElementById("settingsIssues");
   const providerSelect = document.getElementById("cfgLlmProvider");
+  const backendPortInput = document.getElementById("cfgBackendPort");
 
   if (!gearBtn || !overlay || !backBtn || !saveBtn) return;
+
+  async function populateBackendEndpoint() {
+    if (!(backendPortInput instanceof HTMLInputElement)) return;
+    try {
+      const endpoint = await getBackendEndpointConfig();
+      backendPortInput.value = String(endpoint.port);
+    } catch {
+      // Fall back to the placeholder default if storage is unavailable.
+    }
+  }
 
   function showProviderFields(provider) {
     for (const el of overlay.querySelectorAll(".settings-provider-fields")) {
@@ -4160,6 +4181,10 @@ function bindSettings() {
     overlay.hidden = false;
     toast.hidden = true;
     issuesContainer.innerHTML = "";
+    // Backend port is stored in chrome.storage, not on the backend, so it
+    // populates even when the backend is unreachable — which is the whole
+    // point of changing it.
+    await populateBackendEndpoint();
     try {
       const cfg = await fetchConfig();
       populateForm(cfg);
@@ -4211,13 +4236,53 @@ function bindSettings() {
     saveBtn.textContent = "保存中...";
     toast.hidden = true;
     try {
-      const data = collectForm();
-      const result = await updateConfig(data);
-      if (result.config) {
-        renderIssues(result.config.issues);
+      // Backend port lives in chrome.storage, not the backend's
+      // config.toml — persist it locally first so the subsequent
+      // updateConfig() PUT targets the new origin (if the user
+      // restarted the daemon with --port <newPort>).
+      let portChanged = false;
+      let newPort = null;
+      if (backendPortInput instanceof HTMLInputElement) {
+        const portRaw = backendPortInput.value.trim();
+        if (!isValidBackendPort(portRaw)) {
+          showToast("后端端口必须是 1-65535 的整数。", "error");
+          return;
+        }
+        const previous = await getBackendEndpointConfig();
+        const next = await updateBackendPort(portRaw);
+        newPort = next.port;
+        portChanged = next.port !== previous.port;
       }
-      const tone = result.reloaded ? "success" : "warning";
-      showToast(result.message || "配置已保存。", tone);
+
+      const data = collectForm();
+      try {
+        const result = await updateConfig(data);
+        if (result.config) {
+          renderIssues(result.config.issues);
+        }
+        const tone = result.reloaded ? "success" : "warning";
+        showToast(result.message || "配置已保存。", tone);
+      } catch (err) {
+        if (portChanged) {
+          showToast(
+            `端口已切换为 ${newPort}，但保存其余配置失败。请用 openbiliclaw start --port ${newPort} 启动后端后重试。`,
+            "warning",
+          );
+        } else {
+          throw err;
+        }
+      }
+
+      if (portChanged) {
+        // Rebind the runtime stream against the new origin and refresh
+        // the online indicator. If the backend isn't yet running on the
+        // new port these will retry per the WS backoff and the popup
+        // status will flip to offline — exactly the signal the user
+        // needs to remember to start the daemon with --port.
+        connectRuntimeStream();
+        state.online = await checkBackendStatus();
+        setStatus(state.online);
+      }
     } catch (err) {
       showToast(`保存失败: ${err.message}`, "error");
     } finally {

--- a/extension/src/background/cookie-sync.ts
+++ b/extension/src/background/cookie-sync.ts
@@ -16,8 +16,9 @@
  * Douyin cookie for direct discovery smoke / recall.
  */
 
-const COOKIE_SYNC_URL = "http://127.0.0.1:8420/api/bilibili/cookie";
-const DOUYIN_COOKIE_SYNC_URL = "http://127.0.0.1:8420/api/sources/dy/cookie";
+// .ts extension: see service-worker.ts for the node:test resolver rationale.
+import { apiUrl } from "../shared/backend-endpoint.ts";
+
 const COOKIE_SYNC_ALARM = "openbiliclaw-cookie-sync";
 const COOKIE_SYNC_DEBOUNCE_MS = 2_000;
 const COOKIE_SYNC_REFRESH_MINUTES = 60;
@@ -160,7 +161,7 @@ export async function syncBilibiliCookieToBackend(
     return false;
   }
   try {
-    const response = await fetch(COOKIE_SYNC_URL, {
+    const response = await fetch(await apiUrl("/bilibili/cookie"), {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
@@ -230,7 +231,7 @@ export async function syncDouyinCookieToBackend(
     return false;
   }
   try {
-    const response = await fetch(DOUYIN_COOKIE_SYNC_URL, {
+    const response = await fetch(await apiUrl("/sources/dy/cookie"), {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({

--- a/extension/src/background/debug-log.ts
+++ b/extension/src/background/debug-log.ts
@@ -4,14 +4,22 @@
  * separate DevTools consoles. Will be reverted before release.
  */
 
+import { apiUrl } from "../shared/backend-endpoint.ts";
+
 export function debugLog(source: "xhs" | "dy" | "sw", event: string, data?: unknown): void {
   // Fire-and-forget. If daemon is down, swallow silently — dispatcher
   // operation must not depend on debug logging.
-  void fetch("http://127.0.0.1:8420/api/sources/_debug/log", {
-    method: "POST",
-    headers: { "content-type": "application/json" },
-    body: JSON.stringify({ source, event, data: data ?? null }),
-  }).catch(() => {});
+  void (async () => {
+    try {
+      await fetch(await apiUrl("/sources/_debug/log"), {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ source, event, data: data ?? null }),
+      });
+    } catch {
+      // ignore
+    }
+  })();
   // Mirror to local SW console for users with the dev tools open.
   // eslint-disable-next-line no-console
   console.debug(`[obc-${source}] ${event}`, data ?? "");

--- a/extension/src/background/dy-task-dispatcher.ts
+++ b/extension/src/background/dy-task-dispatcher.ts
@@ -28,6 +28,7 @@ import type {
   DouyinScope,
   DouyinSearchItem,
 } from "../main/dy-fetch-tap.js";
+import { apiUrl } from "../shared/backend-endpoint.ts";
 // Cross-source mutex via globalThis. Mirror of the helper inlined
 // in xhs-task-dispatcher; both dispatchers coordinate by writing to
 // the same field on globalThis. See dispatcher-mutex.ts for the
@@ -62,11 +63,17 @@ function releaseDispatcherMutex(label: string): void {
 
 // TEMP DEBUG: extension-side log relay → daemon (see debug-log.ts).
 function debugLog(event: string, data?: unknown): void {
-  void fetch("http://127.0.0.1:8420/api/sources/_debug/log", {
-    method: "POST",
-    headers: { "content-type": "application/json" },
-    body: JSON.stringify({ source: "dy", event, data: data ?? null }),
-  }).catch(() => {});
+  void (async () => {
+    try {
+      await fetch(await apiUrl("/sources/_debug/log"), {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ source: "dy", event, data: data ?? null }),
+      });
+    } catch {
+      // ignore
+    }
+  })();
 }
 
 // buildScopeUrl is loaded lazily via dynamic import inside the
@@ -85,8 +92,6 @@ async function loadBuildScopeUrl(): Promise<
   return mod.buildScopeUrl;
 }
 
-const NEXT_TASK_URL = "http://127.0.0.1:8420/api/sources/dy/next-task";
-const TASK_RESULT_URL = "http://127.0.0.1:8420/api/sources/dy/task-result";
 const DEFAULT_POLL_INTERVAL_MS = 60_000;
 const TASK_TIMEOUT_MS = 30_000;
 const SEARCH_TASK_TIMEOUT_MS = 180_000;
@@ -317,7 +322,7 @@ export function shouldOpenDyTaskActive(task: DyTask): boolean {
 
 async function fetchNextTask(): Promise<DyTask | null> {
   try {
-    const resp = await fetch(NEXT_TASK_URL);
+    const resp = await fetch(await apiUrl("/sources/dy/next-task"));
     if (resp.status === 204) return null; // no pending task
     if (!resp.ok) return null;
     const payload: unknown = await resp.json();
@@ -329,7 +334,7 @@ async function fetchNextTask(): Promise<DyTask | null> {
 
 async function postTaskResult(result: DyTaskResult): Promise<void> {
   try {
-    await fetch(TASK_RESULT_URL, {
+    await fetch(await apiUrl("/sources/dy/task-result"), {
       method: "POST",
       headers: { "content-type": "application/json" },
       body: JSON.stringify(result),

--- a/extension/src/background/service-worker.ts
+++ b/extension/src/background/service-worker.ts
@@ -49,22 +49,17 @@ import {
   handleCookieSyncAlarm,
   handleCookieSyncRuntimeEvent,
 } from "./cookie-sync.js";
+// Use .ts extension so node:test's --experimental-strip-types resolver
+// (which doesn't rewrite .js → .ts for source-only modules) can follow
+// the import when test files load these dispatchers directly. esbuild
+// bundles either extension, so production builds are unaffected.
+import { apiUrl, onBackendEndpointChange, wsUrl } from "../shared/backend-endpoint.ts";
 import type { BehaviorEvent } from "../shared/types.js";
 
 let eventBuffer: BehaviorEvent[] = [];
 const BUFFER_FLUSH_INTERVAL = 30_000;
 const BUFFER_MAX_SIZE = 50;
 const FLUSH_ALARM_NAME = "openbiliclaw-flush-events";
-const BACKEND_URL = "http://localhost:8420/api/events";
-const NOTIFICATION_POLL_URL = "http://127.0.0.1:8420/api/notifications/pending";
-const NOTIFICATION_ACK_URL = "http://127.0.0.1:8420/api/notifications/sent";
-const COGNITION_POLL_URL = "http://127.0.0.1:8420/api/cognition-updates/pending";
-const COGNITION_ACK_URL = "http://127.0.0.1:8420/api/cognition-updates/seen";
-const DELIGHT_ACK_URL = "http://127.0.0.1:8420/api/delight/sent";
-const XHS_OBSERVED_URLS_URL = "http://127.0.0.1:8420/api/sources/xhs/observed-urls";
-const XHS_TOKENS_URL = "http://127.0.0.1:8420/api/sources/xhs/tokens";
-const RUNTIME_STREAM_URL = "ws://127.0.0.1:8420/api/runtime-stream?client=background";
-const HEALTH_URL = "http://127.0.0.1:8420/api/health";
 // v0.3.22+: health probe before WS prevents extension-only installs
 // from flooding chrome://extensions "Errors" with browser-level
 // WebSocket connection failures. A failed fetch caught here is just a
@@ -88,7 +83,7 @@ type PendingCognitionUpdate = import("./notifications.js").PendingCognitionUpdat
 
 async function acknowledgeNotificationSent(bvid: string): Promise<void> {
   if (!bvid) return;
-  await fetch(NOTIFICATION_ACK_URL, {
+  await fetch(await apiUrl("/notifications/sent"), {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ bvid }),
@@ -96,7 +91,7 @@ async function acknowledgeNotificationSent(bvid: string): Promise<void> {
 }
 
 async function fetchPendingNotification(): Promise<PendingNotification | null> {
-  const response = await fetch(NOTIFICATION_POLL_URL, { method: "GET" });
+  const response = await fetch(await apiUrl("/notifications/pending"), { method: "GET" });
   if (!response.ok) {
     throw new Error(`pending notifications failed: ${response.status}`);
   }
@@ -105,7 +100,7 @@ async function fetchPendingNotification(): Promise<PendingNotification | null> {
 }
 
 async function fetchPendingCognitionUpdate(): Promise<PendingCognitionUpdate | null> {
-  const response = await fetch(COGNITION_POLL_URL, { method: "GET" });
+  const response = await fetch(await apiUrl("/cognition-updates/pending"), { method: "GET" });
   if (!response.ok) {
     throw new Error(`pending cognition updates failed: ${response.status}`);
   }
@@ -115,7 +110,7 @@ async function fetchPendingCognitionUpdate(): Promise<PendingCognitionUpdate | n
 
 async function acknowledgeCognitionUpdateSeen(id: string): Promise<void> {
   if (!id) return;
-  await fetch(COGNITION_ACK_URL, {
+  await fetch(await apiUrl("/cognition-updates/seen"), {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ id }),
@@ -128,7 +123,7 @@ async function acknowledgeCognitionUpdateSeen(id: string): Promise<void> {
 
 async function acknowledgeDelightSent(bvid: string): Promise<void> {
   if (!bvid) return;
-  await fetch(DELIGHT_ACK_URL, {
+  await fetch(await apiUrl("/delight/sent"), {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ bvid }),
@@ -245,7 +240,10 @@ async function isBackendAlive(): Promise<boolean> {
     const ctrl = new AbortController();
     const timer = setTimeout(() => ctrl.abort(), HEALTH_PROBE_TIMEOUT_MS);
     try {
-      const resp = await fetch(HEALTH_URL, { method: "GET", signal: ctrl.signal });
+      const resp = await fetch(await apiUrl("/health"), {
+        method: "GET",
+        signal: ctrl.signal,
+      });
       return resp.ok;
     } finally {
       clearTimeout(timer);
@@ -283,7 +281,8 @@ async function connectRuntimeStream(): Promise<void> {
     }
 
     try {
-      runtimeSocket = new WebSocket(RUNTIME_STREAM_URL);
+      const url = await wsUrl("/runtime-stream?client=background");
+      runtimeSocket = new WebSocket(url);
     } catch {
       setBackendBadge(false);
       scheduleWsReconnect();
@@ -341,7 +340,7 @@ async function flushEvents(): Promise<void> {
   eventBuffer = [];
 
   try {
-    const response = await fetch(BACKEND_URL, {
+    const response = await fetch(await apiUrl("/events"), {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ events }),
@@ -396,7 +395,7 @@ chrome.action.onClicked.addListener((tab) => {
 
 async function postXhsObservedUrls(payload: Record<string, unknown>): Promise<void> {
   try {
-    await fetch(XHS_OBSERVED_URLS_URL, {
+    await fetch(await apiUrl("/sources/xhs/observed-urls"), {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(payload),
@@ -411,7 +410,7 @@ async function postXhsTokens(
 ): Promise<void> {
   if (!payload?.pairs || payload.pairs.length === 0) return;
   try {
-    await fetch(XHS_TOKENS_URL, {
+    await fetch(await apiUrl("/sources/xhs/tokens"), {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(payload),
@@ -556,5 +555,27 @@ chrome.notifications.onClicked.addListener((notificationId) => {
 ensureFlushAlarm();
 void connectRuntimeStream();
 startCookieSync();
+
+// Popup writes a new backend port → chrome.storage.onChanged fires here.
+// Close the existing runtime-stream WS so the next connect attempt opens
+// against the new origin. All HTTP callers resolve apiUrl() at call time,
+// so no further bookkeeping is needed for polled requests.
+onBackendEndpointChange(() => {
+  try {
+    runtimeSocket?.close();
+  } catch {
+    // close() shouldn't throw, but we don't want a stray reset to crash
+    // the service worker.
+  }
+  runtimeSocket = null;
+  // Reset backoff so the new origin gets an immediate first attempt
+  // instead of inheriting the failed-against-old-port delay.
+  wsReconnectDelay = WS_RECONNECT_BASE_DELAY;
+  if (wsReconnectTimer !== null) {
+    clearTimeout(wsReconnectTimer);
+    wsReconnectTimer = null;
+  }
+  void connectRuntimeStream();
+});
 
 console.log("[OpenBiliClaw] Service worker initialized");

--- a/extension/src/background/xhs-task-dispatcher.ts
+++ b/extension/src/background/xhs-task-dispatcher.ts
@@ -51,8 +51,8 @@ function releaseDispatcherMutex(label: string): void {
   }
 }
 
-const NEXT_TASK_URL = "http://127.0.0.1:8420/api/sources/xhs/next-task";
-const TASK_RESULT_URL = "http://127.0.0.1:8420/api/sources/xhs/task-result";
+import { apiUrl } from "../shared/backend-endpoint.ts";
+
 const DEFAULT_POLL_INTERVAL_MS = 45_000;
 const TASK_TIMEOUT_MS = 30_000;
 const BOOTSTRAP_SCROLL_TIMEOUT_PER_ROUND_MS = 3_000;
@@ -217,7 +217,7 @@ function bootstrapClickedNextUrl(result: XhsTaskResult): boolean {
 
 async function fetchNextTask(): Promise<XhsTask | null> {
   try {
-    const response = await fetch(NEXT_TASK_URL, { method: "GET" });
+    const response = await fetch(await apiUrl("/sources/xhs/next-task"), { method: "GET" });
     if (response.status === 204) return null;
     if (!response.ok) return null;
     const payload = await response.json();
@@ -229,7 +229,7 @@ async function fetchNextTask(): Promise<XhsTask | null> {
 
 async function reportTaskResult(result: XhsTaskResult): Promise<void> {
   try {
-    await fetch(TASK_RESULT_URL, {
+    await fetch(await apiUrl("/sources/xhs/task-result"), {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(result),

--- a/extension/src/background/yt-task-dispatcher.ts
+++ b/extension/src/background/yt-task-dispatcher.ts
@@ -18,6 +18,7 @@
 
 import type { YtBootstrapItem, YtScope, YtScopeResult } from "../content/yt/task-executor.js";
 import { YT_SCOPE_URLS } from "../content/yt/task-executor.js";
+import { apiUrl } from "../shared/backend-endpoint.ts";
 
 // Cross-source mutex — same field as xhs/dy dispatchers so all three
 // cooperate on a single long-running task slot.
@@ -49,8 +50,6 @@ function releaseDispatcherMutex(label: string): void {
   }
 }
 
-const NEXT_TASK_URL = "http://127.0.0.1:8420/api/sources/yt/next-task";
-const TASK_RESULT_URL = "http://127.0.0.1:8420/api/sources/yt/task-result";
 const DEFAULT_POLL_INTERVAL_MS = 60_000;
 const POLL_ALARM_NAME = "openbiliclaw-yt-task-poll";
 
@@ -142,7 +141,7 @@ let progress: TaskProgress | null = null;
 
 async function fetchNextTask(): Promise<YtTask | null> {
   try {
-    const resp = await fetch(NEXT_TASK_URL);
+    const resp = await fetch(await apiUrl("/sources/yt/next-task"));
     if (resp.status === 204) return null;
     if (!resp.ok) return null;
     const payload: unknown = await resp.json();
@@ -154,7 +153,7 @@ async function fetchNextTask(): Promise<YtTask | null> {
 
 async function postTaskResult(result: YtTaskPayload): Promise<void> {
   try {
-    await fetch(TASK_RESULT_URL, {
+    await fetch(await apiUrl("/sources/yt/task-result"), {
       method: "POST",
       headers: { "content-type": "application/json" },
       body: JSON.stringify(result),

--- a/extension/src/content/douyin.ts
+++ b/extension/src/content/douyin.ts
@@ -24,14 +24,21 @@ import type {
   DouyinScope,
   DouyinSearchItem,
 } from "../main/dy-fetch-tap.js";
+import { apiUrl } from "../shared/backend-endpoint.ts";
 
 // TEMP DEBUG: relay content-script events to daemon (see debug-log.ts).
 function debugLog(event: string, data?: unknown): void {
-  void fetch("http://127.0.0.1:8420/api/sources/_debug/log", {
-    method: "POST",
-    headers: { "content-type": "application/json" },
-    body: JSON.stringify({ source: "dy-cs", event, data: data ?? null }),
-  }).catch(() => {});
+  void (async () => {
+    try {
+      await fetch(await apiUrl("/sources/_debug/log"), {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ source: "dy-cs", event, data: data ?? null }),
+      });
+    } catch {
+      // ignore — debug relay must not break the content script
+    }
+  })();
 }
 
 /**

--- a/extension/src/shared/backend-endpoint.ts
+++ b/extension/src/shared/backend-endpoint.ts
@@ -77,28 +77,27 @@ function getStorageOnChanged(): ChromeStorageOnChangedLike | null {
   }
 }
 
-export function isValidBackendPort(value: unknown): boolean {
+function parseBackendPort(value: unknown): number | null {
   if (typeof value === "number" && Number.isInteger(value)) {
-    return value >= 1 && value <= 65535;
+    return value >= 1 && value <= 65535 ? value : null;
   }
   if (typeof value === "string" && value.trim() !== "") {
-    const parsed = Number.parseInt(value.trim(), 10);
-    return Number.isInteger(parsed) && parsed >= 1 && parsed <= 65535;
+    const trimmed = value.trim();
+    if (!/^[0-9]+$/.test(trimmed)) {
+      return null;
+    }
+    const parsed = Number(trimmed);
+    return Number.isInteger(parsed) && parsed >= 1 && parsed <= 65535 ? parsed : null;
   }
-  return false;
+  return null;
+}
+
+export function isValidBackendPort(value: unknown): boolean {
+  return parseBackendPort(value) !== null;
 }
 
 function coercePort(value: unknown): number {
-  if (typeof value === "number" && Number.isInteger(value) && value >= 1 && value <= 65535) {
-    return value;
-  }
-  if (typeof value === "string" && value.trim() !== "") {
-    const parsed = Number.parseInt(value.trim(), 10);
-    if (Number.isInteger(parsed) && parsed >= 1 && parsed <= 65535) {
-      return parsed;
-    }
-  }
-  return DEFAULT_BACKEND_PORT;
+  return parseBackendPort(value) ?? DEFAULT_BACKEND_PORT;
 }
 
 function sanitizeEndpoint(raw: unknown): BackendEndpoint {

--- a/extension/src/shared/backend-endpoint.ts
+++ b/extension/src/shared/backend-endpoint.ts
@@ -1,0 +1,247 @@
+/**
+ * OpenBiliClaw — configurable local-backend endpoint.
+ *
+ * The popup settings page can override the backend port (default 8420) to
+ * dodge Hyper-V / WSL / Docker port reservations on Windows. Every fetch
+ * and WebSocket in the extension goes through this module so a single
+ * source of truth resolves the current host + port at call time.
+ *
+ * Storage:
+ *   chrome.storage.local key ``popup_backend_endpoint`` =
+ *     { host: "127.0.0.1", port: 8420 }
+ *
+ * Both the popup (popup-backend-config.js) and the service worker / content
+ * scripts read & write this same key. Each context subscribes to
+ * chrome.storage.onChanged so a port change in the popup is picked up by
+ * the service worker immediately (it can then reopen its runtime-stream
+ * WebSocket against the new port).
+ */
+
+export const DEFAULT_BACKEND_HOST = "127.0.0.1";
+export const DEFAULT_BACKEND_PORT = 8420;
+export const BACKEND_ENDPOINT_STORAGE_KEY = "popup_backend_endpoint";
+
+export interface BackendEndpoint {
+  host: string;
+  port: number;
+}
+
+const DEFAULT_ENDPOINT: BackendEndpoint = {
+  host: DEFAULT_BACKEND_HOST,
+  port: DEFAULT_BACKEND_PORT,
+};
+
+let cached: BackendEndpoint = { ...DEFAULT_ENDPOINT };
+let initialized = false;
+let initPromise: Promise<BackendEndpoint> | null = null;
+let storageListenerInstalled = false;
+const subscribers = new Set<(endpoint: BackendEndpoint) => void>();
+
+interface ChromeStorageLocalLike {
+  get?: (
+    key: string,
+    callback: (items: Record<string, unknown>) => void,
+  ) => void;
+  set?: (items: Record<string, unknown>, callback?: () => void) => void;
+}
+
+interface ChromeStorageOnChangedLike {
+  addListener?: (
+    callback: (
+      changes: Record<string, { newValue?: unknown; oldValue?: unknown }>,
+      areaName: string,
+    ) => void,
+  ) => void;
+}
+
+function getStorageLocal(): ChromeStorageLocalLike | null {
+  try {
+    const chromeApi = (globalThis as { chrome?: { storage?: { local?: ChromeStorageLocalLike } } })
+      .chrome;
+    return chromeApi?.storage?.local ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function getStorageOnChanged(): ChromeStorageOnChangedLike | null {
+  try {
+    const chromeApi = (
+      globalThis as {
+        chrome?: { storage?: { onChanged?: ChromeStorageOnChangedLike } };
+      }
+    ).chrome;
+    return chromeApi?.storage?.onChanged ?? null;
+  } catch {
+    return null;
+  }
+}
+
+export function isValidBackendPort(value: unknown): boolean {
+  if (typeof value === "number" && Number.isInteger(value)) {
+    return value >= 1 && value <= 65535;
+  }
+  if (typeof value === "string" && value.trim() !== "") {
+    const parsed = Number.parseInt(value.trim(), 10);
+    return Number.isInteger(parsed) && parsed >= 1 && parsed <= 65535;
+  }
+  return false;
+}
+
+function coercePort(value: unknown): number {
+  if (typeof value === "number" && Number.isInteger(value) && value >= 1 && value <= 65535) {
+    return value;
+  }
+  if (typeof value === "string" && value.trim() !== "") {
+    const parsed = Number.parseInt(value.trim(), 10);
+    if (Number.isInteger(parsed) && parsed >= 1 && parsed <= 65535) {
+      return parsed;
+    }
+  }
+  return DEFAULT_BACKEND_PORT;
+}
+
+function sanitizeEndpoint(raw: unknown): BackendEndpoint {
+  if (typeof raw !== "object" || raw === null) {
+    return { ...DEFAULT_ENDPOINT };
+  }
+  const obj = raw as Record<string, unknown>;
+  const hostRaw = typeof obj.host === "string" ? obj.host.trim() : "";
+  return {
+    host: hostRaw || DEFAULT_BACKEND_HOST,
+    port: coercePort(obj.port),
+  };
+}
+
+async function loadFromStorage(): Promise<BackendEndpoint> {
+  const storage = getStorageLocal();
+  if (!storage?.get) {
+    return { ...cached };
+  }
+  return new Promise<BackendEndpoint>((resolve) => {
+    try {
+      storage.get?.(BACKEND_ENDPOINT_STORAGE_KEY, (items) => {
+        const stored = items?.[BACKEND_ENDPOINT_STORAGE_KEY];
+        resolve(stored === undefined ? { ...cached } : sanitizeEndpoint(stored));
+      });
+    } catch {
+      resolve({ ...cached });
+    }
+  });
+}
+
+function installStorageChangeListener(): void {
+  if (storageListenerInstalled) return;
+  const onChanged = getStorageOnChanged();
+  if (!onChanged?.addListener) return;
+  try {
+    onChanged.addListener((changes, area) => {
+      if (area !== "local") return;
+      const change = changes[BACKEND_ENDPOINT_STORAGE_KEY];
+      if (!change) return;
+      const next = sanitizeEndpoint(change.newValue);
+      cached = next;
+      initialized = true;
+      for (const cb of subscribers) {
+        try {
+          cb(next);
+        } catch {
+          // Subscriber failures must not break peer subscribers.
+        }
+      }
+    });
+    storageListenerInstalled = true;
+  } catch {
+    // chrome.storage.onChanged not available in this context (e.g. tests).
+  }
+}
+
+async function ensureLoaded(): Promise<BackendEndpoint> {
+  if (initialized) return cached;
+  if (initPromise) return initPromise;
+  initPromise = (async () => {
+    const endpoint = await loadFromStorage();
+    cached = endpoint;
+    initialized = true;
+    installStorageChangeListener();
+    return endpoint;
+  })();
+  return initPromise;
+}
+
+export async function getBackendEndpoint(): Promise<BackendEndpoint> {
+  return ensureLoaded();
+}
+
+export async function getBackendOrigin(): Promise<string> {
+  const ep = await ensureLoaded();
+  return `http://${ep.host}:${ep.port}`;
+}
+
+export async function apiUrl(path: string): Promise<string> {
+  const ep = await ensureLoaded();
+  const suffix = path.startsWith("/") ? path : `/${path}`;
+  return `http://${ep.host}:${ep.port}/api${suffix}`;
+}
+
+export async function wsUrl(path: string): Promise<string> {
+  const ep = await ensureLoaded();
+  const suffix = path.startsWith("/") ? path : `/${path}`;
+  return `ws://${ep.host}:${ep.port}/api${suffix}`;
+}
+
+export async function updateBackendPort(value: unknown): Promise<BackendEndpoint> {
+  if (!isValidBackendPort(value)) {
+    throw new Error("Backend port must be an integer between 1 and 65535");
+  }
+  const port = coercePort(value);
+  const endpoint: BackendEndpoint = { host: cached.host || DEFAULT_BACKEND_HOST, port };
+  cached = endpoint;
+  initialized = true;
+  const storage = getStorageLocal();
+  if (storage?.set) {
+    await new Promise<void>((resolve) => {
+      try {
+        storage.set?.({ [BACKEND_ENDPOINT_STORAGE_KEY]: endpoint }, () => resolve());
+      } catch {
+        resolve();
+      }
+    });
+  }
+  // chrome.storage.onChanged will fan out to other contexts (e.g. the
+  // service worker), but the local context still needs to notify its own
+  // subscribers synchronously — onChanged does not fire in the writer.
+  for (const cb of subscribers) {
+    try {
+      cb(endpoint);
+    } catch {
+      // ignore subscriber failures
+    }
+  }
+  return endpoint;
+}
+
+export function onBackendEndpointChange(
+  callback: (endpoint: BackendEndpoint) => void,
+): () => void {
+  subscribers.add(callback);
+  // Lazy-install once any context cares about changes.
+  installStorageChangeListener();
+  // Prime cache so the listener has the right baseline.
+  void ensureLoaded();
+  return () => {
+    subscribers.delete(callback);
+  };
+}
+
+/**
+ * Test-only: reset internal cache and subscribers between tests so each
+ * test can stub a fresh chrome.storage.local.
+ */
+export function __resetBackendEndpointForTests(): void {
+  cached = { ...DEFAULT_ENDPOINT };
+  initialized = false;
+  initPromise = null;
+  storageListenerInstalled = false;
+  subscribers.clear();
+}

--- a/extension/tests/backend-endpoint.test.ts
+++ b/extension/tests/backend-endpoint.test.ts
@@ -1,0 +1,39 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { isValidBackendPort as isValidPopupBackendPort } from "../popup/popup-backend-config.js";
+import { isValidBackendPort as isValidSharedBackendPort } from "../src/shared/backend-endpoint.ts";
+
+const validPorts: unknown[] = [1, 8420, 65535, "1", "8420", "65535", " 19090 "];
+const invalidPorts: unknown[] = [
+  0,
+  65536,
+  -1,
+  "",
+  "   ",
+  "1.5",
+  "1e3",
+  "123abc",
+  "0x20",
+  "+8420",
+  null,
+  undefined,
+];
+
+test("popup backend port validation accepts only complete decimal integers in range", () => {
+  for (const port of validPorts) {
+    assert.equal(isValidPopupBackendPort(port), true, `${String(port)} should be valid`);
+  }
+  for (const port of invalidPorts) {
+    assert.equal(isValidPopupBackendPort(port), false, `${String(port)} should be invalid`);
+  }
+});
+
+test("shared backend port validation accepts only complete decimal integers in range", () => {
+  for (const port of validPorts) {
+    assert.equal(isValidSharedBackendPort(port), true, `${String(port)} should be valid`);
+  }
+  for (const port of invalidPorts) {
+    assert.equal(isValidSharedBackendPort(port), false, `${String(port)} should be invalid`);
+  }
+});

--- a/extension/tests/popup-api.test.ts
+++ b/extension/tests/popup-api.test.ts
@@ -14,6 +14,7 @@ import {
   startChatTurn,
   updateConfig,
 } from "../popup/popup-api.js";
+import { __resetBackendEndpointForTests } from "../popup/popup-backend-config.js";
 
 test("reshuffleRecommendations posts to reshuffle endpoint", async () => {
   const calls = [];
@@ -500,4 +501,46 @@ test("fetchChatTurn and fetchChatTurns read durable chat state", async () => {
   assert.equal(calls[1].options.method, "GET");
   assert.equal(turn.reply, "你好，我在。");
   assert.equal(history.items[0].turn_id, "turn-abc");
+});
+
+test("popup-api requests honor configured backend port from chrome.storage.local", async () => {
+  // Reset module cache so the previous tests' default-port resolution
+  // doesn't shadow the stubbed chrome.storage value.
+  __resetBackendEndpointForTests();
+  const originalChrome = (globalThis as { chrome?: unknown }).chrome;
+  (globalThis as { chrome?: unknown }).chrome = {
+    storage: {
+      local: {
+        get(_key: string, callback: (items: Record<string, unknown>) => void) {
+          callback({
+            popup_backend_endpoint: {
+              host: "127.0.0.1",
+              port: 19090,
+              basePath: "/api",
+            },
+          });
+        },
+      },
+    },
+  };
+
+  const calls: Array<{ url: string; options: { method?: string } }> = [];
+  globalThis.fetch = (async (url: string, options: { method?: string }) => {
+    calls.push({ url, options });
+    return {
+      ok: true,
+      async json() {
+        return { language: "zh" };
+      },
+    };
+  }) as unknown as typeof fetch;
+
+  try {
+    await fetchConfig();
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].url, "http://127.0.0.1:19090/api/config?reveal_keys=true");
+  } finally {
+    (globalThis as { chrome?: unknown }).chrome = originalChrome;
+    __resetBackendEndpointForTests();
+  }
 });

--- a/extension/tests/popup-settings.test.ts
+++ b/extension/tests/popup-settings.test.ts
@@ -7,6 +7,7 @@ test("settings page exposes advanced config fields from backend schema", () => {
   const popupHtml = readFileSync(resolve("popup", "popup.html"), "utf8");
   const popupJs = readFileSync(resolve("popup", "popup.js"), "utf8");
   const expectedIds = [
+    "cfgBackendPort",
     "cfgDataDir",
     "cfgDeepseekReasoning",
     "cfgOpenrouterReferer",

--- a/extension/tests/popup-stream.test.ts
+++ b/extension/tests/popup-stream.test.ts
@@ -15,6 +15,10 @@ test("createRuntimeStreamUrl converts backend http url to websocket runtime stre
     createRuntimeStreamUrl("https://api.example.com/api"),
     "wss://api.example.com/api/runtime-stream",
   );
+  assert.equal(
+    createRuntimeStreamUrl("http://127.0.0.1:19090/api"),
+    "ws://127.0.0.1:19090/api/runtime-stream",
+  );
 });
 
 class FakeWebSocket {
@@ -102,6 +106,22 @@ test("runtime stream client calls onDisconnect when socket closes after being co
   FakeWebSocket.latest?.onclose?.();
   assert.equal(disconnected, true);
 
+  client.disconnect();
+});
+
+test("runtime stream client resolves backend URL dynamically when no explicit backendUrl is given", async () => {
+  FakeWebSocket.latest = null;
+  const client = createRuntimeStreamClient({
+    backendUrl: null,
+    resolveBackendUrl: async () => "http://127.0.0.1:19090/api",
+    WebSocketImpl: FakeWebSocket as never,
+  });
+
+  client.connect();
+  // resolveBackendUrl is async — wait one microtask flush before checking.
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  assert.equal(FakeWebSocket.latest?.url, "ws://127.0.0.1:19090/api/runtime-stream");
   client.disconnect();
 });
 

--- a/extension/tsconfig.json
+++ b/extension/tsconfig.json
@@ -4,6 +4,7 @@
         "lib": ["ES2022", "DOM"],
         "module": "ESNext",
         "moduleResolution": "bundler",
+        "allowImportingTsExtensions": true,
         "strict": true,
         "esModuleInterop": true,
         "types": ["chrome"],

--- a/tests/test_api_app.py
+++ b/tests/test_api_app.py
@@ -4,12 +4,30 @@ from __future__ import annotations
 
 import asyncio
 from pathlib import Path
-from typing import TYPE_CHECKING
 
-if TYPE_CHECKING:
-    import pytest
+import pytest
 
 from openbiliclaw.api.app import create_app
+
+
+@pytest.fixture(autouse=True)
+def _isolate_runtime_config(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Keep create_app() route tests independent from the developer machine.
+
+    Several API tests intentionally exercise routes with partial fake runtime
+    components. create_app() still loads runtime config up front, so without
+    this fixture CI sees the repo's empty template while local runs may see a
+    private config.toml with real credentials.
+    """
+
+    from openbiliclaw.config import Config, save_config
+
+    project_root = tmp_path / "runtime"
+    monkeypatch.setenv("OPENBILICLAW_PROJECT_ROOT", str(project_root))
+    cfg = Config()
+    cfg.llm.default_provider = "ollama"
+    cfg.llm.ollama.model = "llama3"
+    save_config(cfg, project_root / "config.toml")
 
 
 class TestBackendAPI:
@@ -403,6 +421,7 @@ class TestBackendAPI:
         cookie_file = tmp_path / "data" / "bilibili_cookie.json"
         assert cookie_file.exists()
         import json
+
         assert json.loads(cookie_file.read_text())["cookie"] == cookie_value
 
         # Side effect 2: config.toml [bilibili].cookie mirrors the cookie.
@@ -849,28 +868,32 @@ class TestBackendAPI:
                 # only 2 survive.
                 base: list[dict[str, object]] = []
                 for i in range(5):
-                    base.append({
-                        "id": i,
-                        "bvid": f"BV原神{i}",
-                        "title": f"原神 番外 {i}",
-                        "up_name": "某 UP",
+                    base.append(
+                        {
+                            "id": i,
+                            "bvid": f"BV原神{i}",
+                            "title": f"原神 番外 {i}",
+                            "up_name": "某 UP",
+                            "cover_url": "",
+                            "expression": "",
+                            "topic": "游戏",
+                            "presented": 0,
+                            "franchise_key": "原神",
+                        }
+                    )
+                base.append(
+                    {
+                        "id": 99,
+                        "bvid": "BV番茄",
+                        "title": "番茄炒蛋 5 分钟",
+                        "up_name": "美食 UP",
                         "cover_url": "",
                         "expression": "",
-                        "topic": "游戏",
+                        "topic": "美食",
                         "presented": 0,
-                        "franchise_key": "原神",
-                    })
-                base.append({
-                    "id": 99,
-                    "bvid": "BV番茄",
-                    "title": "番茄炒蛋 5 分钟",
-                    "up_name": "美食 UP",
-                    "cover_url": "",
-                    "expression": "",
-                    "topic": "美食",
-                    "presented": 0,
-                    "franchise_key": "",
-                })
+                        "franchise_key": "",
+                    }
+                )
                 return base
 
         app = create_app(database=FakeDatabase())
@@ -879,9 +902,7 @@ class TestBackendAPI:
         response = client.get("/api/recommendations")
         assert response.status_code == 200
         items = response.json()["items"]
-        franchise_count = sum(
-            1 for it in items if str(it["title"]).startswith("原神")
-        )
+        franchise_count = sum(1 for it in items if str(it["title"]).startswith("原神"))
         # 5 同 IP 行被砍到 2，番茄炒蛋（无 franchise）仍保留
         assert franchise_count == 2
         assert any(it["title"].startswith("番茄炒蛋") for it in items)
@@ -1582,7 +1603,7 @@ class TestBackendAPI:
                         "kind": "interest_added",
                         "summary": "阿B 现在更确定你会吃国际时事深拆这一口。",
                         "context_line": "基于最近内容：《中东局势深拆》 / 《国际秩序观察》",
-                        "impact": '画像里\u201c国际新闻 / 深度分析\u201d这条偏好会更靠前。',
+                        "impact": "画像里\u201c国际新闻 / 深度分析\u201d这条偏好会更靠前。",
                         "reasoning": "这更像是连续强化后的稳定兴趣，不只是一次随手点开。",
                         "evidence": "因为你最近连续点开相关内容，还主动提到了国际时事。",
                         "source": "chat",
@@ -1651,7 +1672,9 @@ class TestBackendAPI:
         assert data["deep_needs"] == ["理解世界", "持续成长", "高质量独处", "智性共鸣", "掌控感"]
         assert data["values"] == ["独立思考", "真实", "深度"]
         assert data["motivational_drivers"] == [
-            "建立判断确定性", "持续扩展理解边界", "在复杂信息里找到秩序感",
+            "建立判断确定性",
+            "持续扩展理解边界",
+            "在复杂信息里找到秩序感",
         ]
         assert data["cognitive_style"] == [
             "会先看结构",
@@ -1926,9 +1949,7 @@ class TestBackendAPI:
         response = client.post("/api/chat", json={"message": "我最近总在看国际新闻"})
 
         assert response.status_code == 200
-        assert response.json() == {
-            "reply": "你更在意的是它背后的逻辑，还是事件本身的冲突感？"
-        }
+        assert response.json() == {"reply": "你更在意的是它背后的逻辑，还是事件本身的冲突感？"}
 
     def test_chat_endpoint_rejects_empty_message(self) -> None:
         from fastapi.testclient import TestClient
@@ -2036,9 +2057,7 @@ class TestBackendAPI:
         ]
         assert soul_engine._speculator.rejected == [("城市漫游路线", 30)]
 
-    def test_chat_turn_endpoint_persists_pending_turn_until_reply(
-        self, tmp_path: Path
-    ) -> None:
+    def test_chat_turn_endpoint_persists_pending_turn_until_reply(self, tmp_path: Path) -> None:
         import asyncio
         import time
 
@@ -2166,9 +2185,7 @@ class TestBackendAPI:
                 "/api/chat/turns",
                 params={"session": "popup", "scope": "delight"},
             ).json()
-            assert [item["turn_id"] for item in delight_history["items"]] == [
-                "turn-delight-1"
-            ]
+            assert [item["turn_id"] for item in delight_history["items"]] == ["turn-delight-1"]
 
     def test_recommendation_click_endpoint_ingests_strong_signal(self) -> None:
         """POST /api/recommendation-click should push a strong signal through the pipeline."""
@@ -2183,7 +2200,8 @@ class TestBackendAPI:
 
         class FakeDatabase:
             def get_recommendation_by_id(
-                self, recommendation_id: int,
+                self,
+                recommendation_id: int,
             ) -> dict[str, object] | None:
                 if recommendation_id != 99:
                     return None
@@ -2282,7 +2300,8 @@ class TestBackendAPI:
 
         class FakeDatabase:
             def get_recommendation_by_id(
-                self, recommendation_id: int,
+                self,
+                recommendation_id: int,
             ) -> dict[str, object] | None:
                 return None
 
@@ -2337,7 +2356,8 @@ class TestBackendAPI:
 
         class FakeDatabase:
             def get_recommendation_by_id(
-                self, recommendation_id: int,
+                self,
+                recommendation_id: int,
             ) -> dict[str, object] | None:
                 return None
 
@@ -2383,7 +2403,8 @@ class TestBackendAPI:
 
         class FakeDatabase:
             def get_recommendation_by_id(
-                self, recommendation_id: int,
+                self,
+                recommendation_id: int,
             ) -> dict[str, object] | None:
                 return None  # should not be called
 
@@ -2431,7 +2452,8 @@ class TestBackendAPI:
 
         class FakeDatabase:
             def get_recommendation_by_id(
-                self, recommendation_id: int,
+                self,
+                recommendation_id: int,
             ) -> dict[str, object] | None:
                 return None  # unknown recommendation
 
@@ -2869,9 +2891,7 @@ class TestEmbeddingAndCompatProviderE2E:
         assert "*" in compat["api_key"]
         assert "gsk-groq-secret-key-1234567890" not in compat["api_key"]
 
-    def test_get_config_exposes_embedding_credentials_masked(
-        self, monkeypatch, tmp_path
-    ) -> None:
+    def test_get_config_exposes_embedding_credentials_masked(self, monkeypatch, tmp_path) -> None:
         """v0.3.32+ embedding owns api_key/base_url. They must surface
         in /api/config (so the popup knows what's configured) with
         api_key masked."""
@@ -2907,9 +2927,7 @@ class TestEmbeddingAndCompatProviderE2E:
         assert "*" in emb["api_key"]
         assert "sk-embed-secret-1234567890" not in emb["api_key"]
 
-    def test_get_config_with_reveal_keys_returns_raw_secrets(
-        self, monkeypatch, tmp_path
-    ) -> None:
+    def test_get_config_with_reveal_keys_returns_raw_secrets(self, monkeypatch, tmp_path) -> None:
         """``GET /api/config?reveal_keys=true`` returns unmasked keys
         for both new fields (openai_compatible.api_key + embedding.api_key).
         Used by the popup when the user clicks "show" to edit."""
@@ -2937,9 +2955,7 @@ class TestEmbeddingAndCompatProviderE2E:
 
     # ── PUT round-trip: openai_compatible ───────────────────────────
 
-    def test_put_openai_compatible_round_trips_through_get(
-        self, monkeypatch, tmp_path
-    ) -> None:
+    def test_put_openai_compatible_round_trips_through_get(self, monkeypatch, tmp_path) -> None:
         """PUT a full [llm.openai_compatible] block, then GET — the
         non-secret fields come back identical, api_key comes back
         masked but the in-memory config object holds the real value."""
@@ -2979,9 +2995,7 @@ class TestEmbeddingAndCompatProviderE2E:
         assert "*" in compat["api_key"]
         assert "gsk-fresh-groq-key-1234567890" not in compat["api_key"]
 
-    def test_put_openai_compatible_does_not_stomp_openai_block(
-        self, monkeypatch, tmp_path
-    ) -> None:
+    def test_put_openai_compatible_does_not_stomp_openai_block(self, monkeypatch, tmp_path) -> None:
         """Partial PUT with only [llm.openai_compatible] must NOT clear
         the existing [llm.openai] block. Both providers can coexist
         (the whole point of the v0.3.32 split)."""
@@ -3053,15 +3067,11 @@ class TestEmbeddingAndCompatProviderE2E:
 
         issues = resp.json()["config"]["issues"]
         fields = [i["field"] for i in issues]
-        assert "llm.openai_compatible.base_url" in fields, (
-            f"expected base_url issue in {fields}"
-        )
+        assert "llm.openai_compatible.base_url" in fields, f"expected base_url issue in {fields}"
 
     # ── Embedding round-trip + masked-echo protection ───────────────
 
-    def test_put_embedding_via_openai_compatible_round_trip(
-        self, monkeypatch, tmp_path
-    ) -> None:
+    def test_put_embedding_via_openai_compatible_round_trip(self, monkeypatch, tmp_path) -> None:
         """Embedding can independently target an openai_compatible
         backend (vLLM / Together / Azure OpenAI), with its own api_key
         and base_url — no need to also fill [llm.openai_compatible]."""
@@ -3182,9 +3192,7 @@ class TestEmbeddingAndCompatProviderE2E:
 
     # ── Coexistence: both providers usable in one config ────────────
 
-    def test_get_after_dual_put_returns_both_provider_blocks(
-        self, monkeypatch, tmp_path
-    ) -> None:
+    def test_get_after_dual_put_returns_both_provider_blocks(self, monkeypatch, tmp_path) -> None:
         """Set both [llm.openai] (real OpenAI for chat) and
         [llm.openai_compatible] (Groq for fast drafting) in one PUT.
         Both blocks must round-trip independently — the v0.3.32 split
@@ -3225,9 +3233,7 @@ class TestEmbeddingAndCompatProviderE2E:
         assert "*" in openai_mask and "*" in compat_mask
         assert openai_mask != compat_mask
 
-    def test_get_config_exposes_sources_and_advanced_settings(
-        self, monkeypatch, tmp_path
-    ) -> None:
+    def test_get_config_exposes_sources_and_advanced_settings(self, monkeypatch, tmp_path) -> None:
         """The config API should expose persisted advanced fields so the
         extension settings page can stay aligned with config.toml."""
         from openbiliclaw.config import Config, LLMConfig, LLMProviderConfig
@@ -3319,9 +3325,7 @@ class TestEmbeddingAndCompatProviderE2E:
         assert data["logging"]["unmanaged_truncate_mb"] == 78
         assert data["logging"]["unmanaged_max_age_days"] == 9
 
-    def test_put_config_updates_sources_and_advanced_settings(
-        self, monkeypatch, tmp_path
-    ) -> None:
+    def test_put_config_updates_sources_and_advanced_settings(self, monkeypatch, tmp_path) -> None:
         """PUT /api/config should update the same advanced fields that the
         extension settings page exposes."""
         from openbiliclaw.config import Config, LLMConfig, LLMProviderConfig
@@ -3495,9 +3499,7 @@ class TestEmbeddingAndCompatProviderE2E:
             },
         }
 
-    def test_source_share_suggestion_post_uses_form_overrides(
-        self, monkeypatch, tmp_path
-    ) -> None:
+    def test_source_share_suggestion_post_uses_form_overrides(self, monkeypatch, tmp_path) -> None:
         """POST /api/config/source-share-suggestion should support the
         extension settings page's unsaved switch/share state."""
         from fastapi.testclient import TestClient

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1820,7 +1820,7 @@ def test_init_guides_missing_runtime_config_interactively(
     #   5. "n" — skip module overrides
     #   6. "n" — skip xhs inclusion
     #   7. "n" — skip douyin inclusion
-    #   8. "n" — skip youtube inclusion
+    #   8+. "n" — skip any remaining optional source prompts
     wizard_input = (
         "\n".join(
             [
@@ -1828,6 +1828,7 @@ def test_init_guides_missing_runtime_config_interactively(
                 "gemini-key",
                 "",
                 "1",
+                "n",
                 "n",
                 "n",
                 "n",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -81,6 +81,15 @@ def runner() -> CliRunner:
     return CliRunner()
 
 
+def _ignore_runtime_config_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        cli_module,
+        "_load_runtime_config_error",
+        lambda *, render=True: None,
+        raising=False,
+    )
+
+
 def test_main_bootstraps_container_runtime_when_project_root_is_configured(
     monkeypatch: pytest.MonkeyPatch, runner: CliRunner, tmp_path: Path
 ) -> None:
@@ -480,7 +489,7 @@ def test_db_repair_reports_successful_rebuild(
 
     assert result.exit_code == 0
     assert "数据库已恢复并完成切换。" in result.stdout
-    assert "openbiliclaw.repaired.db" in result.stdout
+    assert "openbiliclaw.repaired.db" in result.stdout.replace("\n", "")
 
 
 def test_runtime_builders_share_database_instance(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -1716,6 +1725,7 @@ def test_init_reports_authentication_failure(
                 message="未配置 B 站 Cookie。",
             )
 
+    _ignore_runtime_config_error(monkeypatch)
     monkeypatch.setattr(cli_module, "_require_runtime_config", lambda: None)
     monkeypatch.setattr(cli_module, "_build_auth_manager", lambda: FakeAuthManager(), raising=False)
     monkeypatch.setattr(cli_module, "_initialize_logging", lambda log_level_override=None: None)
@@ -1936,6 +1946,7 @@ def test_init_reports_when_history_is_empty(
         async def get_user_history(self, max_items: int = 100) -> list[dict[str, object]]:
             return []
 
+    _ignore_runtime_config_error(monkeypatch)
     monkeypatch.setattr(cli_module, "_require_runtime_config", lambda: None)
     monkeypatch.setattr(cli_module, "_build_auth_manager", lambda: FakeAuthManager(), raising=False)
     monkeypatch.setattr(
@@ -2048,6 +2059,7 @@ def test_init_runs_history_preference_profile_and_discovery(
         (),
         {"count_pool_candidates": lambda self: 0},
     )()
+    _ignore_runtime_config_error(monkeypatch)
     monkeypatch.setattr(cli_module, "_require_runtime_config", lambda: None)
     monkeypatch.setattr(cli_module, "_build_auth_manager", lambda: FakeAuthManager(), raising=False)
     monkeypatch.setattr(
@@ -3019,6 +3031,7 @@ def test_init_backfills_pool_in_stages_until_target_is_reached(
 
     fake_database = FakeDatabase()
     fake_discovery = FakeDiscoveryEngine(fake_database)
+    _ignore_runtime_config_error(monkeypatch)
     monkeypatch.setattr(cli_module, "_require_runtime_config", lambda: None)
     monkeypatch.setattr(cli_module, "_build_auth_manager", lambda: FakeAuthManager(), raising=False)
     monkeypatch.setattr(
@@ -3134,6 +3147,7 @@ def test_init_skips_backfill_when_pool_target_is_already_reached(
 
     fake_database = FakeDatabase()
     fake_discovery = FakeDiscoveryEngine(fake_database)
+    _ignore_runtime_config_error(monkeypatch)
     monkeypatch.setattr(cli_module, "_require_runtime_config", lambda: None)
     monkeypatch.setattr(cli_module, "_build_auth_manager", lambda: FakeAuthManager(), raising=False)
     monkeypatch.setattr(
@@ -3224,6 +3238,7 @@ def test_init_reports_partial_success_when_discovery_fails(
         (),
         {"count_pool_candidates": lambda self: 0},
     )()
+    _ignore_runtime_config_error(monkeypatch)
     monkeypatch.setattr(cli_module, "_require_runtime_config", lambda: None)
     monkeypatch.setattr(cli_module, "_build_auth_manager", lambda: FakeAuthManager(), raising=False)
     monkeypatch.setattr(

--- a/tests/test_openclaw_cli.py
+++ b/tests/test_openclaw_cli.py
@@ -20,6 +20,9 @@ from openbiliclaw.integrations.openclaw.schemas import (
     SyncAccountResponse,
 )
 
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_SKILL_PACK_PATH = _REPO_ROOT / "skills" / "openbiliclaw-adapter" / "SKILL.md"
+
 
 class _FakeCliAdapter:
     def __init__(self) -> None:
@@ -222,10 +225,7 @@ def test_doctor_cli_reports_skill_pack_and_registered_skill_names(capsys) -> Non
     assert json.loads(captured.out) == {
         "ok": True,
         "data": {
-            "skill_pack_path": (
-                "/Users/white/workspace/OpenBiliClaw/"
-                "skills/openbiliclaw-adapter/SKILL.md"
-            ),
+            "skill_pack_path": str(_SKILL_PACK_PATH),
             "skill_pack_exists": True,
             "skill_count": 8,
             "skill_names": [
@@ -293,11 +293,15 @@ def test_listen_parser_accepts_custom_flags() -> None:
     from openbiliclaw.integrations.openclaw.cli import _build_parser
 
     parser = _build_parser()
-    args = parser.parse_args([
-        "listen",
-        "--ws-url", "ws://custom:9999/api/runtime-stream",
-        "--events", "delight.candidate,refresh.pool_updated",
-    ])
+    args = parser.parse_args(
+        [
+            "listen",
+            "--ws-url",
+            "ws://custom:9999/api/runtime-stream",
+            "--events",
+            "delight.candidate,refresh.pool_updated",
+        ]
+    )
 
     assert args.ws_url == "ws://custom:9999/api/runtime-stream"
     assert "delight.candidate" in args.events
@@ -305,9 +309,7 @@ def test_listen_parser_accepts_custom_flags() -> None:
 
 
 def test_workspace_skill_pack_exists_and_mentions_cli_bridge() -> None:
-    skill_path = Path("/Users/white/workspace/OpenBiliClaw/skills/openbiliclaw-adapter/SKILL.md")
-
-    content = skill_path.read_text(encoding="utf-8")
+    content = _SKILL_PACK_PATH.read_text(encoding="utf-8")
 
     assert "name: openbiliclaw_adapter" in content
     assert "uv run python -m openbiliclaw.integrations.openclaw.cli" in content


### PR DESCRIPTION
## Summary

- Adds a shared configurable backend endpoint helper for the extension and routes popup, service worker, cookie sync, task dispatchers, WebSocket runtime stream, and debug relays through it.
- Adds a popup settings field for the backend port, validates complete decimal integer ports in the `1-65535` range, and relaxes local extension host permissions so non-8420 ports work.
- Updates extension docs, changelog, README / README_EN release highlights, and public acknowledgements for @addtion99's #8 proposal and popup-side implementation idea.

Closes #8.

## Test Plan

- `cd extension && node --test --experimental-strip-types tests/backend-endpoint.test.ts`
- `cd extension && npm test -- --test-reporter=spec`
- `cd extension && npm run typecheck`
- `cd extension && npm run build`
- `git diff --check`

## Release Note

After this PR lands, publish browser extension `v0.3.24` with both Chrome-compatible and Firefox artifacts. A backend/PyPI release is not required for this change unless the project is doing a whole-repo release batch.
