### PR TITLE
fix(web): retry desktop config snapshot so enabled platform tabs converge

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -220,7 +220,7 @@ Web durable turn 只在成功 completion CAS 后交接认知与成功事件；�
 - `PoolServeSnapshot` — 专属 serve DB worker 在一个只读事务内统一读取 readiness、候选窗口、平台补位、持久化 `seen_items` 和 curator 信号；MMR/多样性纯函数与排序规则不变
 - `serve_with_result()` — 返回 items、提交后扣减库存与分阶段耗时；推荐历史和 shown 在独立短事务中原子提交，API 先广播结果库存，再 detached 精确收敛
 - 换批是默认硬去重动作：桌面 Web、移动 Web 与扩展 side panel 都提交当前卡片 ID，后端继续叠加推荐历史和 `seen_items`；成功响应只写一条 `reshuffle` 批次事件。桌面端不再暴露“换一批时忽略当前”开关，也不会逐卡提交 `dismiss`。CLI 没有持久卡片列表，只复用后两层去重。
-- 平台定向作用域（PC Web 平台 Tab）：`serve / reshuffle / append` 的可选 `source_platform` 让 snapshot 只装载该 canonical 平台的候选并跳过跨平台保底补位，其后的 curator、MMR、多样性、文案、持久化与 shown 提交完全复用同一实现；返回前校验并丢弃跨平台泄漏行（记 ERROR）。数据流为 `PC Web tab → POST {reshuffle,append}.source_platform → RecommendationEngine → Storage 平台候选`，配套只读 `GET /api/recommendations/platform-availability` 提供 Tab 库存徽标。库存与选片共用同一份 canonical available 行集合，`total_available == sum(by_platform)`。移动 Web、扩展与 CLI 无平台 Tab，继续走不带平台的兼容路径
+- 平台定向作用域（PC Web 平台 Tab）：`serve / reshuffle / append` 的可选 `source_platform` 让 snapshot 只装载该 canonical 平台的候选并跳过跨平台保底补位，其后的 curator、MMR、多样性、文案、持久化与 shown 提交完全复用同一实现；返回前校验并丢弃跨平台泄漏行（记 ERROR）。数据流为 `PC Web tab → POST {reshuffle,append}.source_platform → RecommendationEngine → Storage 平台候选`，配套只读 `GET /api/recommendations/platform-availability` 提供 Tab 库存徽标。Tab 集合取“启用配置 ∪ 正库存 ∪ 已加载卡片”；首屏 `/api/config` 瞬断时按 1s / 2s / 4s / 8s 有界恢复，页签转入后台会取消重试定时器，恢复可见后重新水合并收敛。库存与选片共用同一份 canonical available 行集合，`total_available == sum(by_platform)`。移动 Web、扩展与 CLI 无平台 Tab，继续走不带平台的兼容路径
 - 个性化专题生成
 
 ### Runtime (`runtime/`)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,7 @@
 - **候选评估使用真实发布时间**：单条、批量和补分类路径统一携带来源 `published_at` 与真实 UTC `evaluated_at`，缓存同时绑定发布时间摘要和评估小时桶；缺失或无效发布时间保持中性，不再让模型按知识截止时间猜测当前日期。
 - **发现关键词轮换与积压保护增强**：planner 避免重复消费同一关键词，XHS producer 按默认 20 分钟节奏检查，并在 pending + in-progress 搜索达到 5 条时停止 claim 与 LLM 生成。
 - **发布版本与 AMO channel 冲突处理**：后端、桌面和首轮 GitHub 插件包发布为 `0.3.194`；该扩展标签的既有自动签名流程先在 AMO 占用了 unlisted `0.3.194`，AMO 因此拒绝同版本转 listed。商店补丁版本提升为 `0.3.195`，Chrome 用它替换刚提交的 `0.3.194` 审核包，Firefox 以全新 listed 版本重提；仓库变量 `FIREFOX_SIGNING_ENABLED` 同步关闭，今后 GitHub 扩展发布不再抢占正式 AMO listed 版本号。
