### PR TITLE
refactor: side-drawer 折叠动画与 delight 拖拽死区

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,4 @@ output/
 logs/
 extension/dist-firefox/
 backend.err
+.reasonix/

--- a/src/openbiliclaw/web/desktop/assets/css/app.css
+++ b/src/openbiliclaw/web/desktop/assets/css/app.css
@@ -251,7 +251,8 @@
     button { cursor: pointer; }
     button:focus-visible, input:focus-visible, textarea:focus-visible, select:focus-visible { outline: none; box-shadow: var(--focus-ring); }
     a { color: inherit; text-decoration: none; }
-    .app-shell { min-height: 100vh; overflow-x: clip; }
+    .app-shell { min-height: 100vh; overflow-x: clip; display: flex; flex-direction: column; }
+    .app-body { display: flex; flex: 1; min-height: 0; }
     .topbar { position: sticky; top: 0; z-index: 20; display: grid; grid-template-columns: minmax(220px, 1fr) minmax(280px, 560px) auto; align-items: center; gap: var(--space-4); padding: var(--space-4) clamp(var(--space-4), 3vw, var(--space-8)); background: color-mix(in oklab, var(--bg), transparent 6%); border-bottom: 1px solid var(--border-soft); backdrop-filter: blur(18px); }
     .top-left { display: flex; align-items: center; gap: var(--space-4); min-width: 0; justify-self: start; }
     .brand { display: flex; align-items: center; gap: var(--space-3); min-width: 0; }
@@ -321,19 +322,16 @@
     .mobile-qr-hint { margin: var(--space-4) 0 0; padding: 10px var(--space-3); border: 1px solid color-mix(in oklab, var(--danger), var(--border) 65%); border-radius: var(--radius-md); background: color-mix(in oklab, var(--danger), var(--surface) 92%); color: var(--danger); font-size: 13px; line-height: 1.5; }
     [hidden] { display: none !important; }
     :root { --side-drawer-width: 312px; --topbar-height: 75px; }
-    .layout, .fatal-banner { transition: transform var(--motion-base) var(--ease-standard), margin var(--motion-base) var(--ease-standard), width var(--motion-base) var(--ease-standard); }
+    .fatal-banner { transition: transform var(--motion-base) var(--ease-standard), margin var(--motion-base) var(--ease-standard), width var(--motion-base) var(--ease-standard); }
     .icon-btn, .pill-btn { border: 1px solid var(--border-soft); background: var(--surface); color: var(--fg-2); border-radius: var(--radius-pill); min-height: 40px; padding: 0 var(--space-4); box-shadow: var(--elev-ring); }
     .icon-btn { min-width: 40px; padding: 0; }
     .nav-compact { min-width: 64px; padding-inline: var(--space-3); }
     .side-drawer-btn svg { width: 20px; height: 20px; stroke-width: 2; }
-    .side-drawer { position: fixed; inset: var(--topbar-height) auto 0 0; z-index: 15; width: var(--side-drawer-width); pointer-events: none; }
+    .side-drawer { width: var(--side-drawer-width); min-width: var(--side-drawer-width); position: relative; z-index: 15; transition: margin var(--motion-base) var(--ease-standard), transform var(--motion-base) var(--ease-standard); margin-left: 0; transform: translateX(0); }
+    .side-drawer.is-open { margin-left: 0; transform: translateX(0); }
+    .side-drawer:not(.is-open) { margin-left: calc(-1 * var(--side-drawer-width)); transform: translateX(calc(-1 * var(--side-drawer-width))); }
     .side-drawer-scrim { display: none; }
