### PR TITLE
feat: unify dislike filtering across all platforms + recall-LLM pool purge

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,6 +10,7 @@
 - 移动 Web 惊喜推荐的「聊一聊」不再切到对话 tab，而是在当前惊喜卡片内展开 16px textarea composer，提交后就地显示用户气泡、AI thinking、完成回复或失败提示。
 - 移动 Web 和插件的惊喜推荐内聊统一走 durable `/api/chat/turns`，按 `scope=delight` + `subject_id` 归并历史；pending turn 会轮询恢复，reload 后可重新 hydrate。
 - 插件惊喜推荐卡片从单个 `chat_reply` 升级为 per-delight `turns` 多轮气泡，`chat_reply` 仅保留为兼容 last reply；切换候选和 side panel reload 不再覆盖旧回合。
+- Discovery / recommendation 的批量内容评估统一透传近期 negative exemplars：B 站、抖音、YouTube 策略和 OpenClaw bootstrap 都会把共享 database 传给内部 evaluator；推荐层的未分类池子补评估也会带上 `negative_examples`，让短期话术避让与长期 `disliked_topics` 一起生效。
 - 补充移动端回归测试，锁定 delight inline chat 复用 `session=popup` 契约、`chatted` 状态继续保留「聊一聊」入口，同时 viewed/liked/rejected 等永久处理态不泄漏通用动作按钮。
 
 ## v0.3.89 / extension v0.3.43: 显式 fallback 与限流降噪发布（2026-05-22）

--- a/docs/modules/discovery.md
+++ b/docs/modules/discovery.md
@@ -595,6 +595,7 @@ engine.register_strategy(
     SearchStrategy(
         llm_service=service,
         bilibili_client=bilibili_client,
+        database=db,
     )
 )
 
@@ -617,6 +618,7 @@ assert 0.0 <= score <= 1.0
 - batch 评估结果解析会优先选择包含 `score` 的结果数组或 object 序列；如果 provider 回显输入 JSON、包 Markdown fence、或返回 NDJSON，仍按一次 batch 处理，不再拆成 N 次单条评估
 - batch prompt 和响应都带 `bvid/content_id`；只要响应里有可识别 ID，引擎会按 ID 而不是数组下标写回评分和理由。没有 ID 且结果数量不完整时会回退到单条评估，避免 LLM 漏项导致后续候选整体错位
 - 如果 batch 调用失败被识别为 LLM provider 限流或 cooldown，本轮不会再触发逐条 fallback；这些候选按 0 分处理，下一轮 refresh 在 provider 恢复后重新发现 / 评估
+- `SearchStrategy` / `TrendingStrategy` / `RelatedChainStrategy` / `ExploreStrategy`、YouTube 三策略和 `DouyinDirectStrategy` 在内部临时构造 evaluator 时都会透传 `database`。因此 CLI、daemon runtime、YouTube producer、Douyin producer 和 OpenClaw bootstrap 路径都能读取同一份近期 negative exemplars，避免只有外层 engine 能看到短期负反馈样本。
 - 排序口径优先 `candidate_tier`，再看 `relevance_score`、`last_scored_at`、`view_count`
 - 最终结果会把 `relevance_score`、`relevance_reason`、`candidate_tier` 一并写入 `content_cache`
 