+- **PC Web 平台 Tab 集合在配置快照瞬断后自动恢复**：水合时 `/api/config` 与库存快照并行读取，偶发的连接重置此前会被静默吞掉——已启用但零库存的平台（如 Reddit）因此永久缺席筛选行，直到整页刷新。配置快照现在与平台库存一致采用有界重试（1s / 2s / 4s / 8s），成功后 Tab 并集收敛；E2E 桩改用 HTTP/1.0 短连接消除并行水合时的 keep-alive 复位竞态，并新增「配置两次失败后 Reddit 仍以 0 计数出现」的回归用例。
 
 ## extension v0.3.193：Firefox AMO 公开商店提审（2026-08-03）
 

--- a/docs/superpowers/specs/2026-07-19-platform-scoped-recommendations-design.md
+++ b/docs/superpowers/specs/2026-07-19-platform-scoped-recommendations-design.md
@@ -95,6 +95,10 @@ strict_platform_candidates(platform)
 已知平台按现有 `sourceFilterDefinitions` 顺序排列；其它值按稳定字典序排列。若当前
 Tab 因配置热更新或库存变化不再存在，则回退到“全部”。
 
+配置快照（`/api/config`）与库存快照并行读取；前者偶发失败时按有界退避重试
+（1s / 2s / 4s / 8s），成功后 Tab 并集收敛——已启用但零库存的平台不会因一次
+瞬断而永久缺席。
+
 每个 Tab 显示：
 
 ```text

--- a/src/openbiliclaw/web/desktop/assets/js/app.js
+++ b/src/openbiliclaw/web/desktop/assets/js/app.js
@@ -370,6 +370,42 @@
       }
     }
 
+    let configSnapshotRetryAttempt = 0;
+    let configSnapshotRetryTimer = null;
+    let configSnapshotRecoveryInFlight = false;
+
+    // 配置快照只在水合时读一次；失败被 requestJson 静默吞掉会让筛选行永久缺失
+    // 已启用但零库存的平台（库存快照不会包含这类平台），设置页也拿不到默认值。
+    // 与平台库存一样做有界重试，成功后由后续保存 / 刷新自然接管。
+    function scheduleConfigSnapshotRetry() {
+      if (document.hidden) return;
+      if (state.config) return;
+      if (configSnapshotRetryTimer !== null) return;
+      if (configSnapshotRetryAttempt >= DESKTOP_RECOVERY_DELAYS_MS.length) return;
+      const delayMs = DESKTOP_RECOVERY_DELAYS_MS[configSnapshotRetryAttempt];
+      configSnapshotRetryAttempt += 1;
+      configSnapshotRetryTimer = window.setTimeout(() => {
+        configSnapshotRetryTimer = null;
+        void loadConfigSnapshot();
+      }, delayMs);
+    }
+
+    async function loadConfigSnapshot() {
+      if (configSnapshotRecoveryInFlight) return;
+      configSnapshotRecoveryInFlight = true;
+      try {
+        const snapshot = await requestJson(ENDPOINTS.config);
+        if (!snapshot) {
+          scheduleConfigSnapshotRetry();
+          return;
+        }
+        configSnapshotRetryAttempt = 0;
+        applyConfigSnapshot(snapshot);
+      } finally {
+        configSnapshotRecoveryInFlight = false;
+      }
+    }
+
     async function runBackendHydration() {
       if (document.hidden) {
         backendHydrationPending = true;
@@ -8136,6 +8172,14 @@ ${cardFeedbackBarHtml()}`;
       clearSettingsDirty();
     }
 