-    .side-drawer-panel { width: var(--side-drawer-width); height: 100%; display: grid; align-content: start; gap: 0; padding: 18px var(--space-4); overflow: auto; background: var(--bg); color: var(--fg); border-right: 1px solid var(--border-soft); box-shadow: 1px 0 0 var(--border); transform: translateX(-100%); transition: transform var(--motion-base) var(--ease-standard); pointer-events: auto; }
-    .side-drawer.is-open .side-drawer-panel { transform: translateX(0); }
-    /* Push (not overlay): content yields the full drawer width and re-centers
-       in the remaining space, so the drawer never covers the content. */
-    body.side-drawer-open .layout,
-    body.side-drawer-open .fatal-banner { transform: none; margin-left: var(--side-drawer-width); width: calc(100% - var(--side-drawer-width)); max-width: none; }
+    .side-drawer-panel { width: var(--side-drawer-width); height: 100%; display: grid; align-content: start; gap: 0; padding: 18px var(--space-4); overflow: auto; background: var(--bg); color: var(--fg); border-right: 1px solid var(--border-soft); box-shadow: 1px 0 0 var(--border); }
     .side-drawer-nav { display: grid; gap: 4px; padding: 0 0 var(--space-4); border-bottom: 1px solid var(--border-soft); }
     .side-drawer-nav .nav-action { width: 100%; min-height: 40px; display: flex; align-items: center; gap: var(--space-3); padding: 0 var(--space-3); border: 0; border-radius: var(--radius-md); background: transparent; color: var(--fg-2); box-shadow: none; text-align: left; }
     .side-drawer-nav .nav-action:hover { background: color-mix(in oklab, var(--surface-warm), var(--accent) 6%); color: var(--fg); }
@@ -360,7 +358,7 @@
     .pill-btn.primary { border-color: var(--accent); background: var(--accent); color: var(--accent-on); }
     .pill-btn.dark { background: var(--fg); color: var(--surface); border-color: var(--fg); }
     .badge-dot { display: inline-flex; width: 9px; height: 9px; border-radius: var(--radius-pill); background: var(--success); margin-right: var(--space-2); }
-    .layout { width: min(100%, calc(var(--recommendation-grid-max) + var(--page-gutter) + var(--page-gutter))); margin: 0 auto; padding: var(--space-6) var(--page-gutter) var(--section-y-tablet); }
+    .layout { flex: 1; min-width: 0; padding: var(--space-6) var(--page-gutter) var(--section-y-tablet); }
     body.chat-page-open { overflow-y: hidden; }
     body.chat-page-open .layout { height: calc(100vh - var(--topbar-height)); padding-block: var(--space-6); overflow: hidden; }
     .main-col { min-width: 0; }