@@ -645,6 +647,7 @@ async with DouyinDirectClient(cookie=cookie) as direct_client:
     service = DouyinDiscoveryService(
         client=client,
         discovery_engine=engine,  # 传入时会注册 douyin_direct 并写 content_cache
+        database=database,        # 可选；未传时会从 discovery_engine._database 兜底
     )
     result = await service.discover(
         profile,

--- a/docs/modules/integrations.md
+++ b/docs/modules/integrations.md
@@ -21,7 +21,7 @@
 
 | 任务 | 状态 | 说明 |
 |------|------|------|
-| OpenClaw bootstrap | ✅ | 新增 `build_openclaw_adapter_services()`，复用现有 API bootstrap 的依赖装配顺序；direct controller 会接入同一份 scheduler pause gate、独立 `PresenceTracker` 和 config-backed LLM module overrides |
+| OpenClaw bootstrap | ✅ | 新增 `build_openclaw_adapter_services()`，复用现有 API bootstrap 的依赖装配顺序；B 站四个 discovery strategy 共用 adapter database，保证内部 evaluator 能读取近期 negative exemplars；direct controller 会接入同一份 scheduler pause gate、独立 `PresenceTracker` 和 config-backed LLM module overrides |
 | OpenClaw adapter operations | ✅ | 已提供 `sync_account / get_profile / recommend / submit_feedback / get_runtime_status` |
 | OpenClaw skill descriptors | ✅ | 已提供协议中立的 skill descriptor 列表与 async handler |
 | OpenClaw CLI bridge | ✅ | 已提供 `python -m openbiliclaw.integrations.openclaw.cli`，输出稳定 JSON |

--- a/docs/modules/recommendation.md
+++ b/docs/modules/recommendation.md
@@ -34,7 +34,7 @@
 | M123 上游来源配额补货 | ✅ | discovery pool 低于目标值时，runtime 会先补足来源缺口，减少推荐层长期面对“explore 过满、trending 过少”的偏池子 |
 | M124 generate 路径丰富度修正 | ✅ | `generate_recommendations()` 现在也会先对缓存候选做来源均衡，再分阶段放宽 `topic/style/source` 约束，避免高分 `related_chain` 长时间吃掉整批名额 |
 | M125 pool 预生成推荐文案 | ✅ | discovery pool 现在会异步批量预生成 `expression/topic_label`，`reshuffle/append` 只消费预生成结果，缺失时返回空而不是写统一兜底 |
-| M126 源无关内容分类 | ✅ | `classify_pool_backlog()` 在 `precompute_pool_copy` 前自动为未分类内容（XHS 等）补上 `style_key` / `topic_group` / `relevance_score`。COALESCE 保护已分类字段不被重复入库覆盖。`_diversity_tokens` 不再 fallback `source_strategy`——推荐层只看内容特征，来源完全透明 |
+| M126 源无关内容分类 | ✅ | `classify_pool_backlog()` 在 `precompute_pool_copy` 前自动为未分类内容（XHS 等）补上 `style_key` / `topic_group` / `relevance_score`，并在批量评估 prompt 中带上近期 `negative_examples`，让小红书等延迟入池内容也能避开用户刚刚明确不喜欢的话术模式。COALESCE 保护已分类字段不被重复入库覆盖。`_diversity_tokens` 不再 fallback `source_strategy`——推荐层只看内容特征，来源完全透明 |
 | M127 兴趣探针用户确认 | ✅ | WebSocket 推送 `interest.probe` → Chrome 通知 → popup 卡片（是 / 不是 / 多聊聊）→ `POST /api/interest-probes/respond` → speculator confirm/reject/chat。4h 去重冷却。推送从 `_run_refresh_plan` 移到 `run_forever` 主循环 |
 | M128 CLI delight + probe | ✅ | `openbiliclaw delight` 手动查看惊喜推荐候选；`openbiliclaw probe` 手动列出猜测方向并交互确认/拒绝 |
 | M129 惊喜候选自动预热与回填 | ✅ | delight 运行时统一使用共享阈值（默认 `0.70`，保守用户 `0.80`）；后台启动会自动补齐高分但缺 `reason/hook` 的候选，`suppressed` 高分库存也允许作为惊喜推荐入口 |
@@ -337,6 +337,8 @@ report: PoolHealthReport = curator.check_pool_health()
 
 如果候选内容明显命中 `disliked_topics`，prompt 不允许把该避雷项包装成“你一直喜欢这个”。表达层最多保守说明它与已知雷点的差异化理由，避免在已经被用户明确排斥的方向上热情背书。
 
+`classify_pool_backlog()` 对延迟入池、尚未分类的内容做 batch 评估时，也会从事件层读取近期 negative exemplars 并作为 `negative_examples` 传给同一个 evaluator prompt。这补齐了小红书 / 抖音 / YouTube 等非 B 站池子项的短期话术避让：`negative_examples` 处理最近刚出现的标题党、课程钓贴等模式，`disliked_topics` 继续处理长期稳定避雷项。
+
 ### 第四层影响：反馈回流到下一轮推荐
 
 当用户对推荐点 `like` / `dislike` / `comment` 时，会同时发生几件事：
@@ -376,3 +378,4 @@ report: PoolHealthReport = curator.check_pool_health()
 16. **10 条一批必须加来源硬上限**：批量变大后，单靠 topic/style 还不够；现在 `reshuffle` 会同时控制 `source`，避免整批重新被 `explore` 或 `related_chain` 吞掉
 17. **来源补齐优先于风格重复**：如果 `trending` 还没出场，就不该因为它和 `search` 同属 `light_chat` 而被挡在批次外；先让不同来源进来，再做风格均摊
 18. **下游挑得再花，也救不了偏掉的池子**：推荐层的多样性约束只能做第二道保险；真正想让一批内容更丰富，必须让 runtime 在补货时先把各来源补到合理区间
+19. **延迟分类也要消费负反馈样本**：非 B 站内容可能先进入池子、稍后才由推荐层补 `style_key/topic_group/relevance_score`；这条补评估路径必须和 discovery batch evaluator 一样读取 `negative_examples`，否则用户刚刚不喜欢的话术模式会在跨源内容里重新漏进来

--- a/docs/modules/soul.md
+++ b/docs/modules/soul.md
@@ -30,7 +30,7 @@
 | SoulEngine module overrides | ✅ | 构造时可接收 `module_overrides` 并注入内部 `LLMService`，确保 preference / awareness / insight / profile_builder / speculator / dialogue_insight 都遵循 `[llm.soul]` 路由 |
 | PreferenceAnalyzer | ✅ | LLM structured extraction + 合并 + 衰减；v0.3.x `satisfaction_filter_enabled=True` 默认开启，构 prompt 前会丢掉 `quick_exit` 等被动 negative 事件，保留 positive + neutral + unknown / NULL；显式 `dislike` / `thumbs_down` 负反馈会保留为 disliked_topics / 风格避让证据；偏好分析调用前有 prompt 预算保护，超长 chunk 会递归二分，单条超长事件会 compact，`n_keep >= n_ctx` / `context length` 等上下文错误会用更小 chunk 重试 |
 | filter_events_by_satisfaction | ✅ | `soul/event_filters.py` 中的纯函数，按 `inferred_satisfaction` 过滤事件，`"unknown"` 同时匹配缺失 / `None`，使 pre-migration 老行可被显式 opt-in 保留 |
-| recent_negative_exemplars | ✅ | `soul/negative_exemplars.py` 中的纯函数，从事件层拉最近 negative 标题做 recency 加权（半衰期默认 14d）+ 前缀去重 + 80 字截断，最多返回 8 条 `{title, reason, age_days}`。下游消费者是 `discovery/engine.ContentDiscoveryEngine._evaluate_batch`，把列表作为 `negative_examples` 透传给 batch evaluator prompt——这是 [inferred_satisfaction 信号](#) 的第二个消费方（第一个是上面的 `filter_events_by_satisfaction`） |
+| recent_negative_exemplars | ✅ | `soul/negative_exemplars.py` 中的纯函数，从事件层拉最近 negative 标题做 recency 加权（半衰期默认 14d）+ 前缀去重 + 80 字截断，最多返回 8 条 `{title, reason, age_days}`。下游消费者是 `discovery/engine.ContentDiscoveryEngine._evaluate_batch` 和 `recommendation/engine.RecommendationEngine._classify_batch`，二者都会把列表作为 `negative_examples` 透传给 batch evaluator prompt——这是 [inferred_satisfaction 信号](#) 的第二个消费方（第一个是上面的 `filter_events_by_satisfaction`） |
 | SocraticDialogue.respond() | ✅ | 通过 LLMService 调用 LLM，自动注入画像 |
 | ProfileBuilder | ✅ | 结构化 prompt + JSON 校验 + `OnionProfile` 构建 |
 | SoulEngine.build_initial_profile() | ✅ | 从 history + preference 生成并持久化 `soul.json` |

--- a/src/openbiliclaw/api/runtime_context.py
+++ b/src/openbiliclaw/api/runtime_context.py
@@ -37,6 +37,7 @@ if TYPE_CHECKING:
     from fastapi import FastAPI
 
     from openbiliclaw.config import Config
+    from openbiliclaw.storage.database import Database
 
 logger = logging.getLogger(__name__)
 
@@ -52,6 +53,7 @@ def build_youtube_discovery_strategies(
     llm_service: Any,
     memory: Any,
     concurrency: Any,
+    database: Database | None = None,
     strategy_unit_budget: dict[str, int] | None = None,
 ) -> list[Any]:
     """Build YouTube discovery strategies from `[sources.youtube]` config."""
@@ -72,12 +74,14 @@ def build_youtube_discovery_strategies(
             client=client,
             llm_service=llm_service,
             concurrency=concurrency,
+            database=database,
             queries_per_run=max(0, search_budget),
         ),
         YoutubeTrendingStrategy(
             client=client,
             llm_service=llm_service,
             concurrency=concurrency,
+            database=database,
             fetch_limit=max(0, trending_budget),
         ),
         YoutubeChannelStrategy(
@@ -85,6 +89,7 @@ def build_youtube_discovery_strategies(
             llm_service=llm_service,
             memory=memory,
             concurrency=concurrency,
+            database=database,
             max_channels=max(0, channel_budget),
         ),
     ]
@@ -160,6 +165,7 @@ def build_youtube_discovery_producer(
             llm_service=llm_service,
             memory=memory,
             concurrency=concurrency,
+            database=database,
             strategy_unit_budget={strategy: unit_budget},
         )
         selected = [item for item in strategies if item.name == strategy]
@@ -396,11 +402,13 @@ class RuntimeContext:
             llm_service=new_llm_service,
             bilibili_client=new_bilibili_client,
             concurrency=concurrency,
+            database=self.database,
         )
         trending_strategy = TrendingStrategy(
             bilibili_client=new_bilibili_client,
             llm_service=new_llm_service,
             concurrency=concurrency,
+            database=self.database,
         )
         related_strategy = RelatedChainStrategy(
             bilibili_client=new_bilibili_client,
@@ -409,6 +417,7 @@ class RuntimeContext:
             search_strategy=search_strategy,
             trending_strategy=trending_strategy,
             concurrency=concurrency,
+            database=self.database,
         )
         explore_strategy = ExploreStrategy(
             llm_service=new_llm_service,

--- a/src/openbiliclaw/cli.py
+++ b/src/openbiliclaw/cli.py
@@ -544,11 +544,13 @@ def _build_discovery_engine() -> Any:
         llm_service=llm_service,
         bilibili_client=bilibili_client,
         concurrency=concurrency,
+        database=database,
     )
     trending_strategy = TrendingStrategy(
         bilibili_client=bilibili_client,
         llm_service=llm_service,
         concurrency=concurrency,
+        database=database,
     )
     related_strategy = RelatedChainStrategy(
         bilibili_client=bilibili_client,
@@ -557,6 +559,7 @@ def _build_discovery_engine() -> Any:
         search_strategy=search_strategy,
         trending_strategy=trending_strategy,
         concurrency=concurrency,
+        database=database,
     )
     explore_strategy = ExploreStrategy(
         llm_service=llm_service,

--- a/src/openbiliclaw/discovery/douyin.py
+++ b/src/openbiliclaw/discovery/douyin.py
@@ -54,11 +54,13 @@ class DouyinDiscoveryService:
         discovery_engine: Any | None = None,
         llm_service: Any | None = None,
         concurrency: Any | None = None,
+        database: Any | None = None,
     ) -> None:
         self._client = client
         self._discovery_engine = discovery_engine
         self._llm_service = llm_service
         self._concurrency = concurrency
+        self._database = database
 
     async def discover(
         self,
@@ -94,14 +96,17 @@ class DouyinDiscoveryService:
     def _build_strategy(self, opts: DouyinDiscoveryOptions) -> DouyinDirectStrategy:
         llm_service = self._llm_service
         concurrency = self._concurrency
+        database = self._database
         if self._discovery_engine is not None:
             llm_service = llm_service or getattr(self._discovery_engine, "_llm_service", None)
             concurrency = concurrency or getattr(self._discovery_engine, "_concurrency", None)
+            database = database or getattr(self._discovery_engine, "_database", None)
 
         return DouyinDirectStrategy(
             client=self._client,
             llm_service=llm_service,
             concurrency=concurrency,
+            database=database,
             sources=opts.sources,
             seed_keywords=opts.keywords,
             creator_sec_uids=opts.creator_sec_uids,

--- a/src/openbiliclaw/discovery/strategies/douyin_direct.py
+++ b/src/openbiliclaw/discovery/strategies/douyin_direct.py
@@ -18,6 +18,7 @@ from openbiliclaw.sources.douyin_direct import normalize_aweme_item
 
 if TYPE_CHECKING:
     from openbiliclaw.soul.profile import SoulProfile
+    from openbiliclaw.storage.database import Database
 
 logger = logging.getLogger(__name__)
 
@@ -43,6 +44,7 @@ class DouyinDirectStrategy(DiscoveryStrategy):
     client: SupportsDouyinDirectClient
     llm_service: SupportsStructuredTask | None = None
     concurrency: DiscoveryConcurrencyController | None = None
+    database: Database | None = None
     sources: tuple[str, ...] = ("search", "hot", "feed")
     seed_keywords: tuple[str, ...] = ()
     creator_sec_uids: tuple[str, ...] = ()
@@ -110,6 +112,7 @@ class DouyinDirectStrategy(DiscoveryStrategy):
 
         evaluator = ContentDiscoveryEngine(
             llm_service=self.llm_service,
+            database=self.database,
             concurrency=self.concurrency,
         )
         eval_candidates = trim_candidates_for_llm(

--- a/src/openbiliclaw/discovery/strategies/explore.py
+++ b/src/openbiliclaw/discovery/strategies/explore.py
@@ -7,7 +7,7 @@ import json
 import logging
 import re
 from dataclasses import dataclass, field, replace
-from typing import TYPE_CHECKING, Protocol
+from typing import TYPE_CHECKING, Protocol, cast
 
 from openbiliclaw.discovery.engine import (
     ContentDiscoveryEngine,
@@ -29,6 +29,7 @@ from openbiliclaw.llm.prompts import build_explore_domains_prompt
 if TYPE_CHECKING:
     from openbiliclaw.llm.embedding import SupportsEmbeddingService
     from openbiliclaw.soul.profile import SoulProfile
+    from openbiliclaw.storage.database import Database
 
 
 # Minimal contract — explore only needs the topic-group-coverage query
@@ -110,6 +111,7 @@ class ExploreStrategy(DiscoveryStrategy):
 
         evaluator = ContentDiscoveryEngine(
             llm_service=self.llm_service,
+            database=cast("Database | None", self.database),
             concurrency=self.concurrency,
         )
         search_strategy = SearchStrategy(

--- a/src/openbiliclaw/discovery/strategies/related_chain.py
+++ b/src/openbiliclaw/discovery/strategies/related_chain.py
@@ -28,6 +28,7 @@ from openbiliclaw.discovery.strategies._utils import (
 
 if TYPE_CHECKING:
     from openbiliclaw.soul.profile import SoulProfile
+    from openbiliclaw.storage.database import Database
 
 logger = logging.getLogger(__name__)
 
@@ -42,6 +43,7 @@ class RelatedChainStrategy(DiscoveryStrategy):
     search_strategy: SupportsSeedStrategy | None = None
     trending_strategy: SupportsSeedStrategy | None = None
     concurrency: DiscoveryConcurrencyController | None = None
+    database: Database | None = None
     score_threshold: float = 0.70
     max_seeds: int = 5
     related_per_seed: int = 8
@@ -82,6 +84,7 @@ class RelatedChainStrategy(DiscoveryStrategy):
         """
         evaluator = ContentDiscoveryEngine(
             llm_service=self.llm_service,
+            database=self.database,
             concurrency=self.concurrency,
         )
         seed_descriptors = await self._select_seed_descriptors(profile)

--- a/src/openbiliclaw/discovery/strategies/search.py
+++ b/src/openbiliclaw/discovery/strategies/search.py
@@ -30,6 +30,7 @@ from openbiliclaw.llm.prompts import build_search_queries_prompt
 
 if TYPE_CHECKING:
     from openbiliclaw.soul.profile import SoulProfile
+    from openbiliclaw.storage.database import Database
 
 logger = logging.getLogger(__name__)
 
@@ -41,6 +42,7 @@ class SearchStrategy(DiscoveryStrategy):
     llm_service: SupportsStructuredTask
     bilibili_client: SupportsSearchClient
     concurrency: DiscoveryConcurrencyController | None = None
+    database: Database | None = None
     queries_per_run: int = 8
     page_size: int = 10
     max_pages: int = 1
@@ -165,6 +167,7 @@ class SearchStrategy(DiscoveryStrategy):
 
         evaluator = ContentDiscoveryEngine(
             llm_service=self.llm_service,
+            database=self.database,
             concurrency=self.concurrency,
         )
         eval_candidates = self._interleave_query_candidates(candidates_by_query)

--- a/src/openbiliclaw/discovery/strategies/trending.py
+++ b/src/openbiliclaw/discovery/strategies/trending.py
@@ -27,6 +27,7 @@ from openbiliclaw.discovery.strategies._utils import (
 
 if TYPE_CHECKING:
     from openbiliclaw.soul.profile import SoulProfile
+    from openbiliclaw.storage.database import Database
 
 logger = logging.getLogger(__name__)
 
@@ -38,6 +39,7 @@ class TrendingStrategy(DiscoveryStrategy):
     bilibili_client: SupportsRankingClient
     llm_service: SupportsStructuredTask
     concurrency: DiscoveryConcurrencyController | None = None
+    database: Database | None = None
     score_threshold: float = 0.70
     max_related_rids: int = 4
     # Broader default RIDs covering more top-level categories:
@@ -98,6 +100,7 @@ class TrendingStrategy(DiscoveryStrategy):
         """
         evaluator = ContentDiscoveryEngine(
             llm_service=self.llm_service,
+            database=self.database,
             concurrency=self.concurrency,
         )
         rids = await self._select_rids(profile)

--- a/src/openbiliclaw/discovery/strategies/youtube.py
+++ b/src/openbiliclaw/discovery/strategies/youtube.py
@@ -36,6 +36,7 @@ from openbiliclaw.youtube.client import YtScraperClient, normalize_yt_video
 
 if TYPE_CHECKING:
     from openbiliclaw.soul.profile import SoulProfile
+    from openbiliclaw.storage.database import Database
 
 logger = logging.getLogger(__name__)
 
@@ -76,6 +77,7 @@ class YoutubeSearchStrategy(DiscoveryStrategy):
     client: YtScraperClient
     llm_service: SupportsStructuredTask
     concurrency: DiscoveryConcurrencyController | None = None
+    database: Database | None = None
     queries_per_run: int = 6
     results_per_query: int = 15
     score_threshold: float = 0.65
@@ -93,10 +95,7 @@ class YoutubeSearchStrategy(DiscoveryStrategy):
             return []
 
         raw_batches = await asyncio.gather(
-            *[
-                self.client.search_videos(q, limit=self.results_per_query)
-                for q in queries
-            ],
+            *[self.client.search_videos(q, limit=self.results_per_query) for q in queries],
             return_exceptions=True,
         )
 
@@ -157,6 +156,7 @@ class YoutubeSearchStrategy(DiscoveryStrategy):
     ) -> list[DiscoveredContent]:
         evaluator = ContentDiscoveryEngine(
             llm_service=self.llm_service,
+            database=self.database,
             concurrency=self.concurrency,
         )
         trimmed = trim_candidates_for_llm(candidates, limit=limit, source_context=self.name)
@@ -183,6 +183,7 @@ class YoutubeTrendingStrategy(DiscoveryStrategy):
     client: YtScraperClient
     llm_service: SupportsStructuredTask
     concurrency: DiscoveryConcurrencyController | None = None
+    database: Database | None = None
     fetch_limit: int = 50
     score_threshold: float = 0.60
     llm_evaluation: bool = True
@@ -214,6 +215,7 @@ class YoutubeTrendingStrategy(DiscoveryStrategy):
 
         evaluator = ContentDiscoveryEngine(
             llm_service=self.llm_service,
+            database=self.database,
             concurrency=self.concurrency,
         )
         trimmed = trim_candidates_for_llm(candidates, limit=limit, source_context=self.name)
@@ -255,6 +257,7 @@ class YoutubeChannelStrategy(DiscoveryStrategy):
     llm_service: SupportsStructuredTask
     memory: SupportsYtFollowQuery
     concurrency: DiscoveryConcurrencyController | None = None
+    database: Database | None = None
     max_channels: int = 10
     videos_per_channel: int = 5
     score_threshold: float = 0.65
@@ -293,9 +296,7 @@ class YoutubeChannelStrategy(DiscoveryStrategy):
                 seen.add(content.content_id)
                 candidates.append(content)
 
-        logger.info(
-            "yt_channel: %d channels → %d candidates", len(channel_ids), len(candidates)
-        )
+        logger.info("yt_channel: %d channels → %d candidates", len(channel_ids), len(candidates))
         if not candidates:
             return []
 
@@ -304,6 +305,7 @@ class YoutubeChannelStrategy(DiscoveryStrategy):
 
         evaluator = ContentDiscoveryEngine(
             llm_service=self.llm_service,
+            database=self.database,
             concurrency=self.concurrency,
         )
         trimmed = trim_candidates_for_llm(candidates, limit=limit, source_context=self.name)

--- a/src/openbiliclaw/integrations/openclaw/bootstrap.py
+++ b/src/openbiliclaw/integrations/openclaw/bootstrap.py
@@ -113,11 +113,13 @@ def build_openclaw_adapter_services() -> OpenClawAdapterServices:
         llm_service=llm_service,
         bilibili_client=bilibili_client,
         concurrency=concurrency,
+        database=database,
     )
     trending_strategy = TrendingStrategy(
         bilibili_client=bilibili_client,
         llm_service=llm_service,
         concurrency=concurrency,
+        database=database,
     )
     related_strategy = RelatedChainStrategy(
         bilibili_client=bilibili_client,
@@ -126,6 +128,7 @@ def build_openclaw_adapter_services() -> OpenClawAdapterServices:
         search_strategy=search_strategy,
         trending_strategy=trending_strategy,
         concurrency=concurrency,
+        database=database,
     )
     explore_strategy = ExploreStrategy(
         llm_service=llm_service,

--- a/src/openbiliclaw/recommendation/engine.py
+++ b/src/openbiliclaw/recommendation/engine.py
@@ -1008,6 +1008,16 @@ class RecommendationEngine:
             }
             for c in batch
         ]
+        # Fetch recent negative exemplars so Rule 11 pattern-matching
+        # applies equally to non-bilibili pool items (e.g. xiaohongshu).
+        negative_examples: list[dict[str, object]] | None = None
+        try:
+            from openbiliclaw.soul.negative_exemplars import recent_negative_exemplars
+
+            negative_examples = recent_negative_exemplars(self._database) or None
+        except Exception:
+            logger.debug("classify_batch: negative_exemplars unavailable", exc_info=True)
+
         # Determine the dominant platform for prompt context
         platform = (batch[0].source_platform or "bilibili") if batch else "bilibili"
         messages = build_batch_content_evaluation_prompt(
@@ -1015,6 +1025,7 @@ class RecommendationEngine:
             content_items=content_items,
             source_context=batch[0].source_strategy if batch else "",
             source_platform=platform,
+            negative_examples=negative_examples,
         )
 
         response = await self._llm.complete_structured_task(

--- a/src/openbiliclaw/soul/layer_updaters.py
+++ b/src/openbiliclaw/soul/layer_updaters.py
@@ -76,6 +76,7 @@ async def update_layer(
     preference_analyzer: PreferenceAnalyzer,
     profile_builder: ProfileBuilder,
     embedding_service: Any | None = None,
+    llm_service: Any | None = None,
 ) -> LayerUpdateResult:
     """Dispatch to the appropriate layer updater."""
     updater: LayerUpdater | None = _LAYER_UPDATERS.get(layer)
@@ -88,6 +89,7 @@ async def update_layer(
         preference_analyzer=preference_analyzer,
         profile_builder=profile_builder,
         embedding_service=embedding_service,
+        llm_service=llm_service,
     )
 
 
@@ -150,6 +152,7 @@ async def _update_interest(
     memory: MemoryManager,
     preference_analyzer: PreferenceAnalyzer,
     embedding_service: Any | None = None,
+    llm_service: Any | None = None,
     **_: Any,
 ) -> LayerUpdateResult:
     """Update interest layer by delegating to PreferenceAnalyzer."""
@@ -233,25 +236,43 @@ async def _update_interest(
         except Exception:
             logger.exception("Failed to purge pool candidates by new dislikes")
 
-        # Pass 2: embedding-based semantic match. Catches candidates where
-        # the literal word is absent but the topic is semantically close
-        # (e.g. "沙雕视频合集" ~ "鬼畜"). Only runs if an embedding service
-        # was provided to the pipeline.
+        # Pass 2: embedding recall → LLM precision (preferred), or
+        # standalone embedding purge (fallback when LLM unavailable).
         if embedding_service is not None and database is not None:
-            try:
-                from openbiliclaw.soul.pool_purge import (
-                    semantic_purge_pool_by_disliked_topics,
-                )
+            if llm_service is not None:
+                # Full pipeline: low-threshold recall + LLM judge.
+                try:
+                    from openbiliclaw.soul.pool_purge import (
+                        recall_and_llm_purge_pool,
+                    )
 
-                semantic_purged = await semantic_purge_pool_by_disliked_topics(
-                    database=database,
-                    topics=list(newly_added_dislikes),
-                    embedding_service=embedding_service,
-                )
-                if semantic_purged:
-                    changes.append(f"从候选池语义清除 {semantic_purged} 条相关内容")
-            except Exception:
-                logger.exception("Failed to semantic-purge pool candidates")
+                    smart_purged = await recall_and_llm_purge_pool(
+                        database=database,
+                        topics=list(newly_added_dislikes),
+                        all_disliked_topics=list(new_dislikes),
+                        embedding_service=embedding_service,
+                        llm_service=llm_service,
+                    )
+                    if smart_purged:
+                        changes.append(f"从候选池召回+LLM 清除 {smart_purged} 条相关内容")
+                except Exception:
+                    logger.exception("Failed to recall+LLM purge pool candidates")
+            else:
+                # Fallback: high-threshold embedding purge only.
+                try:
+                    from openbiliclaw.soul.pool_purge import (
+                        semantic_purge_pool_by_disliked_topics,
+                    )
+
+                    semantic_purged = await semantic_purge_pool_by_disliked_topics(
+                        database=database,
+                        topics=list(newly_added_dislikes),
+                        embedding_service=embedding_service,
+                    )
+                    if semantic_purged:
+                        changes.append(f"从候选池语义清除 {semantic_purged} 条相关内容")
+                except Exception:
+                    logger.exception("Failed to semantic-purge pool candidates")
 
     # Feed speculative_interests to speculator as seed candidates
     speculative_seeds = updated_preference.get("speculative_interests")

--- a/src/openbiliclaw/soul/pipeline.py
+++ b/src/openbiliclaw/soul/pipeline.py
@@ -748,6 +748,7 @@ class ProfileUpdatePipeline:
                 preference_analyzer=self._preference_analyzer,
                 profile_builder=self._profile_builder,
                 embedding_service=self._embedding_service,
+                llm_service=getattr(self._preference_analyzer, "registry", None),
             )
         except Exception:
             logger.exception("Failed to update layer %s", layer.value)

--- a/src/openbiliclaw/soul/pool_purge.py
+++ b/src/openbiliclaw/soul/pool_purge.py
@@ -1,17 +1,21 @@
-"""Semantic pool purge — embedding-based dislike matching.
+"""Pool purge — recall + LLM precision pipeline.
 
-When a new dislike is learned, string matching catches the obvious cases
-(topic_key / title substring). This module provides the second layer:
-embedding-based semantic matching that catches candidates whose title does
-not literally contain the dislike word but is semantically close to it.
+When a new dislike is learned, the pool is cleaned in two stages:
 
-Example: user says "不喜欢鬼畜", pool has a video titled "恶搞鬼畜区经典回顾"
-— string match catches this via "鬼畜" substring. But a video titled
-"沙雕视频合集" without the word "鬼畜" would only be caught by semantic match.
+Stage 1 (hard purge): string exact match on topic_key / topic_group /
+    pool_topic_label — high confidence, no LLM needed.
+
+Stage 2 (recall → LLM precision):
+  a) Embedding recall with a **low** threshold (0.55) casts a wide net
+     over all fresh candidates.
+  b) The recalled set is sent to an LLM agent that makes the final
+     purge/keep decision per candidate at the intent/pattern level.
+     (e.g. "不喜欢营销文" → purge "5分钟教你月入过万")
 """
 
 from __future__ import annotations
 
+import json
 import logging
 from typing import TYPE_CHECKING, Protocol
 
@@ -19,18 +23,20 @@ if TYPE_CHECKING:
     from openbiliclaw.storage.database import Database
 
 from openbiliclaw.llm.embedding import cosine_similarity
+from openbiliclaw.llm.json_utils import extract_llm_json_object
 
 logger = logging.getLogger(__name__)
 
-# Default semantic similarity threshold for purging. Deliberately higher than
-# the embedding service's default `similarity_threshold` (0.82) so we only
-# purge on strong semantic matches, not weak ones — false positives here
-# directly hurt recommendation recall.
-DEFAULT_SEMANTIC_PURGE_THRESHOLD = 0.78
+# Recall threshold — deliberately low to maximize recall. False positives
+# are filtered out by the LLM precision pass. If no LLM is available,
+# the old high threshold (0.78) is used as a standalone fallback.
+RECALL_THRESHOLD = 0.55
+STANDALONE_PURGE_THRESHOLD = 0.78
+# Backward compat alias for tests.
+DEFAULT_SEMANTIC_PURGE_THRESHOLD = STANDALONE_PURGE_THRESHOLD
 
-# Max candidates to scan per purge pass. Prevents unbounded embedding calls
-# when the pool is very large.
-DEFAULT_SCAN_LIMIT = 200
+# Max candidates to scan per embedding recall pass.
+DEFAULT_SCAN_LIMIT = 500
 
 
 class _SupportsEmbed(Protocol):
@@ -41,46 +47,47 @@ class _SupportsEmbed(Protocol):
     async def embed(self, text: str) -> list[float]: ...
 
 
-async def semantic_purge_pool_by_disliked_topics(
+class _SupportsLLMTask(Protocol):
+    async def complete_structured_task(
+        self,
+        *,
+        system_instruction: str,
+        user_input: str,
+        temperature: float = ...,
+        max_tokens: int = ...,
+        caller: str = ...,
+        reasoning_effort: str | None = ...,
+    ) -> object: ...
+
+
+def _candidate_text(cand: dict[str, object]) -> str:
+    """Build the text to embed for a candidate."""
+    parts: list[str] = []
+    for field in ("title", "topic_key", "topic_group", "pool_topic_label"):
+        value = str(cand.get(field) or "").strip()
+        if value:
+            parts.append(value)
+    return " ".join(parts)
+
+
+# ---------------------------------------------------------------------------
+# Embedding recall
+# ---------------------------------------------------------------------------
+
+
+async def _embedding_recall(
     *,
-    database: Database,
+    candidates: list[dict[str, object]],
     topics: list[str],
     embedding_service: _SupportsEmbed,
-    threshold: float | None = None,
-    scan_limit: int = DEFAULT_SCAN_LIMIT,
-) -> int:
-    """Purge pool candidates whose title/topic is semantically close to a dislike.
+    threshold: float,
+) -> list[tuple[dict[str, object], float, str]]:
+    """Return candidates whose embedding similarity exceeds *threshold*.
 
-    Pipeline:
-      1. Fetch fresh, not-yet-recommended pool candidates (bounded by scan_limit)
-      2. Compute embeddings for each new dislike topic (cached after first call)
-      3. For each candidate, embed ``title`` and ``topic_key`` (also cached)
-      4. If max(similarity_to_any_dislike) >= threshold, mark for purge
-      5. Bulk-update the marked bvids to ``pool_status = 'purged_by_dislike'``
-
-    Silent no-op if any of: topics empty, embedding_service missing, or
-    any embedding call returns empty.
-
-    Returns:
-        Number of candidates purged (may be 0 if no semantic matches found).
+    Each result is ``(candidate_row, best_similarity, best_matching_topic)``.
     """
-    clean_topics = [t.strip() for t in topics if t and t.strip()]
-    if not clean_topics or embedding_service is None:
-        return 0
-
-    effective_threshold = (
-        threshold
-        if threshold is not None
-        else DEFAULT_SEMANTIC_PURGE_THRESHOLD
-    )
-
-    candidates = database.get_fresh_pool_candidates_for_purge_scan(limit=scan_limit)
-    if not candidates:
-        return 0
-
-    # 1. Embed dislike topics once
     topic_vectors: list[tuple[str, list[float]]] = []
-    for topic in clean_topics:
+    for topic in topics:
         try:
             vec = await embedding_service.embed(topic)
         except Exception:
@@ -90,28 +97,17 @@ async def semantic_purge_pool_by_disliked_topics(
             topic_vectors.append((topic, vec))
 
     if not topic_vectors:
-        return 0
+        return []
 
-    # 2. Scan candidates
-    bvids_to_purge: list[str] = []
+    recalled: list[tuple[dict[str, object], float, str]] = []
     for cand in candidates:
-        # Build the text we'll embed for this candidate. Prefer the most
-        # information-dense concatenation of title + topic fields.
-        candidate_text_parts: list[str] = []
-        for field in ("title", "topic_key", "topic_group", "pool_topic_label"):
-            value = str(cand.get(field) or "").strip()
-            if value:
-                candidate_text_parts.append(value)
-        if not candidate_text_parts:
+        text = _candidate_text(cand)
+        if not text:
             continue
-        candidate_text = " ".join(candidate_text_parts)
-
         try:
-            cand_vec = await embedding_service.embed(candidate_text)
+            cand_vec = await embedding_service.embed(text)
         except Exception:
-            logger.debug(
-                "Failed to embed candidate %s", cand.get("bvid"), exc_info=True,
-            )
+            logger.debug("Failed to embed candidate %s", cand.get("bvid"), exc_info=True)
             continue
         if not cand_vec:
             continue
@@ -124,15 +120,223 @@ async def semantic_purge_pool_by_disliked_topics(
                 best_sim = sim
                 best_topic = topic
 
-        if best_sim >= effective_threshold:
-            logger.info(
-                "Semantic purge: '%s' (%.2f ~ '%s')",
-                cand.get("title", "")[:40], best_sim, best_topic,
+        if best_sim >= threshold:
+            recalled.append((cand, best_sim, best_topic))
+
+    return recalled
+
+
+# ---------------------------------------------------------------------------
+# LLM precision judge
+# ---------------------------------------------------------------------------
+
+_LLM_PURGE_SYSTEM_PROMPT = """\
+你是内容推荐池的清理 agent。用户新增了一批"不喜欢"标签，\
+下面的候选内容已被初步召回为疑似相关。\
+你需要逐条判断哪些内容**本质上**属于用户讨厌的类型，即使标题里没有直接出现那个词。
+
+判断标准（按优先级）：
+1. **商业意图 / 话术模式**一致：标题党、营销文、带货软文等，即使换了说法也算。
+2. **内容类型 / 氛围**一致：例如用户不喜欢"低质鬼畜"，那"沙雕恶搞合集"也算。
+3. **受众画像**重叠：如果一个内容的典型受众和用户讨厌的内容高度重合，倾向清除。
+
+不要清除的情况：
+- 仅仅是同一大领域但内容风格/深度完全不同（例如用户不喜欢"游戏直播剪辑"，\
+但"游戏设计深度分析"不应被清除）。
+- 标题模糊、信息不足以判断时，保留（宁可漏杀不可误杀）。
+
+输出严格 JSON，不要附带解释：
+{"purge": ["bvid1", "bvid2"], "reason": {"bvid1": "一句话理由", ...}}
+
+如果没有需要清除的，返回 {"purge": [], "reason": {}}"""
+
+_LLM_PURGE_BATCH_SIZE = 30
+
+
+async def _llm_judge(
+    *,
+    recalled: list[tuple[dict[str, object], float, str]],
+    new_topics: list[str],
+    all_topics: list[str],
+    llm_service: _SupportsLLMTask,
+    batch_size: int = _LLM_PURGE_BATCH_SIZE,
+) -> list[str]:
+    """Ask LLM to judge recalled candidates. Returns bvids to purge."""
+    items = [
+        {
+            "bvid": str(cand.get("bvid", "")),
+            "title": str(cand.get("title", "")),
+            "topic_group": str(cand.get("topic_group", "")),
+            "topic_label": str(cand.get("pool_topic_label", "")),
+            "recall_similarity": round(sim, 2),
+            "matched_dislike": matched_topic,
+        }
+        for cand, sim, matched_topic in recalled
+        if str(cand.get("bvid", "")).strip()
+    ]
+    if not items:
+        return []
+
+    bvids_to_purge: list[str] = []
+    for batch_start in range(0, len(items), batch_size):
+        batch = items[batch_start : batch_start + batch_size]
+
+        user_input = json.dumps(
+            {
+                "newly_added_dislikes": new_topics,
+                "all_disliked_topics": all_topics,
+                "candidates": batch,
+            },
+            ensure_ascii=False,
+            indent=2,
+            sort_keys=True,
+        )
+
+        try:
+            response = await llm_service.complete_structured_task(
+                system_instruction=_LLM_PURGE_SYSTEM_PROMPT,
+                user_input=user_input,
+                temperature=0.1,
+                max_tokens=2048,
+                caller="pool_purge.llm_agent",
+                reasoning_effort="",
             )
-            bvid = str(cand.get("bvid", "")).strip()
+        except Exception:
+            logger.debug("LLM purge batch failed", exc_info=True)
+            continue
+
+        raw = str(getattr(response, "content", "")).strip()
+        parsed = extract_llm_json_object(raw)
+        if not isinstance(parsed, dict):
+            logger.debug("LLM purge: unparseable response: %.200s", raw)
+            continue
+
+        purge_list = parsed.get("purge", [])
+        reasons = parsed.get("reason", {})
+        if not isinstance(purge_list, list) or not purge_list:
+            continue
+
+        for bvid_raw in purge_list:
+            bvid = str(bvid_raw).strip()
             if bvid:
+                reason = reasons.get(bvid, "") if isinstance(reasons, dict) else ""
+                logger.info("LLM purge: '%s' — %s", bvid, reason)
                 bvids_to_purge.append(bvid)
 
+    return bvids_to_purge
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+async def semantic_purge_pool_by_disliked_topics(
+    *,
+    database: Database,
+    topics: list[str],
+    embedding_service: _SupportsEmbed,
+    threshold: float | None = None,
+    scan_limit: int = DEFAULT_SCAN_LIMIT,
+) -> int:
+    """Standalone embedding purge (no LLM available).
+
+    Uses the high standalone threshold (0.78) to avoid false positives.
+    Called when ``llm_service`` is not available — the recall+LLM path
+    is preferred when both services are present.
+    """
+    clean_topics = [t.strip() for t in topics if t and t.strip()]
+    if not clean_topics or embedding_service is None:
+        return 0
+
+    effective_threshold = threshold if threshold is not None else STANDALONE_PURGE_THRESHOLD
+
+    candidates = database.get_fresh_pool_candidates_for_purge_scan(limit=scan_limit)
+    if not candidates:
+        return 0
+
+    recalled = await _embedding_recall(
+        candidates=candidates,
+        topics=clean_topics,
+        embedding_service=embedding_service,
+        threshold=effective_threshold,
+    )
+
+    bvids_to_purge = [
+        str(cand.get("bvid", "")).strip()
+        for cand, _sim, _topic in recalled
+        if str(cand.get("bvid", "")).strip()
+    ]
+    for cand, sim, topic in recalled:
+        logger.info(
+            "Semantic purge: '%s' (%.2f ~ '%s')",
+            str(cand.get("title", ""))[:40],
+            sim,
+            topic,
+        )
+
+    if not bvids_to_purge:
+        return 0
+    return database.mark_pool_items_purged_by_dislike(bvids_to_purge)
+
+
+async def recall_and_llm_purge_pool(
+    *,
+    database: Database,
+    topics: list[str],
+    all_disliked_topics: list[str],
+    embedding_service: _SupportsEmbed,
+    llm_service: _SupportsLLMTask,
+    recall_threshold: float = RECALL_THRESHOLD,
+    scan_limit: int = DEFAULT_SCAN_LIMIT,
+) -> int:
+    """Two-stage purge: embedding recall (low threshold) → LLM precision.
+
+    Args:
+        database: Database handle.
+        topics: Newly added dislike topics.
+        all_disliked_topics: Full dislike list for LLM context.
+        embedding_service: Embedding service for recall.
+        llm_service: LLM service for precision judgment.
+        recall_threshold: Similarity threshold for recall (default 0.55).
+        scan_limit: Max candidates for embedding scan.
+
+    Returns:
+        Number of candidates purged.
+    """
+    clean_new = [t.strip() for t in topics if t and t.strip()]
+    clean_all = [t.strip() for t in all_disliked_topics if t and t.strip()]
+    if not clean_new:
+        return 0
+
+    candidates = database.get_fresh_pool_candidates_for_purge_scan(limit=scan_limit)
+    if not candidates:
+        return 0
+
+    # Stage 1: wide embedding recall
+    recalled = await _embedding_recall(
+        candidates=candidates,
+        topics=clean_new,
+        embedding_service=embedding_service,
+        threshold=recall_threshold,
+    )
+    if not recalled:
+        return 0
+
+    logger.info(
+        "Dislike recall: %d/%d candidates above %.2f threshold",
+        len(recalled),
+        len(candidates),
+        recall_threshold,
+    )
+
+    # Stage 2: LLM precision judge
+    bvids_to_purge = await _llm_judge(
+        recalled=recalled,
+        new_topics=clean_new,
+        all_topics=clean_all,
+        llm_service=llm_service,
+    )
     if not bvids_to_purge:
         return 0
 

--- a/tests/test_mobile_web_view_models.py
+++ b/tests/test_mobile_web_view_models.py
@@ -221,7 +221,11 @@ class TestMobileWebViewModels:
             assert.equal(liked.handled, true);
             assert.equal(liked.response_tone, "success");
 
-            const chatted = getDelightUiState({ bvid: "BV1", state: "chatted", delight_score: 0.7 });
+            const chatted = getDelightUiState({
+                bvid: "BV1",
+                state: "chatted",
+                delight_score: 0.7,
+            });
             assert.equal(chatted.handled, false);
             assert.equal(chatted.response_tone, "info");
 

--- a/tests/test_openclaw_adapter.py
+++ b/tests/test_openclaw_adapter.py
@@ -606,6 +606,7 @@ def test_build_openclaw_adapter_services_reuses_shared_database(monkeypatch) -> 
     created_databases: list[object] = []
     created_memories: list[object] = []
     registered_strategies: list[str] = []
+    created_strategy_kwargs: list[dict[str, object]] = []
 
     class FakeDatabase:
         def __init__(self, path: str) -> None:
@@ -675,6 +676,7 @@ def test_build_openclaw_adapter_services_reuses_shared_database(monkeypatch) -> 
             self.args = args
             self.kwargs = kwargs
             self.name = self.__class__.__name__
+            created_strategy_kwargs.append(kwargs)
 
     class FakeRuntimeController:
         def __init__(self, **kwargs) -> None:
@@ -753,6 +755,12 @@ def test_build_openclaw_adapter_services_reuses_shared_database(monkeypatch) -> 
     assert created_memories[0].database is created_databases[0]
     assert services.database is created_databases[0]
     assert services.memory_manager is created_memories[0]
+    assert [kwargs.get("database") for kwargs in created_strategy_kwargs] == [
+        created_databases[0],
+        created_databases[0],
+        created_databases[0],
+        created_databases[0],
+    ]
     assert services.soul_engine.module_overrides["soul"].provider == "claude"
     assert services.soul_engine.kwargs["speculation_interval_minutes"] == 22
     assert services.soul_engine.kwargs["speculation_ttl_days"] == 8


### PR DESCRIPTION
## Summary
- **Propagate negative exemplars to all discovery evaluators**: All platform strategies (B站/YouTube/抖音) now pass `database` to `ContentDiscoveryEngine`, enabling `negative_examples` (Rule 11 pattern matching) alongside `disliked_topics` (Rule 12).
- **Align xiaohongshu pool classification**: `RecommendationEngine._classify_batch` now fetches `negative_examples` for delayed xhs evaluation.
- **Recall + LLM precision pool purge**: Two-stage pipeline — low-threshold embedding recall (0.55) → LLM agent precision judgment. Falls back to standalone embedding purge (0.78) when no LLM available.

## Test plan
- [x] Full test suite passes (1650 passed, 0 failed)
- [ ] Verify negative exemplars in eval logs for YouTube/Douyin strategies
- [ ] Trigger dislike → confirm recall+LLM purge fires
- [ ] Verify fallback when LLM unavailable

🤖 Generated with [Claude Code](https://claude.com/claude-code)