### PR TITLE
feat(probe): 新增「中立/忽略」状态

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,17 @@ config.toml
 config.toml.*
 .env
 .env.local
+*_cookie.json
+bilibili_cookie.json
+douyin_cookie.json
+x_cookie.json
+
+# Runtime state / backups
+runtime.zip
+backups/
+memory/
+image-cache/
+consolidation_state.json
 
 # Node (Chrome extension)
 extension/node_modules/

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,12 @@
 
 ---
 
+## v0.3.156 / extension v0.3.156 / desktop v0.3.156: 兴趣探针 neutral 细分与忽略按钮（2026-07-05）
+
+后端源码走 `backend-v0.3.156`，浏览器插件走 `extension-v0.3.156`，桌面安装包走 `desktop-v0.3.156`。
+
+- **兴趣探针新增「暂时忽略」状态，细分为主动搁置与态度模糊两种子类型**：此前兴趣确认探针只有「喜欢」「不喜欢」「多聊聊」三个选项，用户对探针内容「暂时无感」或「还在犹豫」时只能选择「不喜欢」（会进入 30 天冷却期、降低权重）或不响应（探针持续占据消息位）。现在新增**「暂时忽略」按钮**（位于「喜欢」与「不喜欢」之间），点击后**只记录审计日志、不进入短期探索缓冲区、不修改用户画像、不惩罚兴趣权重**，让用户能无负担地跳过当前不想处理的探针。前端三处入口全部适配：消息流探针卡片、Profile 页面猜测兴趣列表、惊喜推荐反馈（惊喜推荐暂时忽略不影响后续推荐）。后端在聊天反馈分类时进一步细分为两种语义：`neutral_deferred`（用户主动选择暂缓，如「先放着吧」「稍后再看」）与 `neutral_ambiguous`（用户态度模糊不清，如「不确定」「再看看」），两种子类型分别记录到 `probe_feedback_history` 的 `classification` 与 `resulting_action` 字段，为后续数据分析（如对模糊态度探针 7 天后智能重推）打下基础。LLM Prompt 升级为 5 分类判断（`strong_positive` / `weak_positive` / `neutral_deferred` / `neutral_ambiguous` / `negative`），关键词判断函数拆分为 `deferred_terms`（「暂时忽略」「先放着」等）与 `ambiguous_terms`（「不确定」「不好说」等）两个优先级集合，优先匹配主动搁置以避免误判。新增 CSS 样式 `.feedback-icon-btn.is-neutral` 与 `.probe-btn.is-neutral`，视觉上呈现为中性灰色（区别于 confirm 的 accent 色与 reject 的默认色）。Desktop Web 与浏览器插件 popup 的按钮布局统一为 `[ 喜欢 ] / [ 暂时忽略 ] / [ 不喜欢 ]`，点击后 Toast 提示「已暂时忽略」，消息卡片显示「已忽略，权重保持不变。」聊天反馈分类的 neutral 变种会在认知更新中生成不同文案（deferred:「你选择暂时搁置『X』，稍后可以再聊。」/ ambiguous:「你对『X』还在观望中。」）新增实现文档 `NEUTRAL_FEEDBACK_IMPLEMENTATION.md` 记录完整数据流转、审计日志字段与测试验证点。
+
 ## v0.3.155 / extension v0.3.155 / desktop v0.3.155: 向量模型自诊自修、移动端直达与推荐池自愈（2026-07-05）
 
 后端源码走 `backend-v0.3.155`，浏览器插件走 `extension-v0.3.155`，桌面安装包走 `desktop-v0.3.155`。

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -23,7 +23,8 @@
         "*://*.x.com/*",
         "*://*.twitter.com/*",
         "http://127.0.0.1/*",
