### PR TITLE
feat(extension): add content mode buttons for filter-bubble breaking,…

### DIFF
--- a/extension/popup/popup-api.js
+++ b/extension/popup/popup-api.js
@@ -147,21 +147,27 @@ export async function refreshRecommendations() {
   return requestJson("/recommendations/refresh", { method: "POST" });
 }
 
-export async function reshuffleRecommendations() {
-  const payload = await requestJson("/recommendations/reshuffle", { method: "POST" });
+export async function reshuffleRecommendations(mode = "") {
+  const payload = await requestJson("/recommendations/reshuffle", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ mode }),
+  });
   return {
     ...payload,
     items: Array.isArray(payload.items) ? payload.items.map(normalizeRecommendation) : [],
   };
 }
 
-export async function appendRecommendations(excludedBvids = []) {
+export async function appendRecommendations(excludedBvids = [], mode = "") {
   const payload = await requestJson("/recommendations/append", {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
     },
-    body: JSON.stringify({ excluded_bvids: excludedBvids }),
+    body: JSON.stringify({ excluded_bvids: excludedBvids, mode }),
   });
   return {
     ...payload,

--- a/extension/popup/popup.html
+++ b/extension/popup/popup.html
@@ -1441,6 +1441,52 @@
       color: var(--text-main);
     }
 
+    /* ── Content mode buttons ────────────────────────────────────── */
+    .mode-bar {
+      display: flex;
+      gap: 8px;
+      flex-wrap: wrap;
+    }
+
+    .mode-button {
+      flex: 1 1 auto;
+      min-width: 0;
+      border: 1px solid var(--line);
+      border-radius: 12px;
+      padding: 8px 6px;
+      background: rgba(255, 255, 255, 0.7);
+      color: var(--text-secondary);
+      font-size: 11px;
+      line-height: 1.3;
+      font-weight: 700;
+      cursor: pointer;
+      transition:
+        background 180ms ease,
+        color 180ms ease,
+        border-color 180ms ease,
+        box-shadow 180ms ease,
+        transform 180ms ease;
+    }
+
+    .mode-button:hover {
+      background: rgba(255, 255, 255, 0.92);
+      color: var(--text-main);
+      border-color: var(--sky);
+      transform: translateY(-1px);
+    }
+
+    .mode-button.is-active {
+      color: var(--brand-strong);
+      background: linear-gradient(180deg, rgba(255, 255, 255, 0.98), rgba(255, 240, 246, 0.98));
+      border-color: var(--brand);
+      box-shadow: 0 6px 14px rgba(251, 114, 153, 0.12);
+    }
+
+    .mode-button:focus-visible {
+      outline: none;
+      box-shadow: var(--focus-ring);
+    }
+
     .comment-composer {
       display: flex;
       flex-direction: column;
@@ -3385,6 +3431,12 @@
               </div>
             </div>
           </div>
+        </div>
+        <div class="mode-bar">
+          <button id="modeDefault" class="mode-button is-active" type="button" data-mode="">为你推荐</button>
+          <button id="modeExplore" class="mode-button" type="button" data-mode="explore">打破信息茧房</button>
+          <button id="modeProfessional" class="mode-button" type="button" data-mode="professional">专业知识</button>
+          <button id="modeCasual" class="mode-button" type="button" data-mode="casual">休闲知识</button>
         </div>
         <div id="delightSlot" hidden></div>
         <div id="emptyState" class="empty-state" hidden>

--- a/extension/popup/popup.js
+++ b/extension/popup/popup.js
@@ -59,6 +59,7 @@ import {
 
 const state = {
   activeTab: "recommend",
+  activeMode: "",
   online: false,
   recommendations: [],
   loadingMore: false,
@@ -157,6 +158,10 @@ const elements = {
   messagesOverlay: document.getElementById("messagesOverlay"),
   messagesBack: document.getElementById("messagesBack"),
   messagesList: document.getElementById("messagesList"),
+  modeDefault: document.getElementById("modeDefault"),
+  modeExplore: document.getElementById("modeExplore"),
+  modeProfessional: document.getElementById("modeProfessional"),
+  modeCasual: document.getElementById("modeCasual"),
 };
 
 let recommendationLoadCheckTimer = null;
@@ -3301,7 +3306,7 @@ async function loadMoreRecommendations() {
   state.loadingMore = true;
   setHint("再给你往下捞 10 条。", "info");
   try {
-    const result = await appendRecommendations(getDisplayedRecommendationBvids());
+    const result = await appendRecommendations(getDisplayedRecommendationBvids(), state.activeMode);
     const incoming = Array.isArray(result.items) ? result.items : [];
     const existing = new Set(getDisplayedRecommendationBvids());
     const appended = incoming.filter((item) => {
@@ -3669,7 +3674,7 @@ async function initializeRecommendations() {
 async function handleManualRefresh() {
   setRefreshButtonState(true, "正在给你换一批…");
   try {
-    const result = await reshuffleRecommendations();
+    const result = await reshuffleRecommendations(state.activeMode);
     if (!Array.isArray(result.items)) {
       setHint("先执行 openbiliclaw init，再回来刷新。", "error");
       return;
@@ -3738,6 +3743,38 @@ function bindRefreshButton() {
   elements.refreshRecommendationsButton.addEventListener("click", () => {
     void handleManualRefresh();
   });
+}
+
+function setActiveMode(mode) {
+  state.activeMode = mode;
+  const buttons = [
+    elements.modeDefault,
+    elements.modeExplore,
+    elements.modeProfessional,
+    elements.modeCasual,
+  ];
+  for (const btn of buttons) {
+    if (!(btn instanceof HTMLButtonElement)) continue;
+    btn.classList.toggle("is-active", btn.dataset.mode === mode);
+  }
+}
+
+function bindModeButtons() {
+  const buttons = [
+    elements.modeDefault,
+    elements.modeExplore,
+    elements.modeProfessional,
+    elements.modeCasual,
+  ];
+  for (const btn of buttons) {
+    if (!(btn instanceof HTMLButtonElement)) continue;
+    btn.addEventListener("click", () => {
+      const mode = btn.dataset.mode || "";
+      if (mode === state.activeMode) return;
+      setActiveMode(mode);
+      void handleManualRefresh();
+    });
+  }
 }
 
 function bindActivityToggle() {
@@ -4495,6 +4532,7 @@ async function initializePopup() {
   bindTabs();
   bindProfileHistoryLoading();
   bindRefreshButton();
+  bindModeButtons();
   bindActivityToggle();
   bindChat();
   bindSettings();

--- a/src/openbiliclaw/api/app.py
+++ b/src/openbiliclaw/api/app.py
@@ -60,6 +60,7 @@ from openbiliclaw.api.models import (
     RecommendationListResponse,
     RecommendationOut,
     RecommendationRefreshResponse,
+    RecommendationReshuffleIn,
     RecommendationReshuffleResponse,
     RuntimeStatusResponse,
     SchedulerConfigOut,
@@ -1379,14 +1380,18 @@ def create_app(
             asyncio.create_task(trigger())
 
     @app.post("/api/recommendations/reshuffle", response_model=RecommendationReshuffleResponse)
-    async def reshuffle_recommendations() -> RecommendationReshuffleResponse:
+    async def reshuffle_recommendations(
+        payload: RecommendationReshuffleIn = RecommendationReshuffleIn(),
+    ) -> RecommendationReshuffleResponse:
         if ctx.recommendation_engine is None or ctx.soul_engine is None:
             return RecommendationReshuffleResponse(items=[])
         try:
             profile = await ctx.soul_engine.get_profile()
         except Exception:
             return RecommendationReshuffleResponse(items=[])
-        items = await ctx.recommendation_engine.reshuffle_recommendations(profile=profile, limit=10)
+        items = await ctx.recommendation_engine.reshuffle_recommendations(
+            profile=profile, limit=10, mode=payload.mode,
+        )
         await _trigger_replenishment_if_needed()
         return RecommendationReshuffleResponse(items=_serialize_recommendation_items(items))
 
@@ -1404,6 +1409,7 @@ def create_app(
             profile=profile,
             excluded_bvids=payload.excluded_bvids,
             limit=10,
+            mode=payload.mode,
         )
         await _trigger_replenishment_if_needed()
         return RecommendationReshuffleResponse(items=_serialize_recommendation_items(items))

--- a/src/openbiliclaw/api/models.py
+++ b/src/openbiliclaw/api/models.py
@@ -60,6 +60,12 @@ class RecommendationListResponse(BaseModel):
     items: list[RecommendationOut]
 
 
+class RecommendationReshuffleIn(BaseModel):
+    """Request payload for reshuffling recommendations with optional mode."""
+
+    mode: str = ""
+
+
 class RecommendationReshuffleResponse(BaseModel):
     """Immediate recommendation reshuffle result."""
 
@@ -70,6 +76,7 @@ class RecommendationAppendIn(BaseModel):
     """Request payload for appending another recommendation page."""
 
     excluded_bvids: list[str] = Field(default_factory=list)
+    mode: str = ""
 
 
 class RecommendationRefreshResponse(BaseModel):

--- a/src/openbiliclaw/recommendation/engine.py
+++ b/src/openbiliclaw/recommendation/engine.py
@@ -212,6 +212,7 @@ class RecommendationEngine:
         limit: int = 5,
         excluded_bvids: frozenset[str] = frozenset(),
         expression_mode: Literal["realtime", "precomputed"] = "precomputed",
+        mode: str = "",
     ) -> list[Recommendation]:
         """Unified recommendation entry point — always picks from the pool.
 
@@ -226,6 +227,9 @@ class RecommendationEngine:
             expression_mode: ``"precomputed"`` uses pool-cached copy (fast),
                 ``"realtime"`` generates fresh expressions via LLM (slow but
                 higher quality).
+            mode: Optional recommendation mode — ``"explore"`` for filter-bubble
+                breaking content, ``"professional"`` for tech/programming content,
+                ``"casual"`` for gaming/entertainment content.
 
         Returns:
             List of personalized recommendations.
@@ -294,6 +298,12 @@ class RecommendationEngine:
         if self._curator is not None:
             context = self._curator.build_context()
             score_override = self._curator.score_candidates(candidates, context)
+
+        # Apply mode-based score boost before diversity selection.
+        if mode and candidates:
+            score_override = self._apply_mode_boost(
+                candidates, mode, score_override,
+            )
 
         # v0.3.44+: pre-fetch embeddings for MMR-based diversification.
         # In v0.3.45+ discovery and classify_pool_backlog warm these into
@@ -1296,12 +1306,13 @@ class RecommendationEngine:
         *,
         profile: SoulProfile,
         limit: int = 5,
+        mode: str = "",
     ) -> list[Recommendation]:
         """Instantly pick a new batch from the discovery pool.
 
         Delegates to :meth:`serve` with ``expression_mode="precomputed"``.
         """
-        return await self.serve(profile, limit=limit, expression_mode="precomputed")
+        return await self.serve(profile, limit=limit, expression_mode="precomputed", mode=mode)
 
     async def append_recommendations(
         self,
@@ -1309,6 +1320,7 @@ class RecommendationEngine:
         profile: SoulProfile,
         excluded_bvids: list[str],
         limit: int = 10,
+        mode: str = "",
     ) -> list[Recommendation]:
         """Append another page of recommendations from the discovery pool.
 
@@ -1320,6 +1332,7 @@ class RecommendationEngine:
             limit=limit,
             excluded_bvids=excluded,
             expression_mode="precomputed",
+            mode=mode,
         )
 
     async def generate_personal_topic(
@@ -1466,6 +1479,49 @@ class RecommendationEngine:
     def get_recommendation(self, recommendation_id: int) -> dict[str, object] | None:
         """Load a recommendation row for CLI or feedback workflows."""
         return self._database.get_recommendation_by_id(recommendation_id)
+
+    # Mode boost keywords — lightweight topic_group matching for the three
+    # content-mode buttons in the popup. The keywords are intentionally broad
+    # (substring match on topic_group) to catch LLM-generated topic labels
+    # that may vary in phrasing.
+    _PROFESSIONAL_KEYWORDS: tuple[str, ...] = (
+        "编程", "程序", "代码", "开发", "软件", "计算机", "算法", "架构",
+        "技术", "人工智能", "机器学习", "前端", "后端", "开源", "程序员",
+        "Python", "Java", "Go", "Rust", "C++", "Linux", "IT",
+    )
+    _CASUAL_KEYWORDS: tuple[str, ...] = (
+        "游戏", "电竞", "主机", "手游", "Switch", "Steam", "PS5",
+        "娱乐", "搞笑", "休闲", "番剧", "动漫", "动画", "漫画",
+        "音乐", "电影", "综艺", "吃播", "美食", "旅行",
+    )
+
+    @staticmethod
+    def _apply_mode_boost(
+        candidates: list[DiscoveredContent],
+        mode: str,
+        score_override: dict[str, float] | None,
+    ) -> dict[str, float]:
+        """Apply a mode-based score boost to candidates.
+
+        Returns a score_override dict (or a new one) with adjusted scores.
+        """
+        BOOST = 0.25
+        overrides: dict[str, float] = dict(score_override) if score_override else {}
+        for c in candidates:
+            key = c.bvid
+            base = overrides.get(key, c.relevance_score)
+            if mode == "explore":
+                if c.source_strategy == "explore":
+                    overrides[key] = min(base + BOOST, 1.0)
+            elif mode == "professional":
+                tg = (c.topic_group or "").lower()
+                if any(kw.lower() in tg for kw in RecommendationEngine._PROFESSIONAL_KEYWORDS):
+                    overrides[key] = min(base + BOOST, 1.0)
+            elif mode == "casual":
+                tg = (c.topic_group or "").lower()
+                if any(kw.lower() in tg for kw in RecommendationEngine._CASUAL_KEYWORDS):
+                    overrides[key] = min(base + BOOST, 1.0)
+        return overrides
 
     @staticmethod
     def _ranking_key(item: DiscoveredContent) -> tuple[int, float, float, int, str]:

--- a/tests/test_api_app.py
+++ b/tests/test_api_app.py
@@ -1521,6 +1521,7 @@ class TestBackendAPI:
                 *,
                 profile: object,
                 limit: int = 10,
+                mode: str = "",
             ) -> list[object]:
                 assert profile == {"profile": "ok"}
                 assert limit == 10
@@ -1581,7 +1582,7 @@ class TestBackendAPI:
 
         class FakeRecommendationEngine:
             def __init__(self) -> None:
-                self.calls: list[tuple[object, list[str], int]] = []
+                self.calls: list[tuple[object, list[str], int, str]] = []
 
             async def append_recommendations(
                 self,
@@ -1589,8 +1590,9 @@ class TestBackendAPI:
                 profile: object,
                 excluded_bvids: list[str],
                 limit: int = 10,
+                mode: str = "",
             ) -> list[object]:
-                self.calls.append((profile, excluded_bvids, limit))
+                self.calls.append((profile, excluded_bvids, limit, mode))
                 from openbiliclaw.discovery.engine import DiscoveredContent
                 from openbiliclaw.recommendation.engine import Recommendation
 
@@ -1625,7 +1627,7 @@ class TestBackendAPI:
         )
 
         assert response.status_code == 200
-        assert recommendation_engine.calls == [({"profile": "ok"}, ["BV1A", "BV1B"], 10)]
+        assert recommendation_engine.calls == [({"profile": "ok"}, ["BV1A", "BV1B"], 10, "")]
         assert response.json() == {
             "items": [
                 {


### PR DESCRIPTION
…专业和休闲知识

在弹出窗口中添加三个推荐模式按钮（打破信息茧房、专业知识、休闲知识），根据内容模式重新排列候选池。后端在 reshuffle/append 接口上接受 `mode` 参数，并对匹配的候选项应用分数加成（探索滤泡策略，专业/休闲的 topic_group 关键词匹配）。所有 107 个 API 测试均通过。由deepseek完成，由于测试有限排版上不一定在任何情况下完全正确