+    function applyConfigSnapshot(snapshot) {
+      const configSnapshot = snapshot?.config || snapshot;
+      applyConfig(configSnapshot);
+      presentDegradedConfigRecovery(configSnapshot);
+      renderFilters();
+      syncSourceMetric();
+    }
+
     function normalizeDelight(item) {
       if (!item) return null;
       const canonical = window.OpenBiliClawSavedSync.normalizeSavedItem(item);
@@ -9008,14 +9052,6 @@ ${cardFeedbackBarHtml()}`;
         }
       }
 
-      function applyConfigSnapshot(snapshot) {
-        const configSnapshot = snapshot?.config || snapshot;
-        applyConfig(configSnapshot);
-        presentDegradedConfigRecovery(configSnapshot);
-        renderFilters();
-        syncSourceMetric();
-      }
-
       async function reconcileRuntimeAfterRecommendations() {
         const secondRuntimeGeneration = desktopRuntimeGeneration;
         runtimeReconciliationGeneration = secondRuntimeGeneration;
@@ -9044,7 +9080,9 @@ ${cardFeedbackBarHtml()}`;
       const pingSnapshot = await requestJson(ENDPOINTS.ping);
       applyHealthSnapshot(pingSnapshot);
       if (pingSnapshot?.degraded === true) {
-        applyConfigSnapshot(await requestJson(ENDPOINTS.config));
+        const configSnapshot = await requestJson(ENDPOINTS.config);
+        applyConfigSnapshot(configSnapshot);
+        if (!configSnapshot) scheduleConfigSnapshotRetry();
         return;
       }
 
@@ -9073,7 +9111,7 @@ ${cardFeedbackBarHtml()}`;
         requestJson(ENDPOINTS.notificationPending).then(applyNotificationSnapshot),
         requestJson(`${ENDPOINTS.chatTurns}?session=${encodeURIComponent(SHARED_CHAT_SESSION)}&scope=chat&limit=20`).then(applyChatSnapshot),
         requestJson(`${ENDPOINTS.chatTurns}?session=${encodeURIComponent(SHARED_CHAT_SESSION)}&scope=delight&limit=80`).then(applyDelightChatSnapshot),
-        requestJson(ENDPOINTS.config).then(applyConfigSnapshot),
+        loadConfigSnapshot(),
         refreshPlatformAvailability(),
       ];
 

--- a/src/openbiliclaw/web/desktop/assets/js/app.js
+++ b/src/openbiliclaw/web/desktop/assets/js/app.js
@@ -8858,6 +8858,7 @@ ${cardFeedbackBarHtml()}`;
         desktopRecommendationRecoveryTimer,
         desktopRuntimeRecoveryTimer,
         platformAvailabilityRetryTimer,
+        configSnapshotRetryTimer,
         activityPageRefreshTimer,
       ]) {
         if (timer !== null) window.clearTimeout(timer);
@@ -8866,6 +8867,7 @@ ${cardFeedbackBarHtml()}`;
       desktopRecommendationRecoveryTimer = null;
       desktopRuntimeRecoveryTimer = null;
       platformAvailabilityRetryTimer = null;
+      configSnapshotRetryTimer = null;
       activityPageRefreshTimer = null;
       clearInitPolling();
       const socket = state.runtimeSocket;

--- a/tests/test_desktop_web_background_session.py
+++ b/tests/test_desktop_web_background_session.py
@@ -41,6 +41,7 @@ def test_backgrounding_closes_stream_and_cancels_retry_loops() -> None:
         "desktopRecommendationRecoveryTimer",
         "desktopRuntimeRecoveryTimer",
         "platformAvailabilityRetryTimer",
+        "configSnapshotRetryTimer",
         "activityPageRefreshTimer",
         "desktopRuntimeReconnectTimer",
     ):
@@ -67,6 +68,7 @@ def test_runtime_stream_heartbeat_and_close_use_reconnecting_state() -> None:
 def test_retry_schedulers_are_visibility_gated() -> None:
     for name in (
         "schedulePlatformAvailabilityRetry",
+        "scheduleConfigSnapshotRetry",
         "scheduleDesktopRecommendationRecovery",
         "scheduleDesktopRuntimeRecovery",
         "scheduleInitStatusRefresh",

--- a/tests/test_desktop_web_platform_recommendations_e2e.py
+++ b/tests/test_desktop_web_platform_recommendations_e2e.py
@@ -89,6 +89,7 @@ class PlatformStub:
         self.reshuffle_posts: list[dict[str, Any]] = []
         self.append_posts: list[dict[str, Any]] = []
         self.availability_reads = 0
+        self.config_failures_remaining = 0
         self.lock = threading.Lock()
 
 
@@ -102,11 +103,17 @@ def _json_response(handler: BaseHTTPRequestHandler, payload: Any, status: int = 
         handler.wfile.write(body)
 
 
-@pytest.fixture()
-def platform_server() -> Iterator[tuple[str, PlatformStub]]:
+def _build_platform_app(config_failures: int = 0) -> Iterator[tuple[str, PlatformStub]]:
     state = PlatformStub()
+    state.config_failures_remaining = max(0, int(config_failures))
 
     class Handler(BaseHTTPRequestHandler):
+        # HTTP/1.0 + Connection: close: 水合时会并行发起十几条请求，keep-alive
+        # 连接复用与 ThreadingHTTPServer 的关闭竞态会让其中几条偶发
+        # "TypeError: Failed to fetch"（浏览器侧连接重置）。短连接让每条请求
+        # 独立建连，测试桩的响应时序稳定。
+        protocol_version = "HTTP/1.0"
+
         def log_message(self, format: str, *args: object) -> None:  # noqa: A002
             return
 
@@ -172,6 +179,9 @@ def platform_server() -> Iterator[tuple[str, PlatformStub]]:
                     },
                 )
             if path == "/api/config":
+                if state.config_failures_remaining > 0:
+                    state.config_failures_remaining -= 1
+                    return _json_response(self, {"error": "config_flaky"}, 503)
                 return _json_response(
                     self,
                     {
@@ -250,6 +260,17 @@ def platform_server() -> Iterator[tuple[str, PlatformStub]]:
     finally:
         server.shutdown()
         thread.join(timeout=5)
+
+
+@pytest.fixture()
+def platform_server() -> Iterator[tuple[str, PlatformStub]]:
+    yield from _build_platform_app()
+
+
+@pytest.fixture()
+def flaky_config_server() -> Iterator[tuple[str, PlatformStub]]:
+    """Startup /api/config fails twice, then succeeds (retry recovery path)."""
+    yield from _build_platform_app(config_failures=2)
 
 
 @pytest.fixture()
@@ -334,6 +355,13 @@ def test_platform_tabs_scope_recommendation_requests_in_chromium(
         lambda: all(chip["count"] not in {"", "—"} for chip in _chips(chromium_page)),
         message="库存快照读取后 chip 仍停留在未知态",
     )
+    # /api/config 与库存快照并行读取；配置快照若瞬断，前端有界重试后 Tab 集合
+    # 收敛（已启用但零库存的平台只由配置快照带来）。断言前先等 Tab 并集完整。
+    _wait_for(
+        lambda: {chip["filter"] for chip in _chips(chromium_page)}
+        == {"全部", "B 站", "YouTube", "知乎", "Reddit"},
+        message="已启用平台 Tab 集合未收敛",
+    )
     chips = _chips(chromium_page)
     assert [chip["filter"] for chip in chips] == ["全部", "B 站", "YouTube", "知乎", "Reddit"]
     assert {chip["filter"]: chip["count"] for chip in chips} == {
@@ -399,6 +427,33 @@ def test_platform_tabs_scope_recommendation_requests_in_chromium(
     assert {card["platform"] for card in _visible_cards(chromium_page)} == {"bilibili", "zhihu"}
 
 
+def test_enabled_zero_stock_platform_survives_config_snapshot_retry(
+    flaky_config_server: tuple[str, PlatformStub],
+    chromium_page: Page,
+) -> None:
+    """已启用但零库存的平台在首次 /api/config 失败后仍必须出现（Tab 并集规则）。
+
+    水合时 /api/config 前两次返回 503：筛选行先按库存快照渲染（B 站 / 知乎 /
+    YouTube），Reddit 只能由配置快照带来。有界重试成功后 Reddit Tab 必须补上，
+    且计数显示 0 —— 而不是被永久藏起来。
+    """
+    base_url, stub = flaky_config_server
+    chromium_page.goto(f"{base_url}/web/")
+    expect(chromium_page.locator("#videoGrid .video-card:not(.is-skeleton)")).to_have_count(
+        5, timeout=8000
+    )
+
+    _wait_for(
+        lambda: {chip["filter"] for chip in _chips(chromium_page)}
+        == {"全部", "B 站", "YouTube", "知乎", "Reddit"},
+        timeout=15.0,
+        message="配置快照重试成功后仍缺少已启用平台 Tab",
+    )
+    assert stub.config_failures_remaining == 0
+    counts = {chip["filter"]: chip["count"] for chip in _chips(chromium_page)}
+    assert counts.get("Reddit") == "0"
+
+
 def test_platform_tabs_keyboard_focus_selection_and_no_horizontal_overflow(
     platform_server: tuple[str, PlatformStub],
     chromium_page: Page,
@@ -411,6 +466,13 @@ def test_platform_tabs_keyboard_focus_selection_and_no_horizontal_overflow(
     _wait_for(
         lambda: all(chip["count"] not in {"", "—"} for chip in _chips(chromium_page)),
         message="库存快照读取后 chip 仍停留在未知态",
+    )
+    # /api/config 与库存快照并行读取；配置快照若瞬断，前端有界重试后 Tab 集合
+    # 收敛（已启用但零库存的平台只由配置快照带来）。断言前先等 Tab 并集完整。
+    _wait_for(
+        lambda: {chip["filter"] for chip in _chips(chromium_page)}
+        == {"全部", "B 站", "YouTube", "知乎", "Reddit"},
+        message="已启用平台 Tab 集合未收敛",
     )
 
     row = chromium_page.locator("#filterRow")


### PR DESCRIPTION
## Summary

The desktop web app loads `/api/config` exactly once during hydration. When that single request fails transiently (backend restart, keep-alive reset during the parallel startup burst), `requestJson` silently returned `null` and the platform filter row permanently lost every **enabled-but-zero-stock** platform (e.g. Reddit) until a full page reload — violating the documented Tab union rule (enabled config ∪ stock>0 ∪ loaded cards).

This PR:

- Adds a bounded, visibility-aware retry for the config snapshot (1s/2s/4s/8s), mirroring the existing `platform-availability` recovery pattern. The filter row now converges once the retry succeeds; the settings page also gets its defaults.
- Hoists `applyConfigSnapshot` to module scope so the retry path can reuse it.
- Stabilizes the platform E2E stub: the parallel hydration burst raced with `ThreadingHTTPServer` keep-alive closes, intermittently dropping the config request client-side (`TypeError: Failed to fetch`). The stub now uses HTTP/1.0 short connections, and the two existing tests wait for the full filter union before asserting (the row converges after the config retry).
- Adds a regression test: `/api/config` fails twice with 503, then the row must still converge to `全部 / B 站 / YouTube / 知乎 / Reddit` with Reddit showing `0`.

## Test commands and results

- `pytest tests/test_desktop_web_platform_recommendations_e2e.py` — 3 passed; ran 12 consecutive full-file loops with 0 failures (previously flaky: 1/3 and 1/6 runs failed).
- New regression test run 5 consecutive times — all passed.
- `pytest tests/test_desktop_web_list_stability_e2e.py tests/test_desktop_web_delight_typing_guard.py tests/test_desktop_web_published_time.py tests/test_desktop_web_card_metadata.py` — 21 passed.
- `ruff check src/ tests/` — clean; `node --check` on the edited `app.js` — clean.
- Full `pytest` run: 6922 passed; the only failures are pre-existing environment artifacts unrelated to this change (`ANTHROPIC_BASE_URL` override in the local shell for the Claude default-base-url unit test; E2E flakiness under machine load also reproduced at baseline without this change).

## Docs

- `docs/changelog.md` (v0.3.194 section)
- `docs/superpowers/specs/2026-07-19-platform-scoped-recommendations-design.md` §5.1