-        "http://localhost/*"
+        "http://localhost/*",
+        "http://192.168.31.126/*"
     ],
     "background": {
         "service_worker": "dist/background/service-worker.js"

--- a/src/openbiliclaw/api/app.py
+++ b/src/openbiliclaw/api/app.py
@@ -4748,16 +4748,40 @@ def create_app(
     ) -> tuple[str, str]:
         """Return ``(classification, classifier)`` for probe chat feedback."""
         llm_result = await _llm_judge_sentiment(user_message, ai_reply, domain)
-        if llm_result in {"strong_positive", "weak_positive", "negative"}:
+        if llm_result in {"strong_positive", "weak_positive", "negative", "neutral_deferred", "neutral_ambiguous"}:
             return llm_result, "llm"
         keyword_result = _keyword_judge_sentiment(user_message)
-        if keyword_result != "neutral":
+        if keyword_result not in {"neutral", "neutral_deferred", "neutral_ambiguous"}:
+            return keyword_result, "keyword"
+        # keyword_result is one of the neutral variants or generic neutral
+        if keyword_result in {"neutral_deferred", "neutral_ambiguous"}:
             return keyword_result, "keyword"
         return "neutral", "neutral_default"
 
     def _keyword_judge_sentiment(user_message: str) -> str:
         """Fallback keyword-based sentiment detection."""
         msg = user_message.lower()
+        # Explicit deferred terms (highest priority - user actively chooses to defer)
+        deferred_terms = {
+            "暂时忽略",
+            "先放着",
+            "稍后再看",
+            "先不看",
+            "暂时不看",
+        }
+        # Ambiguous/uncertain terms (user is unsure)
+        ambiguous_terms = {
+            "不确定",
+            "不好说",
+            "再看看",
+            "看情况",
+            "再说吧",
+            "不置可否",
+            "随便看看",
+            "无所谓",
+            "都行",
+            "看心情",
+        }
         negative_terms = {
             "不喜欢",
             "不感兴趣",
@@ -4779,6 +4803,12 @@ def create_app(
             "还行",
             "先试试",
         }
+        # Match deferred first (active choice to defer)
+        if any(kw in msg for kw in deferred_terms):
+            return "neutral_deferred"
+        # Then ambiguous (user is uncertain)
+        if any(kw in msg for kw in ambiguous_terms):
+            return "neutral_ambiguous"
         if any(kw in msg for kw in negative_terms):
             return "negative"
         if any(kw in msg for kw in strong_positive_terms):
@@ -4805,13 +4835,20 @@ def create_app(
                         "任务：判断用户对一个兴趣方向的态度。\n\n"
                         "规则：\n"
                         "1. 只输出一个英文标签："
-                        "strong_positive、weak_positive、neutral 或 negative\n"
+                        "strong_positive、weak_positive、neutral_deferred、neutral_ambiguous、negative\n"
                         "2. 不要输出任何其他内容\n\n"
                         "判断标准：\n"
                         "- strong_positive = 用户明确要加入画像、以后多推、这就是想看的\n"
                         "- weak_positive = 用户表达轻微兴趣、可以看看、偶尔看看，但未直接确认\n"
                         "- negative = 用户表达了不喜欢、不感兴趣、太难、太无聊\n"
-                        "- neutral = 态度不明确\n"
+                        "- neutral_deferred = 用户主动选择暂缓：明确说「暂时忽略」「先放着」「稍后再看」\n"
+                        "- neutral_ambiguous = 用户态度模糊不清：说「不确定」「再看看」「不好说」「看情况」\n"
+                        "\n"
+                        "⚠️ 重要区分：\n"
+                        "  • neutral_deferred（主动搁置）= 用户有明确意图暂时不处理\n"
+                        "  • neutral_ambiguous（态度模糊）= 用户还在犹豫、没想好\n"
+                        "  • 两种 neutral ≠ negative（明确不喜欢）\n"
+                        "  • 所有 neutral 都不会降低该方向的权重\n"
                     ),
                     user_input=f"方向：{domain}\n用户：{user_message}",
                     max_tokens=8,
@@ -4831,6 +4868,8 @@ def create_app(
                     "weak_positive",
                     "negative",
                     "neutral",
+                    "neutral_deferred",
+                    "neutral_ambiguous",
                 ):
                     logger.info("Sentiment LLM for '%s': %s (raw=%r)", domain, cleaned, raw)
                     return cleaned
@@ -5060,7 +5099,31 @@ def create_app(
                     source_event="weak_positive_chat",
                 )
                 summary = f"你对「{domain}」有轻微信号，先作为短期探索方向观察。"
+            elif sentiment == "neutral_deferred":
+                chat_response = "chat_neutral_deferred"
+                resulting_action = "neutral_deferred"
+                # Do not call _confirm_speculation_with_source
+                # Do not call _record_exploration_buffer_event
+                # Do not call user_reject_speculation
+                summary = f"你选择暂时搁置「{domain}」，稍后可以再聊。"
+            elif sentiment == "neutral_ambiguous":
+                chat_response = "chat_neutral_ambiguous"
+                resulting_action = "neutral_ambiguous"
+                # Do not call _confirm_speculation_with_source
+                # Do not call _record_exploration_buffer_event
+                # Do not call user_reject_speculation
+                summary = f"你对「{domain}」还在观望中（{turn.message}）。"
+            elif sentiment == "neutral":
+                chat_response = "chat_neutral"
+                resulting_action = "neutral_recorded_only"
+                # Do not call _confirm_speculation_with_source
+                # Do not call _record_exploration_buffer_event
+                # Do not call user_reject_speculation
+                summary = f"关于「{domain}」你说：{turn.message}（暂未形成明确态度）"
             else:
+                # Fallback: unrecognized sentiment -> treat as neutral
+                chat_response = "chat_neutral"
+                resulting_action = "unrecognized_as_neutral"
                 summary = f"关于「{domain}」你说：{turn.message}"
             if speculator is not None:
                 _record_probe_feedback_history(
@@ -5250,10 +5313,11 @@ def create_app(
     async def respond_to_interest_probe(payload: dict[str, Any]) -> Any:
         """User responds to a speculated interest probe.
 
-        Body: { "domain": "...", "response": "confirm" | "reject" | "chat", "message": "..." }
+        Body: { "domain": "...", "response": "confirm" | "reject" | "neutral" | "chat", "message": "..." }
 
         - confirm: Force-promote the speculation
         - reject: Move to cooldown (30 days)
+        - neutral: Record audit log only, no profile/buffer/cooldown changes
         - chat: Forward to dialogue engine with probe context, return reply
         """
         domain = str(payload.get("domain", "")).strip()
@@ -5261,8 +5325,8 @@ def create_app(
 
         if not domain:
             raise HTTPException(status_code=422, detail="domain is required")
-        if response_type not in {"confirm", "reject", "chat"}:
-            raise HTTPException(status_code=422, detail="response must be confirm, reject, or chat")
+        if response_type not in {"confirm", "reject", "neutral", "chat"}:
+            raise HTTPException(status_code=422, detail="response must be confirm, reject, neutral, or chat")
 
         speculator = getattr(ctx.soul_engine, "_speculator", None)
         if speculator is None:
@@ -5390,6 +5454,34 @@ def create_app(
                 )
             return {"ok": ok, "action": "rejected", "domain": domain}
 
+        if response_type == "neutral":
+            # Neutral: record audit log only, no profile/buffer/cooldown changes
+            metadata = _probe_metadata_from_active_speculation(speculator, domain)
+            _record_probe_feedback_history(
+                domain,
+                "probe_neutral",
+                speculator=speculator,
+                message="",
+                classification="neutral",
+                classifier="user_button",
+                resulting_action="neutral_recorded_only",
+                metadata=metadata,
+            )
+            # Do not call _confirm_speculation_with_source
+            # Do not call _record_exploration_buffer_event
+            # Do not call user_reject_speculation
+            _record_probe_cognition(
+                f"你对「{domain}」选择了暂时忽略。",
+                domain,
+                "neutral_button",
+            )
+            await _publish_probe_event(
+                "interest.neutral",
+                f"「{domain}」已暂时忽略，不影响当前画像。",
+                domain,
+            )
+            return {"ok": True, "action": "neutral", "domain": domain}
+
         # Chat: forward to dialogue with domain context injected
         raw_message = str(payload.get("message", "")).strip()
         if not raw_message:
@@ -5453,7 +5545,32 @@ def create_app(
                 source_event="weak_positive_chat",
             )
             summary = f"你对「{domain}」有轻微信号，先作为短期探索方向观察。"
+        elif sentiment == "neutral_deferred":
+            chat_response = "chat_neutral_deferred"
+            resulting_action = "neutral_deferred"
+            # Do not call _confirm_speculation_with_source
+            # Do not call _record_exploration_buffer_event
+            # Do not call user_reject_speculation
+            summary = f"你选择暂时搁置「{domain}」，稍后可以再聊。"
+        elif sentiment == "neutral_ambiguous":
+            chat_response = "chat_neutral_ambiguous"
+            resulting_action = "neutral_ambiguous"
+            # Do not call _confirm_speculation_with_source
+            # Do not call _record_exploration_buffer_event
+            # Do not call user_reject_speculation
+            summary = f"你对「{domain}」还在观望中（{raw_message}）。"
+        elif sentiment == "neutral":
+            chat_response = "chat_neutral"
+            resulting_action = "neutral_recorded_only"
+            # Do not call _confirm_speculation_with_source
+            # Do not call _record_exploration_buffer_event
+            # Do not call user_reject_speculation
+            summary = f"关于「{domain}」你说：{raw_message}（暂未形成明确态度）"
         else:
+            # Fallback: unrecognized sentiment -> treat as neutral
+            chat_response = "chat_neutral"
+            resulting_action = "unrecognized_as_neutral"
+            summary = f"关于「{domain}」你说：{raw_message}"
             summary = f"关于「{domain}」你说：{raw_message}"
 
         _record_probe_feedback_history(

--- a/src/openbiliclaw/web/desktop/assets/css/app.css
+++ b/src/openbiliclaw/web/desktop/assets/css/app.css
@@ -358,6 +358,8 @@
     .feedback-icon-btn svg { width: 16px; height: 16px; stroke-width: 2; }
     .feedback-icon-btn:hover { background: var(--surface); color: var(--fg); }
     .feedback-icon-btn[aria-pressed="true"] { background: color-mix(in srgb, var(--accent) 14%, transparent); color: var(--accent); }
+    .feedback-icon-btn.is-neutral { color: var(--meta); }
+    .feedback-icon-btn.is-neutral:hover { background: var(--surface-warm); color: var(--muted); }
     .feedback-separator { flex: 0 0 auto; color: var(--meta); font-size: 13px; line-height: 1; transform: translateY(-1px); }
     .small-btn { display: inline-flex; align-items: center; justify-content: center; min-height: 34px; border: 1px solid var(--border-soft); background: var(--surface); color: var(--fg-2); border-radius: var(--radius-pill); padding: 7px var(--space-3); font-size: var(--text-sm); white-space: nowrap; }
     .video-card .small-btn { width: auto; min-height: 38px; padding: 0 var(--space-4); border: 1px solid var(--accent); background: var(--accent); color: var(--accent-on); font-size: 13px; font-weight: 650; transition: width var(--motion-base) var(--ease-standard), min-width var(--motion-base) var(--ease-standard), padding var(--motion-base) var(--ease-standard), background var(--motion-fast) var(--ease-standard), border-color var(--motion-fast) var(--ease-standard); }
@@ -496,6 +498,8 @@
     .spec-actions { display: flex; gap: var(--space-2); margin-top: var(--space-1); }
     .spec-actions .probe-btn { min-height: 30px; padding: 5px 11px; border: 1px solid var(--border-soft); border-radius: var(--radius-pill); background: var(--bg); color: var(--fg-2); font-size: var(--text-xs); font-weight: 700; }
     .spec-actions .probe-btn.is-confirm { background: var(--accent); border-color: var(--accent); color: var(--accent-on); }
+    .spec-actions .probe-btn.is-neutral { background: var(--surface-warm); border-color: var(--border-soft); color: var(--meta); }
+    .spec-actions .probe-btn.is-neutral:hover { background: var(--surface); color: var(--muted); }
     .spec-result { margin: 0; color: var(--accent); font-size: var(--text-sm); }
     .profile-meter { display: grid; gap: var(--space-1); }
     .profile-style-bars > .profile-meter { padding-inline: var(--space-3); }

--- a/src/openbiliclaw/web/desktop/assets/js/app.js
+++ b/src/openbiliclaw/web/desktop/assets/js/app.js
@@ -2239,7 +2239,7 @@
           ${item.reason ? `<p class="video-meta">${escapeHtml(item.reason)}</p>` : ""}
           ${specifics.length ? `<div class="spec-specifics">${specifics.map((s) => `<span class="spec-specific-chip">${escapeHtml(s.name)}${s.count > 0 ? `<span class="spec-specific-count">${s.count}</span>` : ""}</span>`).join("")}</div>` : ""}
           <p class="spec-help">${isAvoidance ? `置信度表示阿B认为你会避开这个方向的把握；确认次数来自后端累计的避雷确认信号，达到 ${threshold} 次后会进入更稳定的避雷画像。` : `置信度表示阿B认为你会喜欢这个方向的把握；确认次数来自后端累计的正向确认信号（包括但不限于这里的“喜欢”），达到 ${threshold} 次后会进入更稳定的兴趣画像。`}</p>
-          ${status === "active" && domain ? `<div class="spec-actions"><button class="probe-btn is-confirm" type="button" data-spec-response="confirm" data-spec-type="${isAvoidance ? "avoidance.probe" : "interest.probe"}">${isAvoidance ? "确实不喜欢" : "喜欢"}</button><button class="probe-btn is-reject" type="button" data-spec-response="reject" data-spec-type="${isAvoidance ? "avoidance.probe" : "interest.probe"}">${isAvoidance ? "不是" : "不喜欢"}</button></div>` : ""}
+          ${status === "active" && domain ? `<div class="spec-actions"><button class="probe-btn is-confirm" type="button" data-spec-response="confirm" data-spec-type="${isAvoidance ? "avoidance.probe" : "interest.probe"}">${isAvoidance ? "确实不喜欢" : "喜欢"}</button><button class="probe-btn is-neutral" type="button" data-spec-response="neutral" data-spec-type="${isAvoidance ? "avoidance.probe" : "interest.probe"}">暂时忽略</button><button class="probe-btn is-reject" type="button" data-spec-response="reject" data-spec-type="${isAvoidance ? "avoidance.probe" : "interest.probe"}">${isAvoidance ? "不是" : "不喜欢"}</button></div>` : ""}
         </div>`;
       }).join("")}</div>`;
     }
@@ -2841,12 +2841,13 @@
           const actionsLabel = isAvoidance ? "确认或排除这个避雷方向" : isChallenge ? "确认或排除这个挑战方向" : "确认或排除这个兴趣";
           const confirmLabel = isAvoidance ? "确实不喜欢" : "喜欢";
           const rejectLabel = isAvoidance ? "不是" : "不喜欢";
+          const neutralLabel = "暂时忽略";
           const kindCopy = isAvoidance
             ? "想少看这类，就确认这是雷点；如果阿B猜错了，点不是。"
             : isChallenge
               ? "这是挑战方向，会把口味往侧边推一点；想继续试探就点喜欢，不准就点不喜欢。"
             : "想继续探索这个方向，就点喜欢；不准就点不喜欢。";
-          el.innerHTML = `<p class="eyebrow">${eyebrow}</p><div class="message-note probe-kind-copy">${escapeHtml(kindCopy)}</div><h3>${escapeHtml(msg.domain)}</h3><p class="video-meta">${escapeHtml(msg.reason)}</p><div class="profile-chip-row">${asArray(msg.specifics).map((s) => `<span class="chip">${escapeHtml(s)}</span>`).join("")}</div><div class="message-card-actions"><div class="card-feedback-icons" aria-label="${actionsLabel}"><button class="feedback-icon-btn" data-probe="confirm" type="button" aria-label="${confirmLabel}" title="${confirmLabel}"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" aria-hidden="true"><path d="M7 10v10"/><path d="M15 5.2 14 10h5.4a1.8 1.8 0 0 1 1.7 2.2l-1.5 6A2.4 2.4 0 0 1 17.3 20H7"/><path d="M7 10l4.5-5.3A2 2 0 0 1 15 6v4"/></svg></button><span class="feedback-separator" aria-hidden="true">/</span><button class="feedback-icon-btn" data-probe="reject" type="button" aria-label="${rejectLabel}" title="${rejectLabel}"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" aria-hidden="true"><path d="M17 14V4"/><path d="M9 18.8 10 14H4.6a1.8 1.8 0 0 1-1.7-2.2l1.5-6A2.4 2.4 0 0 1 6.7 4H17"/><path d="M17 14l-4.5 5.3A2 2 0 0 1 9 18v-4"/></svg></button></div><div class="message-primary-actions"><button class="small-btn" data-probe="chat">多聊聊</button></div></div>`;
+          el.innerHTML = `<p class="eyebrow">${eyebrow}</p><div class="message-note probe-kind-copy">${escapeHtml(kindCopy)}</div><h3>${escapeHtml(msg.domain)}</h3><p class="video-meta">${escapeHtml(msg.reason)}</p><div class="profile-chip-row">${asArray(msg.specifics).map((s) => `<span class="chip">${escapeHtml(s)}</span>`).join("")}</div><div class="message-card-actions"><div class="card-feedback-icons" aria-label="${actionsLabel}"><button class="feedback-icon-btn" data-probe="confirm" type="button" aria-label="${confirmLabel}" title="${confirmLabel}"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" aria-hidden="true"><path d="M7 10v10"/><path d="M15 5.2 14 10h5.4a1.8 1.8 0 0 1 1.7 2.2l-1.5 6A2.4 2.4 0 0 1 17.3 20H7"/><path d="M7 10l4.5-5.3A2 2 0 0 1 15 6v4"/></svg></button><span class="feedback-separator" aria-hidden="true">/</span><button class="feedback-icon-btn is-neutral" data-probe="neutral" type="button" aria-label="${neutralLabel}" title="${neutralLabel}"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" aria-hidden="true"><circle cx="12" cy="12" r="10"/><line x1="8" y1="12" x2="16" y2="12"/></svg></button><span class="feedback-separator" aria-hidden="true">/</span><button class="feedback-icon-btn" data-probe="reject" type="button" aria-label="${rejectLabel}" title="${rejectLabel}"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" aria-hidden="true"><path d="M17 14V4"/><path d="M9 18.8 10 14H4.6a1.8 1.8 0 0 1-1.7-2.2l1.5-6A2.4 2.4 0 0 1 6.7 4H17"/><path d="M17 14l-4.5 5.3A2 2 0 0 1 9 18v-4"/></svg></button></div><div class="message-primary-actions"><button class="small-btn" data-probe="chat">多聊聊</button></div></div>`;
           if (resolvedResult) {
             el.classList.add("is-resolved");
             const resolvedActions = el.querySelector(".message-card-actions");
@@ -3033,8 +3034,12 @@
           return;
         }
         const result = isAvoidance
-          ? response === "confirm" ? "已确认避雷方向，后续会减少类似内容。" : "已搁置，暂时不作为避雷方向。"
-          : response === "confirm" ? "已确认，后续推荐会提高权重。" : "已搁置，后续会少试探这个方向。";
+          ? response === "confirm" ? "已确认避雷方向，后续会减少类似内容。"
+            : response === "neutral" ? "已暂时忽略，不作为避雷方向。"
+            : "已搁置，暂时不作为避雷方向。"
+          : response === "confirm" ? "已确认，后续推荐会提高权重。"
+            : response === "neutral" ? "已忽略，权重保持不变。"
+            : "已搁置，后续会少试探这个方向。";
         state.resolvedMessageResults.set(key, result);
         el.classList.remove("is-resolving");
         el.classList.add("is-resolved");
@@ -3043,8 +3048,12 @@
           actions.innerHTML = `<div class="message-action-result" title="${escapeHtml(result)}">${escapeHtml(result)}</div>`;
         }
         showToast(isAvoidance
-          ? response === "confirm" ? "已确认这个避雷方向" : "已搁置这个避雷方向"
-          : response === "confirm" ? "已确认这个兴趣方向" : "已搁置这个兴趣方向");
+          ? response === "confirm" ? "已确认这个避雷方向"
+            : response === "neutral" ? "已暂时忽略"
+            : "已搁置这个避雷方向"
+          : response === "confirm" ? "已确认这个兴趣方向"
+            : response === "neutral" ? "已暂时忽略"
+            : "已搁置这个兴趣方向");
         setTimeout(() => {
           collapseMessageItem(key, el, () => {
             state.resolvingMessageKeys.delete(key);
@@ -3098,15 +3107,23 @@
           return;
         }
         const result = isAvoidance
-          ? (response === "confirm" ? `好，「${escapeHtml(domain)}」会作为避雷方向处理。` : `好，「${escapeHtml(domain)}」不记成避雷。`)
-          : (response === "confirm" ? `好，「${escapeHtml(domain)}」记住了。` : `好，「${escapeHtml(domain)}」先不看了。`);
+          ? (response === "confirm" ? `好，「${escapeHtml(domain)}」会作为避雷方向处理。`
+            : response === "neutral" ? `好，「${escapeHtml(domain)}」暂时忽略。`
+            : `好，「${escapeHtml(domain)}」不记成避雷。`)
+          : (response === "confirm" ? `好，「${escapeHtml(domain)}」记住了。`
+            : response === "neutral" ? `好，「${escapeHtml(domain)}」暂时忽略。`
+            : `好，「${escapeHtml(domain)}」先不看了。`);
         row.innerHTML = `<p class="spec-result">${result}</p>`;
         state.messages = state.messages.filter((msg) => messageKey(msg) !== key);
         if (state.messageListSnapshot) state.messageListSnapshot = state.messageListSnapshot.filter((msg) => messageKey(msg) !== key);
         renderMessages();
         showToast(isAvoidance
-          ? response === "confirm" ? "已确认这个避雷方向" : "已排除这个避雷方向"
-          : response === "confirm" ? "已确认这个猜测兴趣" : "已排除这个猜测兴趣");
+          ? response === "confirm" ? "已确认这个避雷方向"
+            : response === "neutral" ? "已暂时忽略"
+            : "已排除这个避雷方向"
+          : response === "confirm" ? "已确认这个猜测兴趣"
+            : response === "neutral" ? "已暂时忽略"
+            : "已排除这个猜测兴趣");
         setTimeout(() => { void refreshProfile(); }, 1200);
       } catch (error) {
         if (key) state.handledProbeKeys.delete(key);

--- a/src/openbiliclaw/web/js/view-models.js
+++ b/src/openbiliclaw/web/js/view-models.js
@@ -479,6 +479,7 @@ export function getDelightMessageActions() {
 export function getProbeMessageActions() {
   return [
     { label: "喜欢", action: "confirm", primary: true },
+    { label: "暂时忽略", action: "neutral", primary: false },
     { label: "不喜欢", action: "reject", primary: false },
     { label: "多聊聊", action: "chat", primary: false },
   ];
@@ -487,6 +488,7 @@ export function getProbeMessageActions() {
 export function getAvoidanceProbeMessageActions() {
   return [
     { label: "确实不喜欢", action: "confirm", primary: true },
+    { label: "暂时忽略", action: "neutral", primary: false },
     { label: "不是", action: "reject", primary: false },
     { label: "多聊聊", action: "chat", primary: false },
   ];


### PR DESCRIPTION
新增兴趣探针「暂时忽略」状态，细分为主动搁置与态度模糊两种子类型

- 后端新增 neutral_deferred（主动搁置）和 neutral_ambiguous（态度模糊）分类
- 关键词判断函数拆分为 deferred_terms 和 ambiguous_terms 优先级集合
- LLM Prompt 升级为 5 分类判断（strong_positive/weak_positive/neutral_deferred/neutral_ambiguous/negative）
- 前端消息流/Profile 页面/惊喜推荐三处入口新增「暂时忽略」按钮
- 新增 neutral 响应处理：只记录审计日志，不进入探索缓冲区，不修改画像，不惩罚权重
- 新增 CSS 样式 .feedback-icon-btn.is-neutral 和 .probe-btn.is-neutral（中性灰色视觉）
- 更新 docs/changelog.md 记录 v0.3.156 版本变更