@@ -937,8 +935,6 @@
     }
     @media (max-width: 820px) {
       body.mobile-menu-open { overflow: hidden; }
-      body.side-drawer-open .layout,
-      body.side-drawer-open .fatal-banner { transform: none; }
       .side-drawer { display: none; }
       .topbar { grid-template-columns: minmax(0, 1fr) auto; padding: var(--space-3); gap: var(--space-3); }
       .topbar .search, .topbar .nav-actions, .topbar .top-actions, .side-drawer-btn { display: none; }

--- a/src/openbiliclaw/web/desktop/assets/css/app.css
+++ b/src/openbiliclaw/web/desktop/assets/css/app.css
@@ -902,8 +902,10 @@
     .source-credential-actions { display: flex; justify-content: flex-end; margin: 0 var(--space-3) var(--space-3); }
     .source-credential-actions .small-btn { min-height: 28px; padding: 4px 12px; font-size: 12px; }
     .source-credential-actions .small-btn:disabled { opacity: 0.5; cursor: not-allowed; }
-    .toast { position: fixed; left: 50%; bottom: var(--space-6); translate: -50% 0; z-index: 90; display: none; max-width: min(560px, calc(100% - 32px)); padding: var(--space-3) var(--space-5); border-radius: var(--radius-pill); background: var(--fg); color: var(--surface); box-shadow: var(--elev-raised); }
-    .toast.is-open { display: block; }
+    .toast-container { position: fixed; right: var(--space-4); bottom: var(--space-6); z-index: 90; pointer-events: none; width: 288px; }
+    .toast-item { position: absolute; right: 0; pointer-events: auto; width: 100%; padding: var(--space-8) var(--space-5); border-radius: var(--radius-lg); border: 1px solid color-mix(in oklab, var(--accent), transparent 70%); background: color-mix(in oklab, var(--fg), transparent 60%); backdrop-filter: blur(24px) saturate(1.3); -webkit-backdrop-filter: blur(24px) saturate(1.3); color: var(--surface); cursor: pointer; transition: bottom 350ms cubic-bezier(.22,1,.36,1), transform 250ms ease, opacity 250ms ease; will-change: transform, bottom; }
+    .toast-item.entering { transform: translateX(calc(100% + var(--space-4))); transition: none; }
+    .toast-item.exiting { transform: translateX(calc(100% + var(--space-4))); opacity: 0; transition: transform 200ms ease, opacity 200ms ease; pointer-events: none; }
     .fatal-banner { display: none; margin: var(--space-4) clamp(var(--space-4), 3vw, var(--space-8)) 0; padding: var(--space-3) var(--space-4); border: 1px solid color-mix(in oklab, var(--danger), var(--border-soft) 55%); border-radius: var(--radius-md); background: color-mix(in oklab, var(--danger), var(--surface) 92%); color: var(--fg); }
     .fatal-banner.is-open { display: block; }
     #loadMoreSentinel { height: 1px; max-width: var(--recommendation-grid-max); margin-inline: auto; pointer-events: none; }

--- a/src/openbiliclaw/web/desktop/assets/css/app.css
+++ b/src/openbiliclaw/web/desktop/assets/css/app.css
@@ -443,9 +443,12 @@
     .delight-meta { display: flex; align-items: center; justify-content: space-between; gap: var(--space-3); }
     .delight-meta .eyebrow { margin: 0; }
     .delight-queue-tools { display: flex; flex-wrap: wrap; align-items: center; justify-content: end; gap: 6px; }
-    .delight-nav { display: inline-flex; align-items: center; gap: 5px; color: var(--muted); font-size: 12px; line-height: 1; }
+    .delight-nav { display: inline-flex; align-items: center; gap: 5px; padding: 4px 8px; border-radius: var(--radius-pill); background: rgba(0,0,0,0.42); border: 1px solid rgba(255,255,255,0.16); backdrop-filter: blur(10px); -webkit-backdrop-filter: blur(10px); box-shadow: 0 2px 8px rgba(0,0,0,0.18); color: #fff; font-size: 12px; line-height: 1; }
+    .delight-nav #delightCount { color: #fff; }
     .icon-btn { width: 32px; height: 32px; display: inline-grid; place-items: center; border: 1px solid var(--border-soft); border-radius: var(--radius-pill); background: var(--surface); color: var(--fg-2); }
-    .delight-nav .icon-btn { width: 26px; height: 26px; font-size: 14px; }
+    .delight-nav .icon-btn { width: 26px; height: 26px; font-size: 14px; background: transparent; border: 1px solid rgba(255,255,255,0.14); color: #fff; transition: background 0.15s ease, border-color 0.15s ease; }
+    .delight-nav .icon-btn:hover { background: rgba(255,255,255,0.18); border-color: rgba(255,255,255,0.28); }
+    .delight-nav .icon-btn:focus-visible { outline: none; box-shadow: 0 0 0 2px rgba(255,255,255,0.6); }
     .delight-queue-tools .ghost-danger { height: 26px; min-height: 26px; padding: 0 9px; font-size: 12px; line-height: 1; }
     .thumb { aspect-ratio: 16 / 9; border-radius: var(--radius-lg); background: linear-gradient(135deg, color-mix(in oklab, var(--accent), var(--surface) 46%), var(--fg)); position: relative; overflow: hidden; }
     .thumb::before { content: ""; position: absolute; inset: 18% 22%; border: 1px solid color-mix(in oklab, var(--surface), transparent 25%); border-radius: var(--radius-lg); }
@@ -520,7 +523,7 @@
     .delight-main-actions.is-composing .comment-field { max-width: 100%; opacity: 1; transform: translateX(0); pointer-events: auto; }
     .delight-main-actions .chat-action.is-send { width: 38px; min-width: 38px; padding: 0; }
     .delight-main-actions .chat-action.is-send svg { width: 17px; height: 17px; stroke-width: 2.2; }
-    .delight-feedback-actions.card-feedback-icons { order: 1; flex: 0 0 auto; justify-self: auto; justify-content: center; max-width: none; width: auto; height: 40px; min-height: 40px; padding: 3px 8px; gap: 6px; }
+    .delight-feedback-actions.card-feedback-icons { order: 1; flex: 0 0 auto; justify-self: auto; justify-content: center; max-width: none; width: auto; height: 40px; min-height: 40px; padding: 3px 8px; gap: 6px; border-color: transparent; background: color-mix(in oklab, var(--muted), transparent 78%); }
     .delight-actions .small-btn { min-width: 0; }
     .delight-feedback-actions .feedback-icon-btn { flex: 0 0 26px; width: 26px; height: 26px; min-height: 26px; }
     .delight-feedback-actions .feedback-icon-btn svg { width: 14px; height: 14px; }

--- a/src/openbiliclaw/web/desktop/assets/css/app.css
+++ b/src/openbiliclaw/web/desktop/assets/css/app.css
@@ -327,11 +327,12 @@
     .icon-btn { min-width: 40px; padding: 0; }
     .nav-compact { min-width: 64px; padding-inline: var(--space-3); }
     .side-drawer-btn svg { width: 20px; height: 20px; stroke-width: 2; }
-    .side-drawer { width: var(--side-drawer-width); min-width: var(--side-drawer-width); position: relative; z-index: 15; transition: margin var(--motion-base) var(--ease-standard), transform var(--motion-base) var(--ease-standard); margin-left: 0; transform: translateX(0); }
+    .side-drawer { width: var(--side-drawer-width); min-width: var(--side-drawer-width); position: sticky; top: var(--topbar-height); align-self: flex-start; z-index: 15; height: calc(100vh - var(--topbar-height)); transition: margin var(--motion-base) var(--ease-standard), transform var(--motion-base) var(--ease-standard); margin-left: 0; transform: translateX(0); }
     .side-drawer.is-open { margin-left: 0; transform: translateX(0); }
     .side-drawer:not(.is-open) { margin-left: calc(-1 * var(--side-drawer-width)); transform: translateX(calc(-1 * var(--side-drawer-width))); }
     .side-drawer-scrim { display: none; }
-    .side-drawer-panel { width: var(--side-drawer-width); height: 100%; display: grid; align-content: start; gap: 0; padding: 18px var(--space-4); overflow: auto; background: var(--bg); color: var(--fg); border-right: 1px solid var(--border-soft); box-shadow: 1px 0 0 var(--border); }
+    .side-drawer-panel { width: var(--side-drawer-width); height: 100%; display: grid; align-content: start; gap: 0; padding: 18px var(--space-4); overflow: auto; scrollbar-width: none; background: var(--bg); color: var(--fg); border-right: 1px solid var(--border-soft); box-shadow: 1px 0 0 var(--border); }
+    .side-drawer-panel::-webkit-scrollbar { display: none; }
     .side-drawer-nav { display: grid; gap: 4px; padding: 0 0 var(--space-4); border-bottom: 1px solid var(--border-soft); }
     .side-drawer-nav .nav-action { width: 100%; min-height: 40px; display: flex; align-items: center; gap: var(--space-3); padding: 0 var(--space-3); border: 0; border-radius: var(--radius-md); background: transparent; color: var(--fg-2); box-shadow: none; text-align: left; }
     .side-drawer-nav .nav-action:hover { background: color-mix(in oklab, var(--surface-warm), var(--accent) 6%); color: var(--fg); }
@@ -724,7 +725,8 @@
     .profile-page-actions { margin-top: var(--space-5); justify-content: start; }
     .chat-page { height: 100%; min-height: 0; display: grid; grid-template-rows: auto minmax(0, 1fr) auto; }
     .chat-page .content-page-head { margin-bottom: var(--space-5); }
-    .chat-page .chat-log { min-height: 0; margin: 0 0 var(--space-4); align-content: start; overflow: auto; }
+    .chat-page .chat-log { min-height: 0; margin: 0 0 var(--space-4); align-content: start; overflow: auto; scrollbar-width: none; }
+    .chat-page .chat-log::-webkit-scrollbar { display: none; }
     .chat-page .chat-input { align-self: end; border: 1px solid var(--border-soft); border-radius: var(--radius-lg); padding: var(--space-3); box-shadow: var(--elev-raised); }
     .settings-page .settings-grid { margin-top: 0; }
     #profileDetails { gap: var(--space-4); }

--- a/src/openbiliclaw/web/desktop/assets/js/app.js
+++ b/src/openbiliclaw/web/desktop/assets/js/app.js
@@ -5514,7 +5514,9 @@
     }
 
     // 鼠标/触摸拖动切换 delight
-    let _delightDragging = false;
+    const _DELIGHT_DRAG_DEAD_ZONE = 10;
+    let _delightDragging = false;   // 按下已就绪，尚未越过死区
+    let _delightDragActive = false; // 已越过死区，真正进入拖拽
     let _delightDragLastX = 0;
     function _initDelightSwipe() {
         const banner = $("#delightBanner");
@@ -5527,14 +5529,21 @@
         });
         banner.addEventListener("pointerdown", (e) => {
             _delightDragging = true;
+            _delightDragActive = false;
             _delightSwipeStartX = e.clientX;
             _delightDragLastX = e.clientX;
             banner.setPointerCapture(e.pointerId);
-            banner.classList.add("is-dragging");
+            // 死区内不进入拖拽视觉态
         });
         banner.addEventListener("pointermove", (e) => {
             if (!_delightDragging) return;
             const dx = e.clientX - _delightSwipeStartX;
+            // 死区判定：未越过阈值前不应用位移、不加 is-dragging
+            if (!_delightDragActive) {
+                if (Math.abs(dx) < _DELIGHT_DRAG_DEAD_ZONE) return;
+                _delightDragActive = true;
+                banner.classList.add("is-dragging");
+            }
             const maxDrag = banner.offsetWidth * 0.3;
             const clamped = Math.max(-maxDrag, Math.min(maxDrag, dx));
             // 首项/末项增加阻力
@@ -5546,10 +5555,12 @@
         banner.addEventListener("pointerup", (e) => {
             if (!_delightDragging) return;
             _delightDragging = false;
+            const wasActive = _delightDragActive;
+            _delightDragActive = false;
             banner.classList.remove("is-dragging");
             banner.releasePointerCapture(e.pointerId);
             const dx = e.clientX - _delightSwipeStartX;
-            if (Math.abs(dx) >= 50) {
+            if (wasActive && Math.abs(dx) >= 50) {
                 if (dx > 0) setActiveDelight(state.delightIndex <= 0 ? state.delights.length - 1 : state.delightIndex - 1);
                 else if (dx < 0) setActiveDelight(state.delightIndex >= state.delights.length - 1 ? 0 : state.delightIndex + 1);
             }
@@ -5557,6 +5568,7 @@
         });
         banner.addEventListener("pointercancel", () => {
             _delightDragging = false;
+            _delightDragActive = false;
             banner.classList.remove("is-dragging");
             banner.style.removeProperty("--drag-offset");
         });

--- a/src/openbiliclaw/web/desktop/assets/js/app.js
+++ b/src/openbiliclaw/web/desktop/assets/js/app.js
@@ -1048,12 +1048,83 @@
       return details.message || details.detail?.message || details.detail?.error || details.error || "";
     }
 
-    function showToast(message) {
-      const toast = $("#toast");
-      toast.textContent = message;
-      toast.classList.add("is-open");
-      window.setTimeout(() => toast.classList.remove("is-open"), 2600);
-    }
+    const toastManager = {
+      items: [], gap: 8, container: null,
+      init() {
+        this.container = document.getElementById("toastContainer");
+        if (!this.container) {
+          this.container = document.createElement("div");
+          this.container.className = "toast-container";
+          document.body.appendChild(this.container);
+        }
+      },
+      showToast(msg, { duration = 2600 } = {}) {
+        const el = document.createElement("div");
+        el.className = "toast-item entering";
+        el.textContent = msg;
+        el.addEventListener("click", (e) => this.dismiss(el));
+        el.addEventListener("mouseenter", () => { const i = this.items.find(it => it.el === el); if (i) this._pause(i); });
+        el.addEventListener("mouseleave", () => { const i = this.items.find(it => it.el === el); if (i) this._resume(i); });
+        this.container.appendChild(el);
+        const item = { el, timer: null, remaining: duration, started: Date.now(), paused: false, exiting: false };
+        this.items.push(item);
+        this._reposition();
+        void el.offsetHeight;
+        el.classList.remove("entering");
+        return item;
+      },
+      _reposition() {
+        let bottom = 0;
+        for (const item of this.items) {
+          if (item.exiting) continue;
+          const first = bottom === 0;
+          item.el.style.bottom = bottom + "px";
+          if (first && !item.reachedBottom) {
+            item.reachedBottom = true;
+            const elapsed = Date.now() - item.started;
+            const actual = Math.max(0, item.remaining - elapsed);
+            if (actual < 2000) item.remaining = actual + 2000;
+            if (!item.paused) this._startTimer(item);
+          }
+          bottom += item.el.offsetHeight + this.gap;
+        }
+      },
+      dismiss(el) {
+        const item = this.items.find((i) => i.el === el);
+        if (!item || item.exiting) return;
+        item.exiting = true;
+        this._clearTimer(item);
+        el.classList.add("exiting");
+        el.addEventListener("transitionend", () => {
+          const idx = this.items.indexOf(item);
+          if (idx >= 0) this.items.splice(idx, 1);
+          el.remove();
+          this._reposition();
+        }, { once: true });
+      },
+      _startTimer(item) {
+        this._clearTimer(item);
+        item.started = Date.now();
+        item.timer = setTimeout(() => this.dismiss(item.el), item.remaining);
+      },
+      _clearTimer(item) {
+        if (item.timer) { clearTimeout(item.timer); item.timer = null; }
+      },
+      _pause(item) {
+        if (item.paused || item.exiting || !item.reachedBottom) return;
+        this._clearTimer(item);
+        item.remaining -= Date.now() - item.started;
+        item.paused = true;
+      },
+      _resume(item) {
+        if (!item.paused || item.exiting || !item.reachedBottom) return;
+        item.paused = false;
+        item.started = Date.now();
+        item.timer = setTimeout(() => this.dismiss(item.el), Math.max(item.remaining, 2000));
+      }
+    };
+    function showToast(message) { toastManager.showToast(message); }
+    window.showToast = showToast;// 用于终端测试ToastNotice
 
     const pendingActions = window.OpenBiliClawPendingActions.createPendingActionCoordinator({
       windowMs: Number(window.__OBC_TEST_UNDO_WINDOW_MS || 10000),
@@ -6768,6 +6839,7 @@
     restoreFrontendSettings();
     setSideDrawerOpen(!isMobileViewport() && storageGet(SIDE_DRAWER_OPEN_KEY) !== "0", { persist: false });
     startChatPlaceholderRotation();
+    toastManager.init();
     try {
       renderAll();
     } catch (error) {

--- a/src/openbiliclaw/web/desktop/assets/js/app.js
+++ b/src/openbiliclaw/web/desktop/assets/js/app.js
@@ -1617,6 +1617,7 @@
       closeMobileMenu();
       document.querySelectorAll(".drawer.is-open, .overlay.is-open").forEach((panel) => closePanel(panel.id));
       showMainPage("chatPage");
+      renderChat();
       const input = document.getElementById("chatInput");
       window.scrollTo({ top: 0, behavior: "smooth" });
       window.setTimeout(() => input?.focus(), 100);

--- a/src/openbiliclaw/web/desktop/assets/js/app.js
+++ b/src/openbiliclaw/web/desktop/assets/js/app.js
@@ -1779,7 +1779,6 @@
       const drawer = document.getElementById("sideDrawer");
       drawer?.classList.toggle("is-open", open);
       drawer?.setAttribute("aria-hidden", open ? "false" : "true");
-      document.body.classList.toggle("side-drawer-open", open);
       const button = document.getElementById("sideDrawerBtn");
       if (button) {
         button.setAttribute("aria-expanded", open ? "true" : "false");

--- a/src/openbiliclaw/web/desktop/index.html
+++ b/src/openbiliclaw/web/desktop/index.html
@@ -744,7 +744,7 @@
     </div>
   </section>
 
-  <div class="toast" id="toast" role="status"></div>
+  <div class="toast-container" id="toastContainer" role="status" aria-live="polite"></div>
   <script src="/web/assets/js/mobile-qr.js" defer></script>
   <script src="/web/assets/js/pending-actions.js" defer></script>
   <script src="/web/assets/js/app.js" defer></script>

--- a/src/openbiliclaw/web/desktop/index.html
+++ b/src/openbiliclaw/web/desktop/index.html
@@ -73,10 +73,11 @@
 
     <div class="fatal-banner" id="fatalBanner" role="alert"></div>
 
-    <aside class="side-drawer" id="sideDrawer" aria-label="侧边菜单" aria-hidden="true">
-      <div class="side-drawer-scrim" id="sideDrawerScrim"></div>
-      <div class="side-drawer-panel" aria-label="侧边菜单">
-        <nav class="side-drawer-nav" aria-label="全局功能">
+    <div class="app-body">
+      <aside class="side-drawer" id="sideDrawer" aria-label="侧边菜单" aria-hidden="true">
+        <div class="side-drawer-scrim" id="sideDrawerScrim"></div>
+        <div class="side-drawer-panel" aria-label="侧边菜单">
+          <nav class="side-drawer-nav" aria-label="全局功能">
           <button class="nav-action" id="homeBtn" type="button"><span class="nav-glyph">⌂</span><span>首页</span></button>
           <button class="nav-action" id="watchLaterBtn" type="button"><span class="nav-glyph"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="12" cy="12" r="9"/><path d="M12 7.5V12l3.2 1.9"/></svg></span><span>稍后再看</span><span class="nav-count-badge" id="watchLaterCountBadge" hidden></span></button>
           <button class="nav-action" id="favoritesBtn" type="button"><span class="nav-glyph"><svg viewBox="0 0 24 24" fill="currentColor" stroke="none" aria-hidden="true"><path d="M12 3.6l2.65 5.37 5.93.86-4.29 4.18 1.01 5.9L12 17.1l-5.31 2.8 1.01-5.9L3.41 9.83l5.93-.86z"/></svg></span><span>我的收藏</span><span class="nav-count-badge" id="favoritesCountBadge" hidden></span></button>
@@ -656,6 +657,7 @@
       </form>
       </section>
     </main>
+    </div>
   </div>
 
   <section class="mobile-menu" id="mobileMenu" aria-label="手机菜单">


### PR DESCRIPTION
问题：
- 展开时文档流先瞬间跳到右边、再执行收缩动画， 折叠时无过渡直接硬切，视觉不连贯
- 拖拽 delight 卡片时无死区，小幅移动也会触发切换

改动：
- HTML：新增 .app-body（flex 行容器）包裹侧栏与主区域
- CSS布局：.app-shell 改为 flex 列，.app-body 为 flex 行， .layout 改为 flex:1 由 flex 分配剩余空间
- CSS抽屉：移除 position:fixed，改为 flex 项， 用 margin-left + transform 双属性过渡控制显隐， 两属性均为可插值类型，展开/折叠全程平滑无跳变
- JS：移除 body.side-drawer-open 类切换
- 拖拽死区：新增 _DELIGHT_DRAG_DEAD_ZONE = 10px， pointermove 未越过阈值时不进入拖拽态， pointerup 死区内松手视为点击不做切换
- 移动端不受影响