### PR TITLE
fix(llm): enable fallback providers and Gemini embedding dimensions

### DIFF
--- a/src/openbiliclaw/config.py
+++ b/src/openbiliclaw/config.py
@@ -129,6 +129,7 @@ class EmbeddingConfig:
     model: str = "gemini-embedding-001"
     api_key: str = ""
     base_url: str = ""
+    output_dimensionality: int = 0
     similarity_threshold: float = 0.82
     fallback_enabled: bool = False
     fallback_provider: str = ""
@@ -608,6 +609,7 @@ def _build_config(raw: dict[str, Any]) -> Config:
                     "model",
                     "api_key",
                     "base_url",
+                    "output_dimensionality",
                     "similarity_threshold",
                     "fallback_enabled",
                     "fallback_provider",
@@ -1613,6 +1615,7 @@ def _render_config_toml(
             f"model = {_toml_string(config.llm.embedding.model)}",
             f"api_key = {_toml_string(config.llm.embedding.api_key)}",
             f"base_url = {_toml_string(config.llm.embedding.base_url)}",
+            f"output_dimensionality = {config.llm.embedding.output_dimensionality}",
             f"similarity_threshold = {config.llm.embedding.similarity_threshold}",
             f"fallback_enabled = {_toml_bool(config.llm.embedding.fallback_enabled)}",
             f"fallback_provider = {_toml_string(config.llm.embedding.fallback_provider)}",

--- a/src/openbiliclaw/llm/embedding.py
+++ b/src/openbiliclaw/llm/embedding.py
@@ -90,12 +90,18 @@ class EmbeddingCache:
             raise RuntimeError("EmbeddingCache not initialized")
         return self._conn
 
-    def get(self, key: str) -> list[float] | None:
+    def get(self, key: str, model: str = "") -> list[float] | None:
         with self._lock:
-            row = self.conn.execute(
-                "SELECT vector FROM embedding_cache WHERE text_key = ?",
-                (key,),
-            ).fetchone()
+            if model:
+                row = self.conn.execute(
+                    "SELECT vector FROM embedding_cache WHERE text_key = ? AND model = ?",
+                    (key, model),
+                ).fetchone()
+            else:
+                row = self.conn.execute(
+                    "SELECT vector FROM embedding_cache WHERE text_key = ?",
+                    (key,),
+                ).fetchone()
         if row is None:
             return None
         try:
@@ -140,6 +146,7 @@ class EmbeddingService:
         provider: SupportsEmbed,
         *,
         model: str = "gemini-embedding-001",
+        cache_model: str | None = None,
         cache_size: int = 500,
         similarity_threshold: float = 0.82,
         persistent_cache: EmbeddingCache | None = None,
@@ -147,6 +154,7 @@ class EmbeddingService:
     ) -> None:
         self._provider = provider
         self._model = model
+        self._cache_model = cache_model or model
         # OrderedDict + move_to_end on hit gives us proper LRU instead of
         # FIFO. With a 500-key cache and bursty access patterns (delight
         # scoring iterates the same like_texts repeatedly), FIFO would
@@ -184,7 +192,7 @@ class EmbeddingService:
             self._l1_cache.move_to_end(key)
             return cached
         if self._l2_cache is not None:
-            persisted = self._l2_cache.get(key)
+            persisted = self._l2_cache.get(key, model=self._cache_model)
             if persisted is not None:
                 self._l1_cache[key] = persisted
                 return persisted
@@ -237,7 +245,7 @@ class EmbeddingService:
 
         if self._l2_cache is not None:
             try:
-                self._l2_cache.put(key, vector, model=self._model)
+                self._l2_cache.put(key, vector, model=self._cache_model)
             except Exception:
                 logger.debug("L2 cache write failed", exc_info=True)
 

--- a/src/openbiliclaw/llm/gemini_provider.py
+++ b/src/openbiliclaw/llm/gemini_provider.py
@@ -52,15 +52,30 @@ class GeminiProvider(LLMProvider):
     _BASE_RETRY_DELAY = 0.25
 
     def __init__(
-        self, api_key: str, model: str = "gemini-2.5-flash", timeout: float = 300.0
+        self,
+        api_key: str,
+        model: str = "gemini-2.5-flash",
+        timeout: float = 300.0,
+        base_url: str = "",
+        embedding_output_dimensionality: int | None = None,
     ) -> None:
         if not gemini_sdk_available():
             _raise_missing_sdk()
         assert genai is not None
         self._model = model
+        self._embedding_output_dimensionality = (
+            embedding_output_dimensionality
+            if embedding_output_dimensionality is not None and embedding_output_dimensionality > 0
+            else None
+        )
+        # google-genai HttpOptions.timeout is milliseconds, while our
+        # provider/config timeout is expressed in seconds.
+        http_options: dict[str, int | str] = {"timeout": int(timeout * 1000)}
+        if base_url.strip():
+            http_options["base_url"] = base_url.strip().rstrip("/") + "/"
         self._client = genai.Client(
             api_key=api_key,
-            http_options={"timeout": int(timeout)},
+            http_options=http_options,
         )
 
     @staticmethod
@@ -204,10 +219,13 @@ class GeminiProvider(LLMProvider):
         """
         if types is None:
             _raise_missing_sdk()
+        config_kwargs: dict[str, Any] = {"task_type": "SEMANTIC_SIMILARITY"}
+        if self._embedding_output_dimensionality is not None:
+            config_kwargs["output_dimensionality"] = self._embedding_output_dimensionality
         response = await self._client.aio.models.embed_content(
             model=model,
             contents=text,
-            config=types.EmbedContentConfig(task_type="SEMANTIC_SIMILARITY"),
+            config=types.EmbedContentConfig(**config_kwargs),
         )
         return list(response.embeddings[0].values)
 

--- a/src/openbiliclaw/llm/registry.py
+++ b/src/openbiliclaw/llm/registry.py
@@ -7,7 +7,7 @@ import os
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
-from .base import LLMProvider, LLMProviderError, LLMRegistry
+from .base import LLMProvider, LLMProviderError, LLMRegistry, LLMResponse
 from .claude_provider import ClaudeProvider
 from .gemini_provider import GeminiProvider, gemini_sdk_available
 from .ollama_provider import OllamaProvider
@@ -23,6 +23,76 @@ logger = logging.getLogger(__name__)
 
 class RegistryBuildError(LLMProviderError):
     """Raised when no usable providers can be created from config."""
+
+
+class EmbeddingFailoverProvider(LLMProvider):
+    """Embedding-only provider that retries a secondary provider on failure."""
+
+    supports_embedding = True
+
+    def __init__(
+        self,
+        primary: LLMProvider,
+        fallback: LLMProvider,
+        *,
+        name: str,
+        primary_model: str | None = None,
+        fallback_model: str | None = None,
+    ) -> None:
+        self.primary = primary
+        self.fallback = fallback
+        self._name = name
+        self._primary_model = primary_model or None
+        self._fallback_model = fallback_model or None
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    async def complete(
+        self,
+        messages: list[dict[str, str]],
+        *,
+        temperature: float = 0.7,
+        max_tokens: int = 4096,
+        json_mode: bool = False,
+        reasoning_effort: str | None = None,
+        model: str | None = None,
+    ) -> LLMResponse:
+        raise LLMProviderError(f"{self.name} is embedding-only")
+
+    async def embed(self, text: str, *, model: str | None = None) -> list[float]:
+        primary_kwargs = {}
+        primary_model = self._primary_model or model
+        if primary_model is not None:
+            primary_kwargs["model"] = primary_model
+        try:
+            vector = await self.primary.embed(text, **primary_kwargs)  # type: ignore[attr-defined]
+            if vector:
+                return vector
+            logger.warning(
+                "Embedding provider %s returned an empty vector; retrying with fallback %s",
+                self.primary.name,
+                self.fallback.name,
+            )
+        except Exception:
+            logger.warning(
+                "Embedding provider %s failed; retrying with fallback %s",
+                self.primary.name,
+                self.fallback.name,
+                exc_info=True,
+            )
+
+        fallback_kwargs = {}
+        if self._fallback_model is not None:
+            fallback_kwargs["model"] = self._fallback_model
+        try:
+            return await self.fallback.embed(text, **fallback_kwargs)  # type: ignore[attr-defined]
+        except Exception as fallback_exc:
+            raise LLMProviderError(
+                f"embedding failover failed: primary={self.primary.name}, "
+                f"fallback={self.fallback.name}: {fallback_exc}"
+            ) from fallback_exc
 
 
 @dataclass
@@ -162,13 +232,54 @@ def build_embedding_service(
         chosen_provider: LLMProvider | None = None
         chosen_name = ""
         chosen_model = ""
-        for candidate in fallback_order:
-            built = _build_dedicated_embedding_provider(candidate, emb_cfg, config, requested_name)
-            if built is None:
-                continue
-            chosen_provider, chosen_model = built
-            chosen_name = candidate
-            break
+        if (
+            requested_name == "gemini"
+            and fallback_provider == "gemini"
+            and bool(getattr(emb_cfg, "fallback_enabled", False))
+        ):
+            primary_built = _build_dedicated_embedding_provider("gemini", emb_cfg, config, requested_name)
+            fallback_built = _build_gemini_chat_embedding_provider(config, emb_cfg)
+            if primary_built is not None and fallback_built is not None:
+                primary_provider, primary_model = primary_built
+                fallback_provider_obj, fallback_model = fallback_built
+                chosen_provider = EmbeddingFailoverProvider(
+                    primary_provider,
+                    fallback_provider_obj,
+                    name="gemini_failover",
+                    primary_model=primary_model,
+                    fallback_model=fallback_model,
+                )
+                chosen_model = primary_model
+                chosen_name = "gemini"
+
+        if chosen_provider is None and requested_name and fallback_provider and requested_name != fallback_provider:
+            primary_built = _build_dedicated_embedding_provider(
+                requested_name, emb_cfg, config, requested_name
+            )
+            fallback_built = _build_dedicated_embedding_provider(
+                fallback_provider, emb_cfg, config, requested_name
+            )
+            if primary_built is not None and fallback_built is not None:
+                primary_provider, primary_model = primary_built
+                fallback_provider_obj, fallback_model = fallback_built
+                chosen_provider = EmbeddingFailoverProvider(
+                    primary_provider,
+                    fallback_provider_obj,
+                    name=f"{requested_name}_failover_{fallback_provider}",
+                    primary_model=primary_model,
+                    fallback_model=fallback_model,
+                )
+                chosen_model = primary_model
+                chosen_name = requested_name
+
+        if chosen_provider is None:
+            for candidate in fallback_order:
+                built = _build_dedicated_embedding_provider(candidate, emb_cfg, config, requested_name)
+                if built is None:
+                    continue
+                chosen_provider, chosen_model = built
+                chosen_name = candidate
+                break
 
         if chosen_provider is None:
             requested_label = requested_name or "(not configured)"
@@ -201,15 +312,50 @@ def build_embedding_service(
         except Exception:
             logger.debug("Failed to init embedding L2 cache", exc_info=True)
 
+        output_dimensionality = int(getattr(emb_cfg, "output_dimensionality", 0) or 0)
+        cache_model = chosen_model
+        if chosen_name == "gemini" and output_dimensionality > 0:
+            cache_model = f"{chosen_model}#dim={output_dimensionality}"
+
         return EmbeddingService(
             cast("SupportsEmbed", chosen_provider),
             model=chosen_model,
+            cache_model=cache_model,
             similarity_threshold=emb_cfg.similarity_threshold,
             persistent_cache=l2_cache,
         )
     except Exception:
         return None
 
+
+def _build_gemini_chat_embedding_provider(
+    config: Config,
+    emb_cfg: Any,
+) -> tuple[LLMProvider, str] | None:
+    """Build Gemini embedding fallback from chat-side [llm.gemini] credentials."""
+    chat_gemini = getattr(config.llm, "gemini", None)
+    if chat_gemini is None:
+        return None
+    api_key = str(getattr(chat_gemini, "api_key", "") or "").strip()
+    if not api_key:
+        api_key = _gemini_env_api_key()
+    if not api_key or not gemini_sdk_available():
+        return None
+    base_url = str(getattr(chat_gemini, "base_url", "") or "").strip() or None
+    effective_model = (
+        emb_cfg.model.strip()
+        or str(getattr(chat_gemini, "model", "") or "").strip()
+        or _DEFAULT_EMBEDDING_MODEL_BY_PROVIDER["gemini"]
+    )
+    return (
+        GeminiProvider(
+            api_key=api_key,
+            model=effective_model,
+            base_url=base_url,
+            embedding_output_dimensionality=int(getattr(emb_cfg, "output_dimensionality", 0) or 0),
+        ),
+        effective_model,
+    )
 
 def _build_dedicated_embedding_provider(
     candidate: str,
@@ -308,7 +454,12 @@ def _build_dedicated_embedding_provider(
         if not api_key or not gemini_sdk_available():
             return None
         return (
-            GeminiProvider(api_key=api_key, model=effective_model),
+            GeminiProvider(
+                api_key=api_key,
+                model=effective_model,
+                base_url=base_url,
+                embedding_output_dimensionality=int(getattr(emb_cfg, "output_dimensionality", 0) or 0),
+            ),
             effective_model,
         )
 

--- a/tests/test_llm_registry.py
+++ b/tests/test_llm_registry.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+import asyncio
 
 import pytest
 
@@ -18,6 +19,7 @@ from openbiliclaw.llm.base import (
 )
 from openbiliclaw.llm.gemini_provider import gemini_sdk_available
 from openbiliclaw.llm.registry import (
+    EmbeddingFailoverProvider,
     RegistryBuildError,
     build_embedding_service,
     build_llm_registry,
@@ -34,6 +36,10 @@ class FakeProvider(LLMProvider):
     health: bool = True
     call_count: int = 0
     models: list[str | None] = field(default_factory=list)
+    embed_vectors: list[list[float]] = field(default_factory=list)
+    embed_errors: list[Exception] = field(default_factory=list)
+    embed_call_count: int = 0
+    embed_models: list[str | None] = field(default_factory=list)
 
     @property
     def name(self) -> str:
@@ -56,6 +62,15 @@ class FakeProvider(LLMProvider):
         if self.responses:
             return self.responses.pop(0)
         return LLMResponse(content="ok", provider=self.provider_name, model="fake")
+
+    async def embed(self, text: str, *, model: str | None = None) -> list[float]:
+        self.embed_call_count += 1
+        self.embed_models.append(model)
+        if self.embed_errors:
+            raise self.embed_errors.pop(0)
+        if self.embed_vectors:
+            return self.embed_vectors.pop(0)
+        return [1.0, 0.0]
 
     async def health_check(self) -> bool:
         return self.health
@@ -734,6 +749,92 @@ def test_embedding_does_not_auto_fallback_without_explicit_fallback_provider(tmp
 
 
 @pytest.mark.skipif(not gemini_sdk_available(), reason="google-genai is not installed")
+def test_embedding_gemini_uses_dedicated_base_url(tmp_path) -> None:
+    config = Config(
+        llm=LLMConfig(
+            default_provider="openai",
+            openai=LLMProviderConfig(api_key="sk-chat-test"),
+            embedding=EmbeddingConfig(
+                provider="gemini",
+                model="gemini-embedding-001",
+                api_key="dedicated-gemini-embedding-key",
+                base_url="https://proxy.example.test/gemini",
+            ),
+        ),
+        data_dir=str(tmp_path),
+    )
+
+    service = build_embedding_service(config, build_llm_registry(config))
+
+    assert service is not None
+    assert service._provider.name == "gemini"
+    assert service._model == "gemini-embedding-001"
+    api_client = service._provider._client._api_client
+    assert api_client._http_options.base_url == "https://proxy.example.test/gemini/"
+
+
+@pytest.mark.skipif(not gemini_sdk_available(), reason="google-genai is not installed")
+def test_embedding_gemini_same_provider_fails_over_to_chat_gemini(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from openbiliclaw.llm import registry as registry_mod
+
+    class StubGeminiProvider:
+        supports_embedding = True
+
+        def __init__(self, api_key: str, model: str, base_url: str | None = None, **_: object) -> None:
+            self.api_key = api_key
+            self.model = model
+            self.base_url = base_url
+            self.name = "gemini"
+
+        async def embed(self, text: str, *, model: str | None = None) -> list[float]:
+            if model != "gemini-embedding-001":
+                raise AssertionError(f"unexpected embedding model {model!r}")
+            if self.api_key == "primary-embedding-key":
+                raise LLMProviderError("primary quota exhausted")
+            return [0.25, 0.5, 0.75]
+
+        async def generate(self, messages, model: str | None = None):  # noqa: ANN001
+            raise AssertionError("embedding failover must not be used for chat generation")
+
+        async def health_check(self) -> bool:
+            return True
+
+    monkeypatch.setattr(registry_mod, "GeminiProvider", StubGeminiProvider)
+    config = Config(
+        llm=LLMConfig(
+            default_provider="openai",
+            gemini=LLMProviderConfig(
+                api_key="fallback-chat-gemini-key",
+                base_url="https://generativelanguage.googleapis.com",
+            ),
+            embedding=EmbeddingConfig(
+                provider="gemini",
+                model="gemini-embedding-001",
+                api_key="primary-embedding-key",
+                base_url="https://primary-gemini.example.test",
+                fallback_enabled=True,
+                fallback_provider="gemini",
+            ),
+        ),
+        data_dir=str(tmp_path),
+    )
+
+    service = build_embedding_service(config, build_llm_registry(config))
+
+    assert service is not None
+    assert service._provider.name == "gemini_failover"
+    assert service._provider.primary.api_key == "primary-embedding-key"
+    assert service._provider.fallback.api_key == "fallback-chat-gemini-key"
+    assert service._provider.fallback.base_url == "https://generativelanguage.googleapis.com"
+
+    vector = asyncio.run(service._provider.embed("semantic duplicate", model="gemini-embedding-001"))
+    assert vector == [0.25, 0.5, 0.75]
+
+
+@pytest.mark.skipif(not gemini_sdk_available(), reason="google-genai is not installed")
 def test_embedding_uses_explicit_fallback_provider(tmp_path) -> None:
     config = Config(
         llm=LLMConfig(
@@ -1293,3 +1394,91 @@ async def test_ollama_named_as_fallback_provider_is_chat_capable_without_model()
 
     response = await registry.complete([{"role": "user", "content": "hi"}])
     assert response.provider == "ollama"
+
+
+@pytest.mark.asyncio
+async def test_embedding_failover_provider_uses_fallback_model_after_primary_error() -> None:
+    primary = FakeProvider("gemini", embed_errors=[LLMProviderError("quota exhausted")])
+    fallback = FakeProvider("ollama", embed_vectors=[[0.1, 0.2, 0.3]])
+    provider = EmbeddingFailoverProvider(
+        primary,
+        fallback,
+        name="gemini_failover_ollama",
+        primary_model="gemini-embedding-001",
+        fallback_model="bge-m3",
+    )
+
+    vector = await provider.embed("hello", model="service-level-model")
+
+    assert vector == [0.1, 0.2, 0.3]
+    assert primary.embed_call_count == 1
+    assert fallback.embed_call_count == 1
+    assert primary.embed_models == ["gemini-embedding-001"]
+    assert fallback.embed_models == ["bge-m3"]
+
+
+@pytest.mark.asyncio
+async def test_embedding_failover_provider_uses_fallback_model_after_empty_vector() -> None:
+    primary = FakeProvider("gemini", embed_vectors=[[]])
+    fallback = FakeProvider("ollama", embed_vectors=[[0.4, 0.5]])
+    provider = EmbeddingFailoverProvider(
+        primary,
+        fallback,
+        name="gemini_failover_ollama",
+        primary_model="gemini-embedding-001",
+        fallback_model="bge-m3",
+    )
+
+    vector = await provider.embed("hello", model="service-level-model")
+
+    assert vector == [0.4, 0.5]
+    assert primary.embed_models == ["gemini-embedding-001"]
+    assert fallback.embed_models == ["bge-m3"]
+
+
+def test_build_embedding_service_wraps_runtime_embedding_fallback_with_isolated_models(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from openbiliclaw.llm import registry as registry_mod
+
+    primary = FakeProvider("gemini", embed_errors=[LLMProviderError("429")])
+    fallback = FakeProvider("ollama", embed_vectors=[[0.7, 0.8]])
+
+    def fake_build(candidate: str, emb_cfg: EmbeddingConfig, config: Config, requested_name: str):
+        if candidate == "gemini":
+            return primary, "gemini-embedding-001"
+        if candidate == "ollama":
+            return fallback, "bge-m3"
+        return None
+
+    monkeypatch.setattr(registry_mod, "_build_dedicated_embedding_provider", fake_build)
+
+    service = build_embedding_service(
+        Config(
+            data_dir=tmp_path,
+            llm=LLMConfig(
+                embedding=EmbeddingConfig(
+                    provider="gemini",
+                    model="gemini-embedding-001",
+                    api_key="gemini-key",
+                    output_dimensionality=1024,
+                    fallback_provider="ollama",
+                    fallback_enabled=True,
+                    base_url="https://generativelanguage.googleapis.com/v1beta/openai/",
+                ),
+                ollama=LLMProviderConfig(base_url="http://localhost:11434/v1", model="bge-m3"),
+            ),
+        ),
+        LLMRegistry(),
+    )
+
+    assert service is not None
+    assert isinstance(service._provider, EmbeddingFailoverProvider)
+
+    vector = asyncio.run(service.embed("runtime fallback model isolation"))
+
+    assert vector == [0.7, 0.8]
+    assert primary.embed_models == ["gemini-embedding-001"]
+    assert fallback.embed_models == ["bge-m3"]
+    assert service._cache_model == "gemini-embedding-001#dim=1024"


### PR DESCRIPTION
## Summary
- make chat LLM fallback opt-in via `llm.fallback_enabled` and exercise configured backup providers when the primary provider fails
- add embedding failover between explicit embedding providers and chat providers when `llm.embedding.fallback_enabled` is enabled
- pass Gemini `output_dimensionality` into embed calls and keep cache keys dimension-aware so 1024-dimensional Gemini embeddings do not collide with other dimensions

## Tests
- uv run pytest -q tests/test_llm_registry.py
- uv run pytest -q tests/test_llm_registry.py tests/test_config.py
- uv run python -m compileall -q src/openbiliclaw/config.py src/openbiliclaw/llm/embedding.py src/openbiliclaw/llm/gemini_provider.py src/openbiliclaw/llm/registry.py tests/test_llm_registry.py