### PR TITLE
feat: 深潜研究（Deep Dive）AI 引导的多平台定向检索

### DIFF
--- a/src/openbiliclaw/api/app.py
+++ b/src/openbiliclaw/api/app.py
@@ -4905,17 +4905,18 @@ def create_app(
         xhs_cfg = getattr(getattr(config_obj, "sources", None), "xiaohongshu", None)
         database = getattr(ctx, "database", None)
 
-        def _kick() -> None:
-            """Best-effort wake-up for the extension dispatcher."""
-            from urllib import error, request
+        async def _kick() -> None:
+            """Best-effort wake-up for the extension dispatcher.
 
-            req = request.Request(
-                "http://127.0.0.1:8420/api/sources/xhs/kick",
-                method="POST",
-                data=b"",
-            )
-            with suppress(error.URLError, TimeoutError, OSError):
-                request.urlopen(req, timeout=1.0).close()
+            Broadcasts the same `xhs_task_available` event as the official
+            `/api/sources/xhs/kick` endpoint via the in-process event hub —
+            no HTTP self-call, no hardcoded port, works regardless of the
+            configured server bind address.
+            """
+            publish = getattr(getattr(ctx, "event_hub", None), "publish", None)
+            if callable(publish):
+                with suppress(Exception):
+                    await publish({"type": "xhs_task_available", "source": "deepdive_kick"})
 
         async def _wait_for_task(queue: XhsTaskQueue, task_id: str, wait_seconds: float) -> list[dict]:
             """轮询 xhs_tasks 直到任务完成/失败/超时，返回 notes 列表。"""
@@ -4958,7 +4959,7 @@ def create_app(
                 logger.info("小红书 plugin search skipped: task budget exhausted")
                 return []
             with suppress(Exception):
-                _kick()
+                await _kick()
             notes = await _wait_for_task(
                 queue, task_id, wait_seconds=float(getattr(xhs_cfg, "plugin_wait_seconds", 300.0))
             )

--- a/src/openbiliclaw/api/app.py
+++ b/src/openbiliclaw/api/app.py
@@ -4810,6 +4810,403 @@ def create_app(
             embedding_ready=embedding_ready,
         )
 
+    # ── 深潜研究 API ──────────────────────────────────────────
+    from openbiliclaw.deepdive.session import SessionManager
+    from openbiliclaw.deepdive.engine import DeepDiveEngine
+
+    def _read_enabled_sources() -> list[str]:
+        """读取主站已启用的平台源，深潜研究动态同步。
+
+        每次重新 load_config() 读最新文件——web 设置保存配置后立即生效，
+        ctx.config 是启动快照不会自动更新。
+        """
+        platform_map = {
+            "bilibili": "bilibili",
+            "xiaohongshu": "xhs",
+            "douyin": "douyin",
+            "youtube": "youtube",
+            "twitter": "twitter",
+            "zhihu": "zhihu",
+            "reddit": "reddit",
+            "bangumi": "bangumi",
+        }
+        enabled: list[str] = []
+        try:
+            from openbiliclaw.config import load_config
+            fresh = load_config()
+            sources = getattr(fresh, "sources", None)
+            for cfg_name, short in platform_map.items():
+                section = getattr(sources, cfg_name, None)
+                if section is not None and bool(getattr(section, "enabled", False)):
+                    enabled.append(short)
+        except Exception:
+            logger.exception("读取平台源配置失败")
+        # 兜底：至少 B站
+        if not enabled:
+            enabled = ["bilibili"]
+        return enabled
+
+    def _build_douyin_search_fn() -> Any:
+        """构建抖音搜索回调：plugin 机制（浏览器扩展模拟真实操作）。
+
+        扩展在线时走任务队列真实搜索（规避 direct-cookie 风控）；
+        等不到结果时返回空列表，由引擎兜底链接卡。
+        """
+        from pathlib import Path
+
+        config_obj = getattr(ctx, "config", None)
+        dy_cfg = getattr(getattr(config_obj, "sources", None), "douyin", None)
+
+        async def _search_douyin(keyword: str, *, limit: int = 10) -> list[dict]:
+            if not dy_cfg or not bool(getattr(dy_cfg, "enabled", False)):
+                return []
+            try:
+                from openbiliclaw.sources.douyin_auth import resolve_douyin_cookie
+                from openbiliclaw.sources.douyin_direct import DouyinDirectClient
+                from openbiliclaw.sources.douyin_plugin_search import DouyinPluginSearchClient
+
+                cookie = resolve_douyin_cookie(
+                    data_dir=Path(str(getattr(config_obj, "data_path", "data"))),
+                    cookie_env=str(getattr(dy_cfg, "cookie_env", "OPENBILICLAW_DOUYIN_COOKIE")),
+                )
+                if not cookie:
+                    logger.info("抖音 cookie 缺失，无法 plugin 搜索")
+                    return []
+                async with DouyinDirectClient(cookie=cookie) as direct_client:
+                    client = DouyinPluginSearchClient(
+                        database=getattr(ctx, "database", None),
+                        direct_client=direct_client,
+                        wait_seconds=60.0,  # 等浏览器扩展执行（扩展在线时真实返回）
+                        poll_interval_seconds=0.5,
+                        daily_search_budget=int(getattr(dy_cfg, "daily_search_budget", 0)),
+                    )
+                    return await client.search_aweme(keyword, limit=limit)
+            except Exception as exc:
+                logger.warning("抖音 plugin 搜索构建失败: %s", exc)
+                return []
+
+        return _search_douyin
+
+    def _build_xhs_search_fn() -> Any:
+        """构建小红书搜索回调：扩展任务队列（XhsTaskQueue + 浏览器扩展真实执行）。
+
+        官方小红书内容全部由浏览器扩展抓取（adapter 是 stub，无后端搜索 API）。
+        深潜搜小红书时把关键词入队 xhs_tasks，扩展 claim 后真实搜索并回写
+        notes（含 cover_url/cover_data），轮询取回后返回带封面的笔记。
+        扩展不在线或超时返回空列表，由引擎兜底链接卡。
+        """
+        import asyncio
+        import json
+        from contextlib import suppress
+
+        from openbiliclaw.sources.xhs_tasks import XhsTaskQueue
+
+        config_obj = getattr(ctx, "config", None)
+        xhs_cfg = getattr(getattr(config_obj, "sources", None), "xiaohongshu", None)
+        database = getattr(ctx, "database", None)
+
+        def _kick() -> None:
+            """Best-effort wake-up for the extension dispatcher."""
+            from urllib import error, request
+
+            req = request.Request(
+                "http://127.0.0.1:8420/api/sources/xhs/kick",
+                method="POST",
+                data=b"",
+            )
+            with suppress(error.URLError, TimeoutError, OSError):
+                request.urlopen(req, timeout=1.0).close()
+
+        async def _wait_for_task(queue: XhsTaskQueue, task_id: str, wait_seconds: float) -> list[dict]:
+            """轮询 xhs_tasks 直到任务完成/失败/超时，返回 notes 列表。"""
+            deadline = asyncio.get_running_loop().time() + wait_seconds
+            while True:
+                task = queue.get(task_id)
+                status = str((task or {}).get("status", "")).strip()
+                if status in {"completed", "failed"}:
+                    break
+                if asyncio.get_running_loop().time() >= deadline:
+                    return []
+                await asyncio.sleep(0.5)
+            if not task or task.get("status") != "completed":
+                return []
+            try:
+                result = json.loads(str(task.get("result_json") or "{}"))
+            except json.JSONDecodeError:
+                return []
+            if not isinstance(result, dict):
+                return []
+            notes = result.get("notes", [])
+            return [n for n in notes if isinstance(n, dict)]
+
+        async def _search_xhs(keyword: str, *, limit: int = 10) -> list[dict]:
+            if not xhs_cfg or not bool(getattr(xhs_cfg, "enabled", False)):
+                return []
+            if database is None or not hasattr(database, "conn"):
+                return []
+            try:
+                queue = XhsTaskQueue(database)
+                task_id = queue.enqueue_with_id(
+                    "search",
+                    {"keyword": keyword},
+                    daily_budget=int(getattr(xhs_cfg, "daily_search_budget", 20)),
+                )
+            except Exception as exc:
+                logger.info("小红书 plugin search enqueue failed: %s", exc)
+                return []
+            if not task_id:
+                logger.info("小红书 plugin search skipped: task budget exhausted")
+                return []
+            with suppress(Exception):
+                _kick()
+            notes = await _wait_for_task(
+                queue, task_id, wait_seconds=float(getattr(xhs_cfg, "plugin_wait_seconds", 300.0))
+            )
+            # 规范化：保留封面 URL；扩展有时只回 cover_data（base64），前端会走图片代理
+            items: list[dict] = []
+            for n in notes[:limit]:
+                note_id = str(n.get("note_id") or n.get("content_id") or "").strip()
+                url = str(n.get("url") or "").strip()
+                title = str(n.get("title") or "").strip()
+                if not title and not url:
+                    continue
+                item = {
+                    "title": title,
+                    "url": url,
+                    "author": str(n.get("author") or "").strip(),
+                    "cover_url": str(n.get("cover_url") or "").strip(),
+                    "note_id": note_id,
+                }
+                if n.get("cover_data"):
+                    item["cover_data"] = n["cover_data"]
+                    item["cover_content_type"] = n.get("cover_content_type", "image/webp")
+                items.append(item)
+            return items
+
+        return _search_xhs
+
+    def _sync_engine_platforms() -> None:
+        """每次请求前把最新启用平台同步到引擎（真正动态匹配 web 设置）"""
+        try:
+            _deepdive_engine.enabled_platforms = _read_enabled_sources()
+        except Exception:
+            logger.exception("同步引擎平台白名单失败")
+
+    _deepdive_session_manager = SessionManager(
+        db_path=str(getattr(getattr(ctx, "config", None), "data_path", "data")) + "/deepdive_sessions.db"
+    )
+    _deepdive_enabled_platforms = _read_enabled_sources()
+
+    # ── 深潜 Prompt 自定义（独立 JSON 持久化，不碰 config.toml） ──
+    _deepdive_prompts_path = str(getattr(getattr(ctx, "config", None), "data_path", "data")) + "/deepdive_prompts.json"
+
+    def _load_deepdive_prompts() -> dict[str, str]:
+        """读取自定义 prompt；无文件/字段缺失时返回 {}（engine 用内置默认）"""
+        try:
+            with open(_deepdive_prompts_path, encoding="utf-8") as fh:
+                data = json.load(fh)
+            if not isinstance(data, dict):
+                return {}
+            return {
+                k: str(v).strip()
+                for k, v in data.items()
+                if k in ("plan", "execute", "refine") and isinstance(v, str) and v.strip()
+            }
+        except Exception:
+            return {}
+
+    def _save_deepdive_prompts(prompts: dict[str, str]) -> None:
+        """持久化自定义 prompt 到独立 JSON 文件"""
+        try:
+            with open(_deepdive_prompts_path, "w", encoding="utf-8") as fh:
+                json.dump({k: v for k, v in prompts.items() if k in ("plan", "execute", "refine")}, fh, ensure_ascii=False, indent=2)
+        except Exception:
+            logger.exception("保存深潜 prompt 失败")
+
+    _deepdive_engine = DeepDiveEngine(
+        session_manager=_deepdive_session_manager,
+        llm_service=ctx.llm_service,
+        discovery_engine=ctx.discovery_engine,
+        bilibili_client=ctx.bilibili_client,
+        enabled_platforms=_deepdive_enabled_platforms,
+        data_path=str(getattr(getattr(ctx, "config", None), "data_path", "data")),
+        douyin_search_fn=_build_douyin_search_fn(),
+        xhs_search_fn=_build_xhs_search_fn(),
+        prompts=_load_deepdive_prompts(),
+    )
+
+    @app.post("/api/deepdive/start")
+    async def deepdive_start(body: dict):
+        """开始一次深潜研究"""
+        _sync_engine_platforms()
+        topic = body.get("topic", "").strip()
+        if not topic:
+            return JSONResponse({"error": "topic 不能为空"}, status_code=400)
+        profile = None
+        if ctx.soul_engine is not None:
+            try:
+                profile = await ctx.soul_engine.get_profile()
+            except Exception:
+                pass
+        result = await _deepdive_engine.start_session(topic, profile=profile)
+        return result
+
+    @app.post("/api/deepdive/{session_id}/clarify")
+    async def deepdive_clarify(session_id: str, body: dict):
+        """用户回答澄清问题，开始搜索"""
+        _sync_engine_platforms()
+        user_input = body.get("input", "").strip()
+        if not user_input:
+            return JSONResponse({"error": "input 不能为空"}, status_code=400)
+        result = await _deepdive_engine.clarify(session_id, user_input)
+        if "error" in result:
+            return JSONResponse(result, status_code=404)
+        return result
+
+    @app.post("/api/deepdive/{session_id}/refine")
+    async def deepdive_refine(session_id: str, body: dict):
+        """用户修正搜索方向"""
+        _sync_engine_platforms()
+        refinement = body.get("input", "").strip()
+        if not refinement:
+            return JSONResponse({"error": "input 不能为空"}, status_code=400)
+        result = await _deepdive_engine.refine(session_id, refinement)
+        if "error" in result:
+            return JSONResponse(result, status_code=404)
+        return result
+
+    # ── 深潜 Prompt 自定义 API（必须在 /api/deepdive/{session_id} 之前注册）──
+    from openbiliclaw.deepdive.engine import (
+        DEEP_DIVE_PLAN_PROMPT_TEMPLATE,
+        DEEP_DIVE_EXECUTE_PROMPT_TEMPLATE,
+        DEEP_DIVE_REFINE_PROMPT_TEMPLATE,
+    )
+
+    _DEEP_DIVE_DEFAULT_PROMPTS = {
+        "plan": DEEP_DIVE_PLAN_PROMPT_TEMPLATE,
+        "execute": DEEP_DIVE_EXECUTE_PROMPT_TEMPLATE,
+        "refine": DEEP_DIVE_REFINE_PROMPT_TEMPLATE,
+    }
+
+    @app.get("/api/deepdive/prompts")
+    async def deepdive_get_prompts():
+        """读取深潜 prompt 配置：merged（自定义优先）+ defaults（内置默认）"""
+        custom = _load_deepdive_prompts()
+        merged = {k: custom.get(k) or _DEEP_DIVE_DEFAULT_PROMPTS[k] for k in _DEEP_DIVE_DEFAULT_PROMPTS}
+        return {
+            "prompts": merged,
+            "defaults": dict(_DEEP_DIVE_DEFAULT_PROMPTS),
+            "custom": custom,
+        }
+
+    @app.put("/api/deepdive/prompts")
+    async def deepdive_put_prompts(body: dict):
+        """保存深潜 prompt 配置（仅保存非空字段）并热更新引擎"""
+        custom = _load_deepdive_prompts()
+        changed = False
+        for key in ("plan", "execute", "refine"):
+            val = body.get(key)
+            if isinstance(val, str):
+                val = val.strip()
+                if val:
+                    if custom.get(key) != val:
+                        custom[key] = val
+                        changed = True
+                else:
+                    # 空字符串 = 恢复该字段为默认（从自定义里移除）
+                    if key in custom:
+                        del custom[key]
+                        changed = True
+        if changed:
+            _save_deepdive_prompts(custom)
+            _deepdive_engine.prompts = {
+                k: custom.get(k) or _DEEP_DIVE_DEFAULT_PROMPTS[k] for k in _DEEP_DIVE_DEFAULT_PROMPTS
+            }
+        return {"status": "saved", "custom": custom}
+
+    @app.post("/api/deepdive/prompts/reset")
+    async def deepdive_reset_prompts():
+        """恢复深潜 prompt 为内置默认"""
+        _save_deepdive_prompts({})
+        _deepdive_engine.prompts = dict(_DEEP_DIVE_DEFAULT_PROMPTS)
+        return {"status": "reset", "prompts": dict(_DEEP_DIVE_DEFAULT_PROMPTS)}
+
+    @app.get("/api/deepdive/sessions")
+    async def deepdive_list():
+        """列出所有活跃会话 + 文件夹"""
+        sessions = _deepdive_session_manager.list_sessions()
+        return {
+            "sessions": [
+                _deepdive_engine._session_to_dict(s) for s in sessions
+            ],
+            "folders": _deepdive_session_manager.list_folders(),
+        }
+
+    # ── 深潜文件夹（树形收纳） API ─────────────────────────────
+    @app.post("/api/deepdive/folders")
+    async def deepdive_create_folder(body: dict):
+        """创建文件夹"""
+        name = (body.get("name", "") or "").strip()
+        if not name:
+            return JSONResponse({"error": "name 不能为空"}, status_code=400)
+        ok = _deepdive_session_manager.create_folder(name)
+        if not ok:
+            return JSONResponse({"error": "文件夹已存在或创建失败"}, status_code=409)
+        return {"status": "created", "folders": _deepdive_session_manager.list_folders()}
+
+    @app.patch("/api/deepdive/folders/{name}")
+    async def deepdive_rename_folder(name: str, body: dict):
+        """重命名文件夹"""
+        new_name = (body.get("name", "") or "").strip()
+        ok = _deepdive_session_manager.rename_folder(name, new_name)
+        if not ok:
+            return JSONResponse({"error": "重命名失败（文件夹不存在或新名重复）"}, status_code=404)
+        return {"status": "renamed", "folders": _deepdive_session_manager.list_folders()}
+
+    @app.delete("/api/deepdive/folders/{name}")
+    async def deepdive_delete_folder(name: str):
+        """删除文件夹（归属会话移回根目录）"""
+        ok = _deepdive_session_manager.delete_folder(name)
+        if not ok:
+            return JSONResponse({"error": "文件夹不存在"}, status_code=404)
+        return {"status": "deleted", "folders": _deepdive_session_manager.list_folders()}
+
+    @app.post("/api/deepdive/{session_id}/move")
+    async def deepdive_move_session(session_id: str, body: dict):
+        """把会话移动到文件夹（folder='' 移回根目录）"""
+        folder = (body.get("folder", "") or "").strip()
+        ok = _deepdive_session_manager.move_session(session_id, folder)
+        if not ok:
+            return JSONResponse({"error": "会话不存在"}, status_code=404)
+        return {"status": "moved", "folder": folder}
+
+    @app.get("/api/deepdive/{session_id}")
+    async def deepdive_get(session_id: str):
+        """获取会话状态"""
+        session = _deepdive_session_manager.get_session(session_id)
+        if not session:
+            return JSONResponse({"error": "会话不存在"}, status_code=404)
+        return _deepdive_engine._session_to_dict(session)
+
+    @app.delete("/api/deepdive/{session_id}")
+    async def deepdive_delete(session_id: str):
+        """删除会话"""
+        ok = _deepdive_session_manager.delete_session(session_id)
+        if not ok:
+            return JSONResponse({"error": "会话不存在"}, status_code=404)
+        return {"status": "deleted"}
+
+    @app.patch("/api/deepdive/{session_id}/rename")
+    async def deepdive_rename(session_id: str, body: dict):
+        """重命名会话"""
+        new_name = (body.get("name", "") or "").strip()
+        if not new_name:
+            return JSONResponse({"error": "name 不能为空"}, status_code=400)
+        session = _deepdive_session_manager.rename_session(session_id, new_name)
+        if not session:
+            return JSONResponse({"error": "会话不存在"}, status_code=404)
+        return _deepdive_engine._session_to_dict(session)
+
     @app.get("/api/init-status", response_model=InitStatusOut)
     async def init_status(request: Request) -> InitStatusOut:
         """Authoritative guided-init status + pre-init checklist (gui-init §3).
@@ -7794,6 +8191,7 @@ def create_app(
             author_name=str(row.get("author_name", "")),
             cover_url=str(row.get("cover_url", "")),
             note=str(row.get("note", "")),
+            collection=str(row.get("collection", "")),
             added_at=str(row.get("added_at", "")),
             sync_status=_safe_native_status(row.get("sync_status")),
             sync_task_id=str(row.get("sync_task_id", "")),
@@ -7914,6 +8312,50 @@ def create_app(
             items=[_saved_list_item(row) for row in rows],
             total=_saved_count(list_kind),
         )
+
+    # ── 收藏夹（多选批量分类，复用深潜 folder 模式） ────────────
+    @app.get("/api/saved/{list_kind}/collections")
+    async def saved_collections_list(list_kind: SavedListKind):
+        """列出该列表的收藏夹"""
+        return {"collections": ctx.database.list_saved_collections(list_kind)}
+
+    @app.post("/api/saved/{list_kind}/collections")
+    async def saved_collections_create(list_kind: SavedListKind, body: dict):
+        """创建收藏夹"""
+        name = (body.get("name", "") or "").strip()
+        if not name:
+            return JSONResponse({"error": "name 不能为空"}, status_code=400)
+        ok = ctx.database.create_saved_collection(list_kind, name)
+        if not ok:
+            return JSONResponse({"error": "收藏夹已存在或创建失败"}, status_code=409)
+        return {"status": "created", "collections": ctx.database.list_saved_collections(list_kind)}
+
+    @app.patch("/api/saved/{list_kind}/collections/{name}")
+    async def saved_collections_rename(list_kind: SavedListKind, name: str, body: dict):
+        """重命名收藏夹"""
+        new_name = (body.get("name", "") or "").strip()
+        ok = ctx.database.rename_saved_collection(list_kind, name, new_name)
+        if not ok:
+            return JSONResponse({"error": "重命名失败（不存在或新名重复）"}, status_code=404)
+        return {"status": "renamed", "collections": ctx.database.list_saved_collections(list_kind)}
+
+    @app.delete("/api/saved/{list_kind}/collections/{name}")
+    async def saved_collections_delete(list_kind: SavedListKind, name: str):
+        """删除收藏夹（条目移回未分类）"""
+        ok = ctx.database.delete_saved_collection(list_kind, name)
+        if not ok:
+            return JSONResponse({"error": "收藏夹不存在"}, status_code=404)
+        return {"status": "deleted", "collections": ctx.database.list_saved_collections(list_kind)}
+
+    @app.post("/api/saved/{list_kind}/batch-collection")
+    async def saved_collections_batch(list_kind: SavedListKind, body: dict):
+        """多选批量归类：item_keys → collection"""
+        item_keys = body.get("item_keys") or []
+        collection = (body.get("collection", "") or "").strip()
+        if not isinstance(item_keys, list) or not item_keys:
+            return JSONResponse({"error": "item_keys 不能为空"}, status_code=400)
+        count = ctx.database.batch_set_saved_collection(list_kind, [str(k) for k in item_keys], collection)
+        return {"status": "updated", "count": count, "collection": collection}
 
     @app.post("/api/saved/{list_kind}/sync", response_model=SavedSyncBatchResponse)
     async def saved_sync(
@@ -13482,12 +13924,10 @@ def create_app(
         if native_task is not None:
             return native_task
 
-        # Disabling a source stops automatic discovery immediately, including
-        # tasks that were already pending before the config hot-reload. Keep
-        # them pending so re-enabling can resume rather than silently discard
-        # user-planned work. Explicit native-save jobs above remain available.
-        if not background_tasks_enabled:
-            return Response(status_code=204)
+        # NOTE: 与 dy_next_task 对齐——不检查 scheduler.enabled 全局开关。
+        # scheduler.enabled=false 只应关闭自动发现调度，不应挡住浏览器扩展
+        # 手动 claim 搜索任务（深潜研究等用户主动触发的搜索会被误伤）。
+        # 2026-08-07 修复：移除 background_tasks_enabled 前置检查。
 
         # 204 No Content responses MUST NOT carry a body (RFC 7230).
         # JSONResponse(204, None) serialises None to "null" (4 bytes),

--- a/src/openbiliclaw/api/models.py
+++ b/src/openbiliclaw/api/models.py
@@ -1824,6 +1824,7 @@ class SavedListItem(BaseModel):
     author_name: str = ""
     cover_url: str = ""
     note: str = ""
+    collection: str = ""
     added_at: str = ""
     sync_status: NativeSaveStatusOut = "pending"
     sync_task_id: str = ""

--- a/src/openbiliclaw/deepdive/engine.py
+++ b/src/openbiliclaw/deepdive/engine.py
@@ -1,0 +1,557 @@
+"""深潜研究 · 核心引擎：搜索计划生成 + 搜索执行 + 结果聚合"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from typing import TYPE_CHECKING, Any
+
+from openbiliclaw.deepdive.session import DeepDiveCard, DeepDiveSession, SearchPlan, SessionManager
+
+if TYPE_CHECKING:
+    from openbiliclaw.discovery.engine import ContentDiscoveryEngine
+    from openbiliclaw.llm.service import StructuredTaskService
+    from openbiliclaw.soul.profile import SoulProfile
+
+logger = logging.getLogger(__name__)
+
+# ── LLM Prompt 模板 ──────────────────────────────────────────
+
+DEEP_DIVE_PLAN_PROMPT_TEMPLATE = """你是一个深潜研究助手。用户想深入了解某个领域，请帮他们拟定搜索计划。
+
+## 用户输入
+{topic}
+
+## 用户画像（可供参考）
+{profile_summary}
+
+## 任务
+1. 根据用户输入，生成**澄清问题**（最多 3 个），用来帮助用户细化需求
+2. 根据用户输入，生成**多平台搜索关键词**——只在以下**已启用平台**中选择：
+{enabled_platforms}
+
+## 输出格式
+请严格输出 JSON（不要 markdown 包裹），格式如下：
+{{
+    "topic": "总结后的主题",
+    "clarifying_questions": ["问题1", "问题2", "问题3"],
+    "keywords": [
+        {{"platform": "bilibili", "query": "搜索词1", "type": "video"}},
+        {{"platform": "xhs", "query": "搜索词2", "type": "note"}},
+        {{"platform": "zhihu", "query": "搜索词3", "type": "article"}}
+    ]
+}}
+
+注意：platform 只能从上述已启用平台中选择，不要生成未启用平台的搜索词
+type 可选值：video, note, article, general
+"""
+
+DEEP_DIVE_EXECUTE_PROMPT_TEMPLATE = """你是一个深潜研究助手。用户已经确认了搜索计划，请生成搜索关键词来执行。
+
+## 搜索主题
+{topic}
+
+## 用户补充信息
+{clarification}
+
+## 已启用平台（只能从中选择）
+{enabled_platforms}
+
+## 输出格式
+请严格输出 JSON（不要 markdown 包裹），格式如下：
+{{
+    "keywords": [
+        {{"platform": "bilibili", "query": "搜索词1", "type": "video"}},
+        {{"platform": "xhs", "query": "搜索词2", "type": "note"}}
+    ]
+}}
+"""
+
+DEEP_DIVE_REFINE_PROMPT_TEMPLATE = """用户对当前搜索结果不满意，希望调整方向。
+
+## 当前搜索主题
+{topic}
+
+## 用户修正意见
+{refinement}
+
+## 已启用平台（只能从中选择）
+{enabled_platforms}
+
+## 请基于修正意见，生成新的搜索关键词
+输出格式：
+{{
+    "keywords": [
+        {{"platform": "bilibili", "query": "搜索词1", "type": "video"}},
+        {{"platform": "xhs", "query": "搜索词2", "type": "note"}}
+    ]
+}}
+"""
+
+
+class DeepDiveEngine:
+    """深潜研究引擎"""
+
+    def __init__(
+        self,
+        session_manager: SessionManager,
+        llm_service: Any,  # StructuredTaskService
+        discovery_engine: Any,  # ContentDiscoveryEngine
+        bilibili_client: Any = None,  # BilibiliClient
+        enabled_platforms: list[str] | None = None,  # 已启用平台白名单
+        data_path: str | None = None,  # 数据目录（抖音 cookie 读取用）
+        douyin_search_fn: Any = None,  # 抖音搜索回调（plugin 机制，规避风控）
+        xhs_search_fn: Any = None,  # 小红书搜索回调（扩展任务队列，返回带封面笔记）
+        prompts: dict[str, str] | None = None,  # 自定义 prompt（plan/execute/refine），缺省用内置默认
+    ):
+        self.session_manager = session_manager
+        self.llm_service = llm_service
+        self.discovery_engine = discovery_engine
+        self.bilibili_client = bilibili_client
+        self.enabled_platforms = list(enabled_platforms or [])
+        self.data_path = data_path
+        self.douyin_search_fn = douyin_search_fn
+        self.xhs_search_fn = xhs_search_fn
+        # 生效的 prompt 模板：自定义优先，否则内置默认
+        self.prompts = {
+            "plan": (prompts or {}).get("plan") or DEEP_DIVE_PLAN_PROMPT_TEMPLATE,
+            "execute": (prompts or {}).get("execute") or DEEP_DIVE_EXECUTE_PROMPT_TEMPLATE,
+            "refine": (prompts or {}).get("refine") or DEEP_DIVE_REFINE_PROMPT_TEMPLATE,
+        }
+        self._profile: Any = None
+
+    def _platform_hint(self) -> str:
+        """把已启用平台转成 prompt 提示文本"""
+        names = {
+            "bilibili": "bilibili（B站，视频）",
+            "xhs": "xhs（小红书，笔记）",
+            "zhihu": "zhihu（知乎，文章）",
+            "youtube": "youtube（YouTube，视频）",
+            "douyin": "douyin（抖音，短视频）",
+            "reddit": "reddit（Reddit，帖子）",
+        }
+        if not self.enabled_platforms:
+            return "bilibili（B站）"
+        return "、".join(names.get(p, p) for p in self.enabled_platforms)
+
+    async def start_session(self, topic: str, profile: Any = None) -> dict:
+        """开始新会话：创建 session + 生成澄清问题 + 搜索计划"""
+        self._profile = profile
+        session = self.session_manager.create_session(topic=topic)
+        self.session_manager.set_status(session.id, "clarifying")
+
+        # 生成探索计划
+        plan = await self._generate_plan(topic, profile)
+        self.session_manager.set_plan(session.id, plan)
+
+        # 把澄清问题添加到消息列表
+        for q in plan.clarifying_questions:
+            self.session_manager.add_message(session.id, "assistant", q)
+
+        return self._session_to_dict(session)
+
+    async def clarify(self, session_id: str, user_input: str) -> dict:
+        """用户回答了澄清问题，生成搜索关键词并执行"""
+        session = self.session_manager.get_session(session_id)
+        if not session:
+            return {"error": "会话不存在", "session_id": session_id}
+
+        self.session_manager.add_message(session_id, "user", user_input)
+        self.session_manager.set_status(session_id, "searching")
+
+        plan = session.search_plan
+        if not plan:
+            return {"error": "没有搜索计划", "session_id": session_id}
+
+        # 根据用户澄清生成具体搜索关键词
+        keywords = await self._generate_keywords(plan.topic, user_input)
+        if not keywords:
+            keywords = plan.keywords
+
+        # 执行搜索
+        cards = await self._execute_search(keywords, session)
+        self.session_manager.set_results(session_id, cards)
+
+        return self._session_to_dict(session)
+
+    async def refine(self, session_id: str, refinement: str) -> dict:
+        """用户修正搜索方向，重新搜索"""
+        session = self.session_manager.get_session(session_id)
+        if not session:
+            return {"error": "会话不存在", "session_id": session_id}
+
+        self.session_manager.add_message(session_id, "user", refinement)
+        self.session_manager.set_status(session_id, "searching")
+
+        # 根据修正重新生成关键词
+        plan = session.search_plan
+        if not plan:
+            return {"error": "没有搜索计划", "session_id": session_id}
+
+        keywords = await self._generate_refined_keywords(plan.topic, refinement)
+        if not keywords:
+            # 回退：直接用修正文本作为关键词
+            keywords = [
+                {"platform": "bilibili", "query": refinement, "type": "video"},
+                {"platform": "xhs", "query": refinement, "type": "note"},
+            ]
+
+        # 执行搜索
+        cards = await self._execute_search(keywords, session)
+        self.session_manager.set_results(session_id, cards)
+
+        return self._session_to_dict(session)
+
+    async def _generate_plan(self, topic: str, profile: Any = None) -> SearchPlan:
+        """LLM 生成探索计划"""
+        profile_summary = ""
+        if profile:
+            try:
+                if hasattr(profile, "compact_summary"):
+                    profile_summary = profile.compact_summary()
+                else:
+                    profile_summary = str(profile)[:500]
+            except Exception:
+                profile_summary = ""
+
+        prompt = self.prompts["plan"].format(
+            topic=topic,
+            profile_summary=profile_summary or "（无可用画像）",
+            enabled_platforms=self._platform_hint(),
+        )
+
+        try:
+            result = await self.llm_service.complete_structured_task(
+                system_instruction="你是一个深潜研究助手，输出 JSON。",
+                user_input=prompt,
+                caller="deepdive.plan",
+            )
+            data = self._parse_json_response(getattr(result, "content", result))
+            return SearchPlan(
+                topic=data.get("topic", topic),
+                keywords=data.get("keywords", []),
+                clarifying_questions=data.get("clarifying_questions", []),
+                raw_prompt=prompt,
+            )
+        except Exception as e:
+            logger.warning("LLM 生成探索计划失败: %s，使用默认计划", e)
+            return SearchPlan(
+                topic=topic,
+                keywords=[
+                    {"platform": "bilibili", "query": topic, "type": "video"},
+                    {"platform": "xhs", "query": topic, "type": "note"},
+                ],
+                clarifying_questions=["你想深入了解哪个方面？", "有什么具体需求吗？"],
+            )
+
+    async def _generate_keywords(self, topic: str, clarification: str) -> list[dict]:
+        """LLM 根据用户澄清生成搜索关键词"""
+        prompt = self.prompts["execute"].format(
+            topic=topic,
+            clarification=clarification,
+            enabled_platforms=self._platform_hint(),
+        )
+        try:
+            result = await self.llm_service.complete_structured_task(
+                system_instruction="你是一个深潜研究助手，输出 JSON。",
+                user_input=prompt,
+                caller="deepdive.keywords",
+            )
+            data = self._parse_json_response(getattr(result, "content", result))
+            return data.get("keywords", [])
+        except Exception as e:
+            logger.warning("LLM 生成搜索关键词失败: %s", e)
+            return []
+
+    async def _generate_refined_keywords(self, topic: str, refinement: str) -> list[dict]:
+        """LLM 根据用户修正重新生成搜索关键词"""
+        prompt = self.prompts["refine"].format(
+            topic=topic,
+            refinement=refinement,
+            enabled_platforms=self._platform_hint(),
+        )
+        try:
+            result = await self.llm_service.complete_structured_task(
+                system_instruction="你是一个深潜研究助手，输出 JSON。",
+                user_input=prompt,
+                caller="deepdive.refine",
+            )
+            data = self._parse_json_response(getattr(result, "content", result))
+            return data.get("keywords", [])
+        except Exception as e:
+            logger.warning("LLM 生成修正搜索词失败: %s", e)
+            return []
+
+    async def _execute_search(self, keywords: list[dict], session: DeepDiveSession) -> list[DeepDiveCard]:
+        """执行搜索：对每个关键词调用现有搜索策略，聚合去重 + 平台混合排序"""
+        all_cards: list[DeepDiveCard] = []
+
+        for kw in keywords:
+            platform = kw.get("platform", "bilibili")
+            query = kw.get("query", "")
+            if not query:
+                continue
+
+            try:
+                cards = await self._search_platform(platform, query)
+                all_cards.extend(cards)
+            except Exception as e:
+                logger.warning("平台 %s 搜索 '%s' 失败: %s", platform, query, e)
+
+        # ── 去重（复用主站 discovery/engine 机制） ──────────────
+        # 1. 身份去重：platform:content_id 优先（同一内容多关键词/多平台搜到不重复）
+        # 2. 标题归一化去重：跨平台近似重复内容（复用 _normalize_prompt_text_for_dedupe 去空白）
+        try:
+            from openbiliclaw.discovery.engine import _normalize_prompt_text_for_dedupe
+        except Exception:
+            _normalize_prompt_text_for_dedupe = lambda v: re.sub(r"\s+", "", v).strip()
+
+        by_identity: dict[str, DeepDiveCard] = {}
+        by_title: dict[str, DeepDiveCard] = {}
+        for card in all_cards:
+            # 身份 key：优先内容 ID，其次 url，最后 title+author
+            cid = (card.bvid or "").strip()
+            identity = f"{card.platform}:{cid}" if cid else (card.url or f"{card.platform}:title:{card.title}:{card.author or ''}")
+            existing = by_identity.get(identity)
+            if existing is None or card.score > existing.score:
+                by_identity[identity] = card
+            # 标题归一化 key（跨平台去重）：去空白后的标题
+            title_key = _normalize_prompt_text_for_dedupe(card.title)
+            if title_key:
+                existing_t = by_title.get(title_key)
+                if existing_t is None or card.score > existing_t.score:
+                    by_title[title_key] = card
+
+        merged = list(by_identity.values())
+        # 用标题归一化去重覆盖（保留高分，同标题只留一条）
+        seen_titles: set[str] = set()
+        final_cards: list[DeepDiveCard] = []
+        for card in sorted(merged, key=lambda c: c.score, reverse=True):
+            tk = _normalize_prompt_text_for_dedupe(card.title)
+            if tk and tk in seen_titles:
+                continue
+            if tk:
+                seen_titles.add(tk)
+            final_cards.append(card)
+
+        # ── 平台混合排序（复用主站 _merge_and_rank 思路） ────────
+        # 平台权重：B站/抖音/小红书 真实结果优先，链接卡兜底靠后
+        platform_weight = {"bilibili": 3, "douyin": 2, "xhs": 2, "zhihu": 1, "youtube": 1}
+
+        def _is_link_card(c: DeepDiveCard) -> bool:
+            # 链接卡：无内容 ID 且标题形如「X平台搜索: query」
+            return (not c.bvid) and (":搜索:" in c.title or "搜索:" in c.title)
+
+        def _sort_key(c: DeepDiveCard) -> tuple:
+            return (
+                _is_link_card(c),          # 链接卡排最后
+                -platform_weight.get(c.platform, 1),  # 平台权重
+                -c.score,                   # 原始分
+                c.title or "",
+            )
+
+        final_cards.sort(key=_sort_key)
+        return final_cards[:30]  # 最多返回 30 条
+
+    async def _search_platform(self, platform: str, query: str) -> list[DeepDiveCard]:
+        """搜索单个平台"""
+        cards: list[DeepDiveCard] = []
+
+        def _abs(url: str) -> str:
+            """平台返回协议相对路径（//i0.hdslb.com/...），补全 https:"""
+            url = (url or "").strip()
+            if url.startswith("//"):
+                url = "https:" + url
+            return url
+
+        if platform == "bilibili" and self.bilibili_client is not None:
+            try:
+                results = await self.bilibili_client.search(query, page=1, page_size=10, order="totalrank")
+                for r in (results or []):
+                    bvid = r.get("bvid", "")
+                    cards.append(DeepDiveCard(
+                        platform="bilibili",
+                        title=(r.get("title", "") or "").strip(),
+                        url=f"https://www.bilibili.com/video/{bvid}" if bvid else "",
+                        description=r.get("desc", "") or "",
+                        author=r.get("author", "") or "",
+                        cover_url=_abs(r.get("pic", "")),
+                        published_at=str(r.get("pubdate", "") or ""),
+                        score=float(r.get("score", 0) or 0),
+                        bvid=bvid,
+                    ))
+            except Exception as e:
+                logger.warning("B站搜索 '%s' 失败: %s", query, e)
+            if not cards:
+                cards.append(DeepDiveCard(
+                    platform="bilibili",
+                    title=f"B站搜索: {query}",
+                    url=f"https://search.bilibili.com/all?keyword={query}",
+                    score=0.5,
+                ))
+
+        elif platform == "douyin":
+            # 抖音搜索：优先 plugin 机制（浏览器扩展模拟真实操作，规避 direct-cookie 风控）
+            dy_items: list[dict] = []
+            if self.douyin_search_fn is not None:
+                try:
+                    dy_items = await self.douyin_search_fn(query) or []
+                except Exception as e:
+                    logger.warning("抖音 plugin 搜索 '%s' 失败: %s", query, e)
+            if not dy_items:
+                # 兜底：direct-cookie 搜索
+                try:
+                    from openbiliclaw.sources.douyin_direct import DouyinDirectClient
+                    from openbiliclaw.sources.douyin_auth import resolve_douyin_cookie
+                    from pathlib import Path
+                    cookie = resolve_douyin_cookie(
+                        data_dir=Path(self.data_path),
+                        cookie_env="OPENBILICLAW_DOUYIN_COOKIE",
+                    )
+                    if cookie:
+                        async with DouyinDirectClient(cookie=cookie) as dy_client:
+                            dy_items = await dy_client.search_aweme(query, limit=10)
+                except Exception as e:
+                    logger.warning("抖音 direct 搜索 '%s' 失败: %s", query, e)
+            for r in (dy_items or []):
+                aweme_id = r.get("aweme_id") or r.get("awemeId") or ""
+                title = (r.get("desc") or r.get("title") or "").strip()
+                if not title:
+                    continue
+                author = r.get("author") or {}
+                author_name = author.get("nickname") if isinstance(author, dict) else str(author or "")
+                video = r.get("video") or {}
+                cover = r.get("cover") or (video.get("cover") if isinstance(video, dict) else "") or ""
+                # plugin 返回的 cover 可能是 {"url_list": [...]} 结构，取第一个真实 URL
+                if isinstance(cover, dict):
+                    url_list = cover.get("url_list") or cover.get("urlList") or []
+                    cover = url_list[0] if url_list else ""
+                elif isinstance(cover, str) and cover.strip().startswith("{") and "url_list" in cover:
+                    # 已字符串化的 dict（如 "{'url_list': [...]}"），尝试解析
+                    try:
+                        import ast
+                        parsed = ast.literal_eval(cover)
+                        if isinstance(parsed, dict):
+                            url_list = parsed.get("url_list") or parsed.get("urlList") or []
+                            cover = url_list[0] if url_list else ""
+                    except Exception:
+                        pass
+                cards.append(DeepDiveCard(
+                    platform="douyin",
+                    title=title,
+                    url=f"https://www.douyin.com/video/{aweme_id}" if aweme_id else "",
+                    description=title,
+                    author=author_name,
+                    cover_url=_abs(str(cover)),
+                    score=1.0,
+                    bvid=aweme_id,
+                ))
+            if not cards:
+                cards.append(DeepDiveCard(
+                    platform="douyin",
+                    title=f"抖音搜索: {query}",
+                    url=f"https://www.douyin.com/search/{query}",
+                    score=0.4,
+                    description="",
+                ))
+
+        elif platform == "xhs":
+            # 小红书搜索：优先扩展任务队列（XhsTaskQueue + 浏览器扩展真实执行，返回带封面笔记）
+            if self.xhs_search_fn is not None:
+                try:
+                    xhs_items = await self.xhs_search_fn(query) or []
+                except Exception as e:
+                    logger.warning("小红书 plugin 搜索 '%s' 失败: %s", query, e)
+                    xhs_items = []
+                for r in xhs_items:
+                    title = (r.get("title") or "").strip()
+                    if not title:
+                        continue
+                    cards.append(DeepDiveCard(
+                        platform="xhs",
+                        title=title,
+                        url=_abs(r.get("url", "")),
+                        description=(r.get("desc") or r.get("description") or "") or "",
+                        author=r.get("author") or "",
+                        cover_url=_abs(r.get("cover_url", "")),
+                        score=float(r.get("score", 0.8) or 0.8),
+                        bvid=r.get("note_id") or r.get("content_id") or "",
+                    ))
+                if cards:
+                    return cards
+            # 兜底：链接卡
+            cards.append(DeepDiveCard(
+                platform="xhs",
+                title=f"小红书搜索: {query}",
+                url=f"https://www.xiaohongshu.com/search_result?keyword={query}",
+                score=0.4,
+                description="",
+            ))
+
+        elif platform == "zhihu":
+            cards.append(DeepDiveCard(
+                platform="zhihu",
+                title=f"知乎搜索: {query}",
+                url=f"https://www.zhihu.com/search?type=content&q={query}",
+                score=0.4,
+                description="",
+            ))
+
+        elif platform == "youtube":
+            cards.append(DeepDiveCard(
+                platform="youtube",
+                title=f"YouTube搜索: {query}",
+                url=f"https://www.youtube.com/results?search_query={query}",
+                score=0.4,
+                description="",
+            ))
+
+        return cards
+
+    def _parse_json_response(self, result: Any) -> dict:
+        """解析 LLM 返回的 JSON"""
+        if isinstance(result, dict):
+            return result
+        text = str(result)
+        # 尝试去掉 markdown 包裹
+        if "```json" in text:
+            text = text.split("```json")[1].split("```")[0]
+        elif "```" in text:
+            text = text.split("```")[1].split("```")[0]
+        return json.loads(text.strip())
+
+    def _session_to_dict(self, session: DeepDiveSession) -> dict:
+        """将会话转换为字典（API 返回用）"""
+        return {
+            "id": session.id,
+            "topic": session.topic,
+            "status": session.status,
+            "folder": session.folder or "",
+            "messages": [
+                {"role": m.role, "content": m.content, "timestamp": m.timestamp}
+                for m in session.messages
+            ],
+            "search_plan": {
+                "topic": session.search_plan.topic if session.search_plan else "",
+                "keywords": session.search_plan.keywords if session.search_plan else [],
+                "clarifying_questions": session.search_plan.clarifying_questions if session.search_plan else [],
+                "raw_prompt": session.search_plan.raw_prompt if session.search_plan else "",
+            } if session.search_plan else None,
+            "results": [
+                {
+                    "platform": c.platform,
+                    "title": c.title,
+                    "url": c.url,
+                    "description": c.description,
+                    "author": c.author,
+                    "cover_url": c.cover_url,
+                    "published_at": c.published_at,
+                    "score": c.score,
+                    "bvid": c.bvid,
+                }
+                for c in session.results
+            ],
+            "created_at": session.created_at,
+            "updated_at": session.updated_at,
+        }

--- a/src/openbiliclaw/deepdive/session.py
+++ b/src/openbiliclaw/deepdive/session.py
@@ -1,0 +1,349 @@
+"""深潜研究 · 会话管理器（SQLite 持久化）"""
+
+from __future__ import annotations
+
+import json
+import threading
+import uuid
+from dataclasses import dataclass, field, asdict
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+@dataclass
+class SearchPlan:
+    """搜索计划：LLM 生成的结构化搜索方案"""
+    topic: str
+    keywords: list[dict[str, str]]  # [{platform, query, type}, ...]
+    clarifying_questions: list[str]  # 需要用户确认的问题
+    raw_prompt: str = ""
+
+    def to_dict(self) -> dict:
+        return {
+            "topic": self.topic,
+            "keywords": self.keywords,
+            "clarifying_questions": self.clarifying_questions,
+            "raw_prompt": self.raw_prompt,
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict | None) -> "SearchPlan | None":
+        if not d:
+            return None
+        return cls(
+            topic=d.get("topic", ""),
+            keywords=d.get("keywords", []) or [],
+            clarifying_questions=d.get("clarifying_questions", []) or [],
+            raw_prompt=d.get("raw_prompt", ""),
+        )
+
+
+@dataclass
+class DeepDiveMessage:
+    """会话中的一条消息"""
+    role: str  # "user" | "assistant" | "system"
+    content: str
+    timestamp: str = field(default_factory=_now)
+
+    def to_dict(self) -> dict:
+        return {"role": self.role, "content": self.content, "timestamp": self.timestamp}
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "DeepDiveMessage":
+        return cls(role=d.get("role", ""), content=d.get("content", ""), timestamp=d.get("timestamp", _now()))
+
+
+@dataclass
+class DeepDiveCard:
+    """搜索结果卡片"""
+    platform: str
+    title: str
+    url: str
+    description: str = ""
+    author: str | None = None
+    cover_url: str | None = None
+    published_at: str | None = None
+    score: float = 0.0
+    bvid: str = ""  # 内容 ID（反馈用）
+
+    def to_dict(self) -> dict:
+        return {
+            "platform": self.platform,
+            "title": self.title,
+            "url": self.url,
+            "description": self.description,
+            "author": self.author,
+            "cover_url": self.cover_url,
+            "published_at": self.published_at,
+            "score": self.score,
+            "bvid": self.bvid,
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "DeepDiveCard":
+        return cls(
+            platform=d.get("platform", ""),
+            title=d.get("title", ""),
+            url=d.get("url", ""),
+            description=d.get("description", ""),
+            author=d.get("author"),
+            cover_url=d.get("cover_url"),
+            published_at=d.get("published_at"),
+            score=float(d.get("score", 0) or 0),
+            bvid=d.get("bvid", ""),
+        )
+
+
+@dataclass
+class DeepDiveSession:
+    """一个深潜研究会话"""
+    id: str = field(default_factory=lambda: uuid.uuid4().hex[:12])
+    topic: str = ""
+    status: str = "initial"  # initial | clarifying | planning | searching | displaying | completed
+    messages: list[DeepDiveMessage] = field(default_factory=list)
+    search_plan: SearchPlan | None = None
+    results: list[DeepDiveCard] = field(default_factory=list)
+    folder: str = ""  # 所属文件夹名（空 = 根目录）
+    created_at: str = field(default_factory=_now)
+    updated_at: str = field(default_factory=_now)
+
+
+class SessionManager:
+    """SQLite 持久化会话管理器
+
+    会话数据永久保存到本地 SQLite 文件（默认 data/deepdive_sessions.db），
+    重启服务后会话不丢失。支持创建、读取、删除、重命名、列出。
+    """
+
+    def __init__(self, db_path: str | Path | None = None):
+        self._db_path = Path(db_path) if db_path else Path("data/deepdive_sessions.db")
+        self._db_path.parent.mkdir(parents=True, exist_ok=True)
+        self._lock = threading.Lock()
+        self._init_db()
+
+    # ── 数据库 ──────────────────────────────────────────────
+    def _connect(self):
+        import sqlite3
+        con = sqlite3.connect(str(self._db_path))
+        con.row_factory = sqlite3.Row
+        con.execute("PRAGMA journal_mode=WAL")
+        return con
+
+    def _init_db(self) -> None:
+        with self._lock, self._connect() as con:
+            con.execute("""
+                CREATE TABLE IF NOT EXISTS deepdive_sessions (
+                    id          TEXT PRIMARY KEY,
+                    topic       TEXT NOT NULL DEFAULT '',
+                    status      TEXT NOT NULL DEFAULT 'initial',
+                    messages    TEXT NOT NULL DEFAULT '[]',
+                    search_plan TEXT,
+                    results     TEXT NOT NULL DEFAULT '[]',
+                    folder      TEXT NOT NULL DEFAULT '',
+                    created_at  TEXT NOT NULL,
+                    updated_at  TEXT NOT NULL
+                )
+            """)
+            con.execute("""
+                CREATE TABLE IF NOT EXISTS deepdive_folders (
+                    name       TEXT PRIMARY KEY,
+                    created_at TEXT NOT NULL
+                )
+            """)
+            # 兼容旧库：给已存在的表补 folder 列（若缺）
+            cols = [r[1] for r in con.execute("PRAGMA table_info(deepdive_sessions)").fetchall()]
+            if "folder" not in cols:
+                con.execute("ALTER TABLE deepdive_sessions ADD COLUMN folder TEXT NOT NULL DEFAULT ''")
+
+    def _serialize(self, session: DeepDiveSession) -> tuple:
+        return (
+            session.id,
+            session.topic,
+            session.status,
+            json.dumps([m.to_dict() for m in session.messages], ensure_ascii=False),
+            json.dumps(session.search_plan.to_dict(), ensure_ascii=False) if session.search_plan else None,
+            json.dumps([c.to_dict() for c in session.results], ensure_ascii=False),
+            session.folder,
+            session.created_at,
+            session.updated_at,
+        )
+
+    def _deserialize(self, row) -> DeepDiveSession:
+        msgs = json.loads(row["messages"] or "[]")
+        results = json.loads(row["results"] or "[]")
+        plan = row["search_plan"]
+        return DeepDiveSession(
+            id=row["id"],
+            topic=row["topic"],
+            status=row["status"],
+            messages=[DeepDiveMessage.from_dict(m) for m in msgs],
+            search_plan=SearchPlan.from_dict(json.loads(plan)) if plan else None,
+            results=[DeepDiveCard.from_dict(c) for c in results],
+            folder=row["folder"] or "",
+            created_at=row["created_at"],
+            updated_at=row["updated_at"],
+        )
+
+    def _write(self, session: DeepDiveSession) -> None:
+        with self._lock, self._connect() as con:
+            con.execute(
+                """INSERT INTO deepdive_sessions
+                   (id, topic, status, messages, search_plan, results, folder, created_at, updated_at)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                   ON CONFLICT(id) DO UPDATE SET
+                    topic=excluded.topic, status=excluded.status, messages=excluded.messages,
+                    search_plan=excluded.search_plan, results=excluded.results, folder=excluded.folder,
+                    updated_at=excluded.updated_at""",
+                self._serialize(session),
+            )
+
+    # ── CRUD ────────────────────────────────────────────────
+    def create_session(self, topic: str = "") -> DeepDiveSession:
+        """创建新会话（写入磁盘）"""
+        session = DeepDiveSession(topic=topic)
+        if topic:
+            session.messages.append(DeepDiveMessage(role="user", content=topic))
+        self._write(session)
+        return session
+
+    def get_session(self, session_id: str) -> DeepDiveSession | None:
+        """获取会话"""
+        with self._lock, self._connect() as con:
+            row = con.execute(
+                "SELECT * FROM deepdive_sessions WHERE id = ?", (session_id,)
+            ).fetchone()
+        return self._deserialize(row) if row else None
+
+    def delete_session(self, session_id: str) -> bool:
+        """删除会话（从磁盘删除）"""
+        with self._lock, self._connect() as con:
+            cur = con.execute("DELETE FROM deepdive_sessions WHERE id = ?", (session_id,))
+        return cur.rowcount > 0
+
+    def rename_session(self, session_id: str, new_name: str) -> DeepDiveSession | None:
+        """重命名会话 topic"""
+        session = self.get_session(session_id)
+        if not session:
+            return None
+        session.topic = (new_name or "").strip()
+        session.updated_at = _now()
+        self._write(session)
+        return session
+
+    def list_sessions(self) -> list[DeepDiveSession]:
+        """列出所有会话（最新在前）"""
+        with self._lock, self._connect() as con:
+            rows = con.execute(
+                "SELECT * FROM deepdive_sessions ORDER BY updated_at DESC"
+            ).fetchall()
+        return [self._deserialize(r) for r in rows]
+
+    def add_message(self, session_id: str, role: str, content: str) -> DeepDiveMessage | None:
+        """添加消息（写盘）"""
+        session = self.get_session(session_id)
+        if not session:
+            return None
+        msg = DeepDiveMessage(role=role, content=content)
+        session.messages.append(msg)
+        session.updated_at = _now()
+        self._write(session)
+        return msg
+
+    def set_plan(self, session_id: str, plan: SearchPlan) -> bool:
+        """设置搜索计划"""
+        session = self.get_session(session_id)
+        if not session:
+            return False
+        session.search_plan = plan
+        session.status = "planning"
+        session.updated_at = _now()
+        self._write(session)
+        return True
+
+    def set_results(self, session_id: str, results: list[DeepDiveCard]) -> bool:
+        """设置搜索结果"""
+        session = self.get_session(session_id)
+        if not session:
+            return False
+        session.results = results
+        session.status = "displaying"
+        session.updated_at = _now()
+        self._write(session)
+        return True
+
+    def set_status(self, session_id: str, status: str) -> bool:
+        """更新会话状态"""
+        session = self.get_session(session_id)
+        if not session:
+            return False
+        session.status = status
+        session.updated_at = _now()
+        self._write(session)
+        return True
+
+    # ── 文件夹（树形收纳） ────────────────────────────────────
+    def create_folder(self, name: str) -> bool:
+        """创建文件夹（已存在返回 False）"""
+        name = (name or "").strip()
+        if not name:
+            return False
+        with self._lock, self._connect() as con:
+            try:
+                con.execute(
+                    "INSERT INTO deepdive_folders (name, created_at) VALUES (?, ?)",
+                    (name, _now()),
+                )
+                return True
+            except Exception:
+                return False
+
+    def list_folders(self) -> list[str]:
+        """列出所有文件夹名"""
+        with self._lock, self._connect() as con:
+            rows = con.execute("SELECT name FROM deepdive_folders ORDER BY created_at").fetchall()
+        return [r["name"] for r in rows]
+
+    def rename_folder(self, old_name: str, new_name: str) -> bool:
+        """重命名文件夹：更新 folders 表 + 更新归属会话的 folder 字段"""
+        old_name = (old_name or "").strip()
+        new_name = (new_name or "").strip()
+        if not old_name or not new_name or old_name == new_name:
+            return False
+        with self._lock, self._connect() as con:
+            cur = con.execute(
+                "UPDATE deepdive_folders SET name = ? WHERE name = ?", (new_name, old_name)
+            )
+            if cur.rowcount == 0:
+                return False
+            con.execute(
+                "UPDATE deepdive_sessions SET folder = ? WHERE folder = ?", (new_name, old_name)
+            )
+        return True
+
+    def delete_folder(self, name: str) -> bool:
+        """删除文件夹：移除 folders 记录 + 把归属会话移回根目录"""
+        name = (name or "").strip()
+        if not name:
+            return False
+        with self._lock, self._connect() as con:
+            cur = con.execute("DELETE FROM deepdive_folders WHERE name = ?", (name,))
+            if cur.rowcount == 0:
+                return False
+            con.execute("UPDATE deepdive_sessions SET folder = '' WHERE folder = ?", (name,))
+        return True
+
+    def move_session(self, session_id: str, folder: str) -> bool:
+        """把会话移动到指定文件夹（folder='' 移回根目录）"""
+        session = self.get_session(session_id)
+        if not session:
+            return False
+        session.folder = (folder or "").strip()
+        session.updated_at = _now()
+        self._write(session)
+        return True
+        return True

--- a/src/openbiliclaw/runtime/image_cache.py
+++ b/src/openbiliclaw/runtime/image_cache.py
@@ -279,6 +279,7 @@ def cleanup_image_cache(
 
 ALLOWED_IMAGE_HOST_SUFFIXES: tuple[str, ...] = (
     "hdslb.com",
+    "biliimg.com",
     "xhscdn.com",
     "pstatp.com",
     "douyinpic.com",

--- a/src/openbiliclaw/storage/database.py
+++ b/src/openbiliclaw/storage/database.py
@@ -16427,8 +16427,15 @@ class Database:
                 list_kind TEXT NOT NULL CHECK (list_kind IN ('favorite', 'watch_later')),
                 item_key  TEXT NOT NULL REFERENCES saved_items(item_key) ON DELETE CASCADE,
                 note      TEXT NOT NULL DEFAULT '',
+                collection TEXT NOT NULL DEFAULT '',
                 added_at  TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
                 PRIMARY KEY (list_kind, item_key)
+            );
+            CREATE TABLE IF NOT EXISTS saved_collections (
+                list_kind  TEXT NOT NULL CHECK (list_kind IN ('favorite', 'watch_later')),
+                name       TEXT NOT NULL,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                PRIMARY KEY (list_kind, name)
             );
             CREATE INDEX IF NOT EXISTS idx_saved_memberships_item_key
                 ON saved_memberships(item_key);
@@ -16522,6 +16529,20 @@ class Database:
                 applied_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
             );
         """)
+        # 兼容旧库：saved_memberships 补 collection 列 + 建 saved_collections 表
+        membership_cols = {
+            str(row["name"])
+            for row in self.conn.execute("PRAGMA table_info(saved_memberships)").fetchall()
+        }
+        if "collection" not in membership_cols:
+            self.conn.execute(
+                "ALTER TABLE saved_memberships ADD COLUMN collection TEXT NOT NULL DEFAULT ''"
+            )
+        # collection 列就绪后再建索引（旧库升级时列不存在会导致 CREATE INDEX 失败）
+        self.conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_saved_memberships_collection "
+            "ON saved_memberships(list_kind, collection)"
+        )
         native_state_columns = {
             str(row["name"])
             for row in self.conn.execute("PRAGMA table_info(native_save_states)").fetchall()
@@ -17160,6 +17181,7 @@ class Database:
                 i.updated_at,
                 m.note,
                 m.added_at,
+                m.collection,
                 COALESCE(n.requested_action, '') AS requested_action,
                 COALESCE(n.resolved_action, '') AS resolved_action,
                 COALESCE(n.resolved_target, '') AS resolved_target,
@@ -17351,6 +17373,84 @@ class Database:
             (normalized_kind, limit, offset),
         ).fetchall()
         return [dict(row) for row in rows]
+
+    # ── 收藏夹（多选批量分类，复用深潜 folder 模式） ─────────────
+    def list_saved_collections(self, list_kind: str) -> list[str]:
+        """列出某列表（favorite/watch_later）的收藏夹名"""
+        normalized_kind = self._saved_list_kind(list_kind)
+        rows = self.conn.execute(
+            "SELECT name FROM saved_collections WHERE list_kind = ? ORDER BY created_at",
+            (normalized_kind,),
+        ).fetchall()
+        return [str(row["name"]) for row in rows]
+
+    def create_saved_collection(self, list_kind: str, name: str) -> bool:
+        """创建收藏夹（已存在返回 False）"""
+        normalized_kind = self._saved_list_kind(list_kind)
+        cleaned = name.strip()
+        if not cleaned:
+            return False
+        try:
+            self.conn.execute(
+                "INSERT INTO saved_collections (list_kind, name) VALUES (?, ?)",
+                (normalized_kind, cleaned),
+            )
+            return True
+        except Exception:
+            return False
+
+    def rename_saved_collection(self, list_kind: str, old_name: str, new_name: str) -> bool:
+        """重命名收藏夹：更新 collections 表 + 同步归属条目的 collection 字段"""
+        normalized_kind = self._saved_list_kind(list_kind)
+        old_name = old_name.strip()
+        new_name = new_name.strip()
+        if not old_name or not new_name or old_name == new_name:
+            return False
+        cursor = self.conn.execute(
+            "UPDATE saved_collections SET name = ? WHERE list_kind = ? AND name = ?",
+            (new_name, normalized_kind, old_name),
+        )
+        if int(cursor.rowcount or 0) == 0:
+            return False
+        self.conn.execute(
+            "UPDATE saved_memberships SET collection = ? WHERE list_kind = ? AND collection = ?",
+            (new_name, normalized_kind, old_name),
+        )
+        return True
+
+    def delete_saved_collection(self, list_kind: str, name: str) -> bool:
+        """删除收藏夹：移除记录 + 条目移回未分类（collection=''）"""
+        normalized_kind = self._saved_list_kind(list_kind)
+        cleaned = name.strip()
+        if not cleaned:
+            return False
+        cursor = self.conn.execute(
+            "DELETE FROM saved_collections WHERE list_kind = ? AND name = ?",
+            (normalized_kind, cleaned),
+        )
+        if int(cursor.rowcount or 0) == 0:
+            return False
+        self.conn.execute(
+            "UPDATE saved_memberships SET collection = '' WHERE list_kind = ? AND collection = ?",
+            (normalized_kind, cleaned),
+        )
+        return True
+
+    def batch_set_saved_collection(
+        self, list_kind: str, item_keys: list[str], collection: str
+    ) -> int:
+        """多选批量归类：把多个条目设置到同一收藏夹（''=移回未分类）"""
+        normalized_kind = self._saved_list_kind(list_kind)
+        keys = [k.strip() for k in item_keys if k and k.strip()]
+        if not keys:
+            return 0
+        target = collection.strip()
+        placeholders = ",".join("?" for _ in keys)
+        cursor = self.conn.execute(
+            f"UPDATE saved_memberships SET collection = ? WHERE list_kind = ? AND item_key IN ({placeholders})",
+            (target, normalized_kind, *keys),
+        )
+        return int(cursor.rowcount or 0)
 
     def upsert_native_save_state(
         self,

--- a/src/openbiliclaw/web/desktop/index.html
+++ b/src/openbiliclaw/web/desktop/index.html
@@ -167,6 +167,8 @@
     .saved-batch-count { font-size: 12.5px; color: var(--fg, #e6e8ee); font-weight: 600; }
     .saved-batch-target { background: var(--surface-2, #232733); color: var(--fg, #e6e8ee); border: 1px solid var(--border-soft, #2d3340); border-radius: 8px; padding: 5px 8px; font-size: 12.5px; }
     .saved-batch-target:focus { outline: none; border-color: var(--accent, #6c8cff); }
+    /* ── 主站首页卡片反馈后自动消失（dislike/dismiss 10s 生效） ── */
+    .video-card.fs-removing { opacity: 0; transform: scale(0.94); transition: opacity .25s ease, transform .25s ease; }
   </style>
 </head>
 <body>
@@ -3053,6 +3055,48 @@
         });
       }
     }, true);  // 捕获阶段：先于 app.js 的 bubble 阶段 handler
+  })();
+</script>
+<script>
+  // ── 主站首页卡片：点踩/忽略 10s 生效后自动消失（复用深潜交互） ──
+  // 主站首页的 pendingActions 在 512KB bundle 闭包内，无法直接接 committed 回调。
+  // 用 MutationObserver 监听卡片 .status-line 文本：当变成 committed 文案
+  // （「已记录不感兴趣/已忽略这条推荐，下次刷新列表时会隐藏」）时，卡片渐隐移除。
+  (function() {
+    var COMMITTED_MARKERS = ["下次刷新列表时会隐藏", "会用于优化画像"];
+    var grid = document.getElementById("videoGrid");
+    if (!grid) return;
+
+    function removeCard(card) {
+      if (!card || card.dataset.fsRemoving) return;
+      card.dataset.fsRemoving = "1";
+      card.classList.add("fs-removing");
+      window.setTimeout(function() {
+        if (card.isConnected) card.remove();
+      }, 260);  // 配合 CSS transition .25s
+    }
+
+    function scanStatusLines() {
+      grid.querySelectorAll(".video-card .status-line").forEach(function(status) {
+        var text = (status.textContent || "").trim();
+        for (var i = 0; i < COMMITTED_MARKERS.length; i++) {
+          if (text.indexOf(COMMITTED_MARKERS[i]) !== -1) {
+            var card = status.closest(".video-card");
+            removeCard(card);
+            break;
+          }
+        }
+      });
+    }
+
+    // 观察子节点变化（点踩/忽略提交后 status-line 文本更新）
+    var obs = new MutationObserver(function() {
+      scanStatusLines();
+    });
+    obs.observe(grid, { childList: true, subtree: true, characterData: true });
+
+    // 首次扫描（已加载的卡片）
+    scanStatusLines();
   })();
 </script>
 </body></html>

--- a/src/openbiliclaw/web/desktop/index.html
+++ b/src/openbiliclaw/web/desktop/index.html
@@ -167,6 +167,13 @@
     .saved-batch-count { font-size: 12.5px; color: var(--fg, #e6e8ee); font-weight: 600; }
     .saved-batch-target { background: var(--surface-2, #232733); color: var(--fg, #e6e8ee); border: 1px solid var(--border-soft, #2d3340); border-radius: 8px; padding: 5px 8px; font-size: 12.5px; }
     .saved-batch-target:focus { outline: none; border-color: var(--accent, #6c8cff); }
+    /* ── 收藏夹 tab：hover 显示 ✎重命名 / ✕删除 ── */
+    .saved-collection-tab { position: relative; display: inline-flex; align-items: center; gap: 4px; }
+    .saved-collection-ops { display: none; align-items: center; gap: 2px; }
+    .saved-collection-tab:hover .saved-collection-ops { display: inline-flex; }
+    .saved-collection-op { background: transparent; border: none; color: var(--fg-dim, #9aa3b2); font-size: 12px; line-height: 1; padding: 1px 3px; border-radius: 4px; cursor: pointer; }
+    .saved-collection-op:hover { background: var(--surface-2, #232733); color: var(--fg, #e6e8ee); }
+    .saved-collection-del:hover { color: #ff6b6b; }
     /* ── 主站首页卡片反馈后自动消失（dislike/dismiss 10s 生效） ── */
     .video-card.fs-removing { opacity: 0; transform: scale(0.94); transition: opacity .25s ease, transform .25s ease; }
   </style>
@@ -2712,25 +2719,18 @@
         tabs.appendChild(un);
         collections.forEach(function(name) {
           var b = document.createElement("button");
-          b.type = "button"; b.className = "pill-btn" + (activeFilter[listKind] === name ? " active" : "");
-          b.textContent = name;
-          b.title = "重命名：右键 / 删除：双击";
-          b.addEventListener("click", function() {
-            activeFilter[listKind] = name;
-            refreshCollections(listKind);
-            applyFilter(listKind);
-          });
-          b.addEventListener("dblclick", function(e) {
-            e.stopPropagation();
-            if (!window.confirm("删除收藏夹「" + name + "」？其中的内容会移回未分类。")) return;
-            api("/" + listKind + "/collections/" + encodeURIComponent(name), { method: "DELETE" }).then(function() {
-              if (activeFilter[listKind] === name) activeFilter[listKind] = "";
-              refreshCollections(listKind);
-              refreshList(listKind);
-            });
-          });
-          b.addEventListener("contextmenu", function(e) {
-            e.preventDefault();
+          b.type = "button"; b.className = "pill-btn saved-collection-tab" + (activeFilter[listKind] === name ? " active" : "");
+          b.title = "点击筛选";
+          // 文件夹名字 span + 操作按钮组（hover 显示）
+          var nameSpan = document.createElement("span");
+          nameSpan.className = "saved-collection-name";
+          nameSpan.textContent = name;
+          var ops = document.createElement("span");
+          ops.className = "saved-collection-ops";
+          var renameBtn = document.createElement("button");
+          renameBtn.type = "button"; renameBtn.className = "saved-collection-op"; renameBtn.title = "重命名";
+          renameBtn.textContent = "✎";
+          renameBtn.addEventListener("click", function(e) {
             e.stopPropagation();
             var newName = window.prompt("重命名收藏夹：", name);
             if (!newName) return;
@@ -2741,6 +2741,28 @@
               refreshCollections(listKind);
               refreshList(listKind);
             });
+          });
+          var delBtn = document.createElement("button");
+          delBtn.type = "button"; delBtn.className = "saved-collection-op saved-collection-del"; delBtn.title = "删除收藏夹";
+          delBtn.textContent = "✕";
+          delBtn.addEventListener("click", function(e) {
+            e.stopPropagation();
+            if (!window.confirm("删除收藏夹「" + name + "」？其中的内容会移回未分类。")) return;
+            api("/" + listKind + "/collections/" + encodeURIComponent(name), { method: "DELETE" }).then(function() {
+              if (activeFilter[listKind] === name) activeFilter[listKind] = "";
+              refreshCollections(listKind);
+              refreshList(listKind);
+            });
+          });
+          ops.appendChild(renameBtn);
+          ops.appendChild(delBtn);
+          b.appendChild(nameSpan);
+          b.appendChild(ops);
+          b.addEventListener("click", function(e) {
+            if (e.target.closest(".saved-collection-ops")) return;
+            activeFilter[listKind] = name;
+            refreshCollections(listKind);
+            applyFilter(listKind);
           });
           tabs.appendChild(b);
         });

--- a/src/openbiliclaw/web/desktop/index.html
+++ b/src/openbiliclaw/web/desktop/index.html
@@ -2161,7 +2161,8 @@
             }
             if (commentInput) commentInput.value = '';
             closeComposer();
-            status.textContent = '已提交聊天线索，卡片会保留在当前结果。';
+            status.textContent = '已发起对话，AI 回复会出现在对话面板。';
+            // 1) 记录 feedback 事件（画像/信号，与主 Web 一致）
             fetch('/api/events', {
               method: 'POST',
               headers: {'Content-Type': 'application/json'},
@@ -2175,10 +2176,35 @@
                 metadata: { feedback_type: 'comment', bvid: c.bvid || '', content_id: c.bvid || '', feedback_note: note }
               }]})
             }).then(function(r) {
-              if (!r.ok) throw new Error('反馈提交失败');
+              if (!r.ok) throw new Error('反馈记录失败');
               return r.json();
             }).catch(function(err) {
-              status.textContent = err.message || '反馈提交失败';
+              // 反馈记录失败不阻塞对话发起
+              console.warn('深潜聊一聊 feedback 记录失败:', err.message);
+            });
+            // 2) 创建对话 turn（session=popup 与主 Web 共享），触发 AI 回复
+            fetch('/api/chat/turns', {
+              method: 'POST',
+              headers: {'Content-Type': 'application/json'},
+              body: JSON.stringify({
+                session: 'popup',
+                scope: 'chat',
+                message: note,
+                subject_id: c.bvid || '',
+                subject_title: c.title || ''
+              })
+            }).then(function(r) {
+              if (!r.ok) return r.json().then(function(e) { throw new Error(e.detail || e.error || '对话发起失败'); });
+              return r.json();
+            }).then(function(turn) {
+              status.textContent = '已发起对话，AI 回复会出现在对话面板。';
+              if (turn && turn.turn_id) {
+                // 尝试切换到共享对话面板查看回复（若主 Web 存在该面板）
+                var panel = document.querySelector('#chatPage, [data-page="chat"]');
+                if (panel && typeof openChatPage === 'function') openChatPage();
+              }
+            }).catch(function(err) {
+              status.textContent = err.message || '对话发起失败';
             });
           } else {
             openComposer();

--- a/src/openbiliclaw/web/desktop/index.html
+++ b/src/openbiliclaw/web/desktop/index.html
@@ -32,6 +32,142 @@
   </script>
   <link rel="stylesheet" href="/web/assets/css/app.css">
   <link rel="stylesheet" href="/web/assets/css/classic.css">
+  <style>
+    /* 深潜研究 · 内嵌样式（跟随主站主题变量） */
+    .deepdive-page { width: 100%; max-width: 100%; display: flex; gap: 0; height: 100%; min-height: 0; }
+    /* 平台占位封面（无真实封面时显示） */
+    .platform-ph { display: flex; align-items: center; justify-content: center; width: 100%; height: 100%; min-height: 120px; font-weight: 800; letter-spacing: 0.05em; color: rgba(255,255,255,0.9); font-size: 1.1rem; }
+    .platform-ph span { opacity: 0.92; text-shadow: 0 1px 3px rgba(0,0,0,0.25); }
+    .platform-ph-xhs { background: linear-gradient(135deg, #ff2e4d, #ff6b81); }
+    .platform-ph-zhihu { background: linear-gradient(135deg, #0066ff, #4d94ff); }
+    .platform-ph-douyin { background: linear-gradient(135deg, #170b1d, #2a1a3a); }
+    .platform-ph-youtube { background: linear-gradient(135deg, #cc0000, #ff4d4d); }
+    .platform-ph-bilibili { background: linear-gradient(135deg, #fb7299, #fc9eb5); }
+    .platform-ph-x { background: linear-gradient(135deg, #444, #666); }
+    .deepdive-main { flex: 1; min-width: 0; overflow-y: auto; padding-right: var(--space-4, 16px); }
+    .deepdive-side { width: 360px; flex-shrink: 0; display: flex; flex-direction: column; border-left: 1px solid var(--border-soft, #2d3340); transition: width .2s, opacity .2s; overflow: hidden; }
+    .deepdive-side.collapsed { width: 0; border-left: none; opacity: 0; pointer-events: none; }
+    .deepdive-side-head { display: flex; align-items: center; justify-content: space-between; padding: var(--space-2, 8px) var(--space-3, 12px); border-bottom: 1px solid var(--border-soft, #2d3340); flex-shrink: 0; }
+    .deepdive-side-head h3 { font-size: 14px; font-weight: 600; }
+    .deepdive-side-toggle { background: none; border: none; color: var(--fg-dim, #9aa3b2); cursor: pointer; font-size: 12px; padding: 4px 8px; border-radius: 6px; }
+    .deepdive-side-toggle:hover { background: var(--surface-2, #232733); color: var(--fg, #e6e8ee); }
+    .deepdive-side-log { flex: 1; overflow-y: auto; padding: var(--space-2, 8px); display: flex; flex-direction: column; gap: 8px; }
+    .deepdive-side-log .msg { max-width: 92%; padding: 8px 12px; border-radius: var(--radius-md, 12px); font-size: 13px; line-height: 1.5; white-space: pre-wrap; word-break: break-word; }
+    .deepdive-side-log .msg.user { align-self: flex-end; background: var(--accent, #6c8cff); color: #fff; border-bottom-right-radius: 4px; }
+    .deepdive-side-log .msg.assistant { align-self: flex-start; background: var(--surface, #1a1d24); border: 1px solid var(--border-soft, #2d3340); border-bottom-left-radius: 4px; }
+    .deepdive-side-log .msg.system { align-self: center; background: transparent; color: var(--fg-dim, #9aa3b2); font-size: 11px; }
+    .deepdive-side-input { display: flex; gap: 8px; padding: var(--space-2, 8px) 0 0; margin-top: 6px; flex-shrink: 0; }
+    .deepdive-side-input input { flex: 1; background: var(--surface, #1a1d24); border: 1px solid var(--border-soft, #2d3340); color: var(--fg, #e6e8ee); padding: 8px 12px; border-radius: 8px; font-size: 13px; outline: none; min-width: 0; }
+    .deepdive-side-input input:focus { border-color: var(--accent, #6c8cff); }
+    .deepdive-side-input button { background: var(--accent, #6c8cff); color: #fff; border: none; padding: 8px 14px; border-radius: 8px; font-size: 13px; cursor: pointer; flex-shrink: 0; }
+    .deepdive-side-input button:disabled { opacity: 0.5; cursor: default; }
+    .deepdive-hist-fold { text-align: center; }
+    .deepdive-hist-fold button { background: none; border: 1px dashed var(--border-soft, #2d3340); color: var(--fg-dim, #9aa3b2); font-size: 11.5px; padding: 4px 12px; border-radius: 14px; cursor: pointer; }
+    .deepdive-hist-fold button:hover { color: var(--accent, #6c8cff); border-color: var(--accent, #6c8cff); }
+    .deepdive-typing { color: var(--fg-dim, #9aa3b2); font-size: 12px; padding: 4px 8px; }
+    .deepdive-typing::after { content: "…"; animation: deepdive-blink 1s infinite; }
+    @keyframes deepdive-blink { 50% { opacity: 0.2; } }
+    .deepdive-empty { display: flex; flex-direction: column; align-items: center; justify-content: center; min-height: 300px; color: var(--fg-dim, #9aa3b2); text-align: center; gap: 8px; }
+    .deepdive-empty .icon { font-size: 36px; }
+    /* 搜索结果卡片在 video-card 基础上微调 */
+    .deepdive-card-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(300px, 1fr)); gap: var(--space-4, 16px); margin-top: var(--space-3, 12px); }
+    .deepdive-card-grid .video-card { cursor: pointer; }
+    .deepdive-card-grid .video-card .cover { cursor: pointer; }
+    /* 右侧面板折叠按钮浮动 */
+    .deepdive-side.collapsed + .deepdive-side-float { display: flex; }
+    .deepdive-side-float { display: none; position: absolute; right: 0; top: 0; z-index: 10; }
+    .deepdive-side-float button { writing-mode: vertical-lr; padding: 12px 6px; background: var(--surface, #1a1d24); border: 1px solid var(--border-soft, #2d3340); border-right: none; border-radius: 8px 0 0 8px; color: var(--fg-dim, #9aa3b2); cursor: pointer; font-size: 12px; }
+    .deepdive-side-float button:hover { color: var(--accent, #6c8cff); }
+    .deepdive-side-wrap { position: relative; display: flex; }
+    .deepdive-filter-row { display: flex; gap: 8px; flex-wrap: wrap; margin: var(--space-2, 8px) 0; }
+    .deepdive-filter-row .pill-btn { font-size: 12px; padding: 4px 12px; }
+    .deepdive-sessions-bar { display: flex; flex-direction: column; gap: 4px; margin-bottom: var(--space-2, 8px); }
+    .deepdive-tree-root { display: flex; flex-direction: column; gap: 4px; }
+    .deepdive-tree-folder { display: flex; flex-direction: column; }
+    .deepdive-folder-row { display: flex; align-items: center; gap: 4px; padding: 3px 8px; border-radius: 8px; cursor: pointer; font-size: 11.5px; font-weight: 600; color: var(--fg-2, #c4c9d4); background: var(--surface-2, #232733); }
+    .deepdive-folder-row:hover { background: var(--surface-3, #2a2f3a); }
+    .deepdive-folder-toggle { display: inline-flex; width: 14px; justify-content: center; color: var(--fg-dim, #9aa3b2); transition: transform .15s; }
+    .deepdive-folder-toggle.collapsed { transform: rotate(-90deg); }
+    .deepdive-folder-icon { margin-right: 2px; }
+    .deepdive-folder-name { flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+    .deepdive-folder-count { color: var(--fg-dim, #9aa3b2); font-size: 10px; }
+    .deepdive-folder-op { background: none; border: none; color: var(--fg-dim, #9aa3b2); cursor: pointer; font-size: 11px; padding: 0 2px; border-radius: 4px; line-height: 1; opacity: 0; transition: opacity .15s; }
+    .deepdive-folder-row:hover .deepdive-folder-op { opacity: 1; }
+    .deepdive-folder-op:hover { color: var(--accent, #6c8cff); }
+    .deepdive-folder-op.del:hover { color: #ff6b6b; }
+    .deepdive-tree-folder-body { display: flex; flex-direction: column; gap: 3px; margin: 2px 0 2px 16px; padding-left: 8px; border-left: 1px solid var(--border-soft, #2d3340); }
+    .deepdive-tree-folder-body.collapsed { display: none; }
+    .deepdive-tree-toolbar { display: flex; align-items: center; gap: 6px; padding: 2px 4px 4px; }
+    .deepdive-tree-toolbar button { background: none; border: 1px dashed var(--border-soft, #2d3340); color: var(--fg-dim, #9aa3b2); font-size: 11px; padding: 2px 10px; border-radius: 12px; cursor: pointer; }
+    .deepdive-tree-toolbar button:hover { color: var(--accent, #6c8cff); border-color: var(--accent, #6c8cff); }
+    .deepdive-session-chip { background: var(--surface, #1a1d24); border: 1px solid var(--border-soft, #2d3340); color: var(--fg-dim, #9aa3b2); padding: 3px 10px; border-radius: 16px; font-size: 11px; cursor: pointer; }
+    .deepdive-session-chip.active { border-color: var(--accent, #6c8cff); color: var(--fg, #e6e8ee); }
+    .deepdive-session-chip { display: inline-flex; align-items: center; gap: 2px; width: fit-content; }
+    .deepdive-session-name { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; max-width: 130px; }
+    .deepdive-session-op { background: none; border: none; color: var(--fg-dim, #9aa3b2); cursor: pointer; font-size: 11px; padding: 0 2px; border-radius: 4px; line-height: 1; opacity: 0; transition: opacity .15s; }
+    .deepdive-session-chip:hover .deepdive-session-op { opacity: 1; }
+    .deepdive-session-op:hover { color: var(--accent, #6c8cff); }
+    .deepdive-session-op.deepdive-session-del:hover { color: #ff6b6b; }
+    /* 移动端：全屏对话 */
+    @media (max-width: 820px) {
+      .deepdive-page { flex-direction: column; }
+      .deepdive-main { display: none; }
+      .deepdive-main.mobile-visible { display: block; }
+      .deepdive-side { width: 100%; border-left: none; }
+      .deepdive-side.mobile-hidden { display: none; }
+      .deepdive-side-head .deepdive-side-toggle { display: none; }
+      .deepdive-mobile-back { display: inline-flex; }
+      .deepdive-mobile-chat-btn { display: inline-flex; }
+      .deepdive-side-head { justify-content: flex-start; gap: 8px; }
+      .deepdive-side-head h3 { margin-right: auto; }
+    }
+    .deepdive-mobile-back { display: none; background: none; border: 1px solid var(--border-soft, #2d3340); color: var(--fg-dim, #9aa3b2); cursor: pointer; font-size: 13px; padding: 4px 10px; border-radius: 6px; align-items: center; }
+    .deepdive-mobile-back:hover { color: var(--accent, #6c8cff); border-color: var(--accent, #6c8cff); }
+    .deepdive-mobile-chat-btn { display: none; background: var(--surface, #1a1d24); border: 1px solid var(--border-soft, #2d3340); color: var(--fg-dim, #9aa3b2); cursor: pointer; font-size: 13px; padding: 6px 12px; border-radius: 16px; align-items: center; }
+    .deepdive-mobile-chat-btn:hover { color: var(--accent, #6c8cff); border-color: var(--accent, #6c8cff); }
+    /* ── 卡片详情弹窗（毛玻璃 · 防误点跳转） ── */
+    .card-detail-overlay { position: fixed; inset: 0; z-index: 9999; display: flex; align-items: center; justify-content: center; padding: clamp(12px, 3vw, 32px); background: color-mix(in oklab, var(--bg, #14161c), transparent 22%); backdrop-filter: blur(22px) saturate(1.3); -webkit-backdrop-filter: blur(22px) saturate(1.3); animation: card-detail-fade .18s var(--ease-standard, ease); }
+    .card-detail-overlay.is-closing { animation: card-detail-fade-out .16s var(--ease-standard, ease) forwards; }
+    @keyframes card-detail-fade { from { opacity: 0; } to { opacity: 1; } }
+    @keyframes card-detail-fade-out { from { opacity: 1; } to { opacity: 0; } }
+    .card-detail-modal { position: relative; width: min(520px, 100%); max-height: calc(100vh - 64px); overflow: auto; background: var(--surface, #1a1d24); border: 1px solid var(--border-soft, #2d3340); border-radius: 20px; box-shadow: var(--elev-raised, 0 18px 60px rgba(0,0,0,0.5)); animation: card-detail-pop .22s var(--ease-standard, ease); }
+    .card-detail-overlay.is-closing .card-detail-modal { animation: card-detail-pop-out .16s var(--ease-standard, ease) forwards; }
+    @keyframes card-detail-pop { from { opacity: 0; transform: translateY(14px) scale(.97); } to { opacity: 1; transform: none; } }
+    @keyframes card-detail-pop-out { from { opacity: 1; transform: none; } to { opacity: 0; transform: translateY(10px) scale(.98); } }
+    .card-detail-cover { position: relative; aspect-ratio: 16/9; background: var(--surface-2, #232733); border-radius: 20px 20px 0 0; overflow: hidden; }
+    .card-detail-cover img { width: 100%; height: 100%; object-fit: cover; display: block; }
+    .card-detail-cover .platform-badge { position: absolute; top: 12px; left: 12px; padding: 3px 10px; border-radius: 999px; background: color-mix(in oklab, var(--bg, #14161c), transparent 30%); color: var(--fg, #e6e8ee); font-size: 12px; font-weight: 600; backdrop-filter: blur(6px); -webkit-backdrop-filter: blur(6px); border: 1px solid color-mix(in oklab, var(--border-soft, #2d3340), transparent 20%); }
+    .card-detail-body { padding: 18px 20px 16px; }
+    .card-detail-title { font-size: 16px; font-weight: 700; line-height: 1.45; color: var(--fg, #e6e8ee); margin: 0 0 8px; }
+    .card-detail-author { font-size: 13px; color: var(--fg-dim, #9aa3b2); margin: 0 0 10px; }
+    .card-detail-desc { font-size: 13px; line-height: 1.6; color: var(--fg-2, #c4c9d4); margin: 0 0 14px; white-space: pre-wrap; word-break: break-word; max-height: 120px; overflow: auto; }
+    .card-detail-actions { display: flex; align-items: center; justify-content: space-between; gap: 10px; border-top: 1px solid var(--border-soft, #2d3340); padding-top: 14px; }
+    .card-detail-hint { font-size: 12px; color: var(--fg-dim, #9aa3b2); }
+    .card-detail-actions .card-detail-open-btn { background: var(--accent, #6c8cff); color: #fff; border: none; padding: 8px 16px; border-radius: 10px; font-size: 13px; font-weight: 600; cursor: pointer; transition: background .15s, transform .1s; }
+    .card-detail-actions .card-detail-open-btn:hover { background: var(--accent-strong, #5a7bf0); }
+    .card-detail-actions .card-detail-open-btn:active { transform: scale(.97); }
+    .card-detail-close { position: absolute; top: 10px; right: 10px; z-index: 2; width: 32px; height: 32px; display: flex; align-items: center; justify-content: center; background: color-mix(in oklab, var(--bg, #14161c), transparent 25%); border: 1px solid color-mix(in oklab, var(--border-soft, #2d3340), transparent 20%); border-radius: 50%; color: var(--fg, #e6e8ee); font-size: 16px; cursor: pointer; backdrop-filter: blur(6px); -webkit-backdrop-filter: blur(6px); }
+    .card-detail-close:hover { background: color-mix(in oklab, var(--bg, #14161c), transparent 10%); }
+    /* ── 深潜 Prompt 设置（设置页 · 高级功能） ── */
+    #deepdivePlanPrompt, #deepdiveExecutePrompt, #deepdiveRefinePrompt { width: 100%; min-height: 72px; resize: vertical; padding: 8px 10px; border: 1px solid var(--border-soft, #2d3340); border-radius: 8px; background: var(--surface-2, #232733); color: var(--fg, #e6e8ee); font: inherit; font-size: 12.5px; line-height: 1.55; }
+    #deepdivePlanPrompt:focus, #deepdiveExecutePrompt:focus, #deepdiveRefinePrompt:focus { outline: none; border-color: var(--accent, #6c8cff); }
+    .settings-advanced-actions { display: flex; gap: 8px; align-items: center; }
+    /* ── 收藏夹（多选批量分类） ── */
+    .saved-collections-bar { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; margin: 8px 0; }
+    .saved-collections-tabs { display: flex; gap: 6px; flex-wrap: wrap; }
+    .saved-collections-tabs .pill-btn { font-size: 12px; padding: 3px 10px; }
+    .saved-collections-tabs .pill-btn.active { border-color: var(--accent, #6c8cff); color: var(--accent, #6c8cff); }
+    .saved-card { position: relative; }
+    .saved-card.is-selecting .saved-select-box { display: flex; }
+    .saved-select-box { display: none; position: absolute; top: 8px; left: 8px; z-index: 5; width: 22px; height: 22px; align-items: center; justify-content: center; background: color-mix(in oklab, var(--bg, #14161c), transparent 20%); border: 2px solid var(--fg-dim, #9aa3b2); border-radius: 6px; cursor: pointer; backdrop-filter: blur(4px); }
+    .saved-select-box.checked { background: var(--accent, #6c8cff); border-color: var(--accent, #6c8cff); }
+    .saved-select-box.checked::after { content: "✓"; color: #fff; font-size: 13px; font-weight: 800; }
+    .saved-card.is-selected { outline: 2px solid var(--accent, #6c8cff); outline-offset: -2px; }
+    .saved-batch-bar { display: flex; align-items: center; gap: 10px; margin: 10px 0; padding: 8px 12px; border: 1px solid var(--border-soft, #2d3340); border-radius: 10px; background: var(--surface, #1a1d24); }
+    .saved-batch-count { font-size: 12.5px; color: var(--fg, #e6e8ee); font-weight: 600; }
+    .saved-batch-target { background: var(--surface-2, #232733); color: var(--fg, #e6e8ee); border: 1px solid var(--border-soft, #2d3340); border-radius: 8px; padding: 5px 8px; font-size: 12.5px; }
+    .saved-batch-target:focus { outline: none; border-color: var(--accent, #6c8cff); }
+  </style>
 </head>
 <body>
   <div class="app-shell">
@@ -96,6 +232,9 @@
           <nav class="side-drawer-nav" aria-label="全局功能">
           <button class="nav-action" id="homeBtn" type="button"><span class="nav-glyph"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg></span><span>首页</span></button>
           <button class="nav-action" id="contentLibraryBtn" type="button"><span class="nav-glyph"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4 5.5A2.5 2.5 0 0 1 6.5 3H10l2 2h5.5A2.5 2.5 0 0 1 20 7.5v9A2.5 2.5 0 0 1 17.5 19h-11A2.5 2.5 0 0 1 4 16.5z"/><path d="M8 10h8M8 14h6"/></svg></span><span>内容库</span></button>
+          <button class="nav-action" id="deepdiveBtn" type="button" onclick="openDeepDivePage()"><span class="nav-glyph"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/><line x1="11" y1="8" x2="11" y2="14"/><line x1="8" y1="11" x2="14" y2="11"/></svg></span><span>深潜研究</span></button>
+          <button class="nav-action" id="watchLaterBtn" type="button"><span class="nav-glyph"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg></span><span>稍后再看</span><span class="nav-count-badge" id="watchLaterCountBadge" hidden></span></button>
+          <button class="nav-action" id="favoritesBtn" type="button"><span class="nav-glyph"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/></svg></span><span>我的收藏</span><span class="nav-count-badge" id="favoritesCountBadge" hidden></span></button>
           <button class="nav-action" id="profileBtn" type="button"><span class="nav-glyph"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4 7h3a1 1 0 0 0 1 -1v-1a2 2 0 0 1 4 0v1a1 1 0 0 0 1 1h3a1 1 0 0 1 1 1v3a1 1 0 0 0 1 1h1a2 2 0 0 1 0 4h-1a1 1 0 0 0 -1 1v3a1 1 0 0 1 -1 1h-3a1 1 0 0 1 -1 -1v-1a2 2 0 0 0 -4 0v1a1 1 0 0 1 -1 1h-3a1 1 0 0 1 -1 -1v-3a1 1 0 0 1 1 -1h1a2 2 0 0 0 0 -4h-1a1 1 0 0 1 -1 -1v-3a1 1 0 0 1 1 -1"/></svg></span><span>我的画像</span></button>
           <button class="nav-action" id="chatBtn" type="button"><span class="nav-glyph"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg></span><span>聊聊口味</span><span class="nav-count-badge" id="chatPendingCountBadge" hidden></span></button>
           <button class="nav-action" id="settingsBtn" type="button"><span class="nav-glyph"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg></span><span>设置</span></button>
@@ -235,6 +374,17 @@
           </div>
           <button class="pill-btn" id="watchLaterSyncAll" data-saved-list-action="sync-all" type="button" disabled hidden>同步未同步内容（0）</button>
         </div>
+        <div class="saved-collections-bar" id="watchLaterCollectionsBar" data-collections-for="watch_later">
+          <button class="pill-btn saved-collections-multi" type="button">☑ 多选</button>
+          <button class="pill-btn saved-collections-add" type="button">＋ 新建收藏夹</button>
+          <div class="saved-collections-tabs" role="tablist" aria-label="收藏夹筛选"></div>
+          <div class="saved-batch-bar" id="watchLaterBatchBar" hidden>
+            <span class="saved-batch-count">已选 0 项</span>
+            <select class="saved-batch-target" aria-label="目标收藏夹"><option value="">未分类</option></select>
+            <button class="pill-btn primary saved-batch-apply" type="button">批量归类</button>
+            <button class="pill-btn saved-batch-cancel" type="button">取消</button>
+          </div>
+        </div>
         <p class="saved-sync-status" id="watchLaterSyncStatus" aria-live="polite"></p>
         <div class="saved-grid" id="watchLaterList"></div>
         <div class="saved-empty" id="watchLaterEmpty" hidden>还没有稍后再看的内容，去推荐里点时钟图标加入吧。</div>
@@ -248,6 +398,17 @@
             <p class="video-meta">点 ★ 收藏的内容会长期留在这里，和稍后再看互相独立。</p>
           </div>
           <button class="pill-btn" id="favoritesSyncAll" data-saved-list-action="sync-all" type="button" disabled hidden>同步未同步内容（0）</button>
+        </div>
+        <div class="saved-collections-bar" id="favoritesCollectionsBar" data-collections-for="favorite">
+          <button class="pill-btn saved-collections-multi" type="button">☑ 多选</button>
+          <button class="pill-btn saved-collections-add" type="button">＋ 新建收藏夹</button>
+          <div class="saved-collections-tabs" role="tablist" aria-label="收藏夹筛选"></div>
+          <div class="saved-batch-bar" id="favoritesBatchBar" hidden>
+            <span class="saved-batch-count">已选 0 项</span>
+            <select class="saved-batch-target" aria-label="目标收藏夹"><option value="">未分类</option></select>
+            <button class="pill-btn primary saved-batch-apply" type="button">批量归类</button>
+            <button class="pill-btn saved-batch-cancel" type="button">取消</button>
+          </div>
         </div>
         <p class="saved-sync-status" id="favoritesSyncStatus" aria-live="polite"></p>
         <div class="saved-grid" id="favoritesList"></div>
@@ -1151,6 +1312,24 @@
             </div>
             <p class="settings-note-inline">经典：仅用合并关键词生成器；混合：在经典基础上再叠加 search-backed 灵感轴链路（最丰富，但同时跑两套，混合最贵）；灵感：完全用灵感轴链路替代经典。</p>
           </section>
+
+          <section class="settings-advanced-section" aria-labelledby="advancedDeepDiveHeading">
+            <div class="settings-advanced-section-head">
+              <p class="settings-section-kicker">Deep Dive prompts</p>
+              <h3 id="advancedDeepDiveHeading">深潜探索</h3>
+            </div>
+            <p class="settings-note-inline">自定义深潜研究的 AI 提示词。三个模板分别用于：生成探索计划（plan）、根据澄清执行搜索（execute）、根据用户修正调整方向（refine）。模板中的 <code>{topic}</code>、<code>{enabled_platforms}</code> 等占位符会被自动替换。保存后立即生效。</p>
+            <div class="settings-advanced-fields">
+              <label class="settings-field full"><span>plan 提示词（生成搜索计划）</span><textarea id="deepdivePlanPrompt" rows="5" spellcheck="false" placeholder="内置默认提示词"></textarea></label>
+              <label class="settings-field full"><span>execute 提示词（执行搜索）</span><textarea id="deepdiveExecutePrompt" rows="4" spellcheck="false" placeholder="内置默认提示词"></textarea></label>
+              <label class="settings-field full"><span>refine 提示词（修正方向）</span><textarea id="deepdiveRefinePrompt" rows="4" spellcheck="false" placeholder="内置默认提示词"></textarea></label>
+              <p class="settings-probe-status" id="deepdivePromptsStatus" aria-live="polite"></p>
+              <div class="settings-advanced-actions">
+                <button class="pill-btn primary" id="deepdivePromptsSave" type="button">保存深潜提示词</button>
+                <button class="pill-btn" id="deepdivePromptsReset" type="button">恢复默认提示词</button>
+              </div>
+            </div>
+          </section>
         </div>
 
         <div id="settingsPanelGeneral" class="settings-panel" data-settings-panel="general" role="tabpanel" aria-labelledby="settingsTabGeneral" hidden>
@@ -1306,6 +1485,49 @@
           </span>
         </div>
       </form>
+      </section>
+
+      <section class="chat-page content-page deepdive-page" id="deepdivePage" aria-label="深潜研究" hidden>
+        <div class="deepdive-main">
+          <div class="content-page-head">
+            <div>
+              <p class="eyebrow">Deep Dive</p>
+              <h2>深潜研究</h2>
+              <p class="video-meta">主动探索一个方向，AI 引导你澄清需求，然后跨平台搜集整理。</p>
+            </div>
+            <button class="pill-btn" id="deepdiveNewBtn" type="button">＋ 新建探索</button>
+            <button class="deepdive-mobile-chat-btn" id="deepdiveMobileChatBtn" type="button">💬 对话</button>
+          </div>
+          <div class="deepdive-sessions-bar" id="deepdiveSessionsBar" aria-label="活跃探索会话"></div>
+          <div class="deepdive-filter-row" id="deepdiveFilterRow" role="tablist" aria-label="搜索平台筛选"></div>
+          <div class="deepdive-empty" id="deepdiveEmpty">
+            <div class="icon">🔍</div>
+            <p>还没有搜索结果</p>
+            <p class="video-meta">在右侧输入探索方向，AI 会跨平台搜集整理</p>
+          </div>
+          <div class="deepdive-card-grid" id="deepdiveCardGrid" hidden></div>
+        </div>
+        <div class="deepdive-side-wrap">
+          <aside class="deepdive-side" id="deepdiveSide" aria-label="AI 引导对话">
+            <div class="deepdive-side-head">
+              <button class="deepdive-mobile-back" id="deepdiveMobileBack" type="button" title="查看结果卡片">‹ 结果</button>
+              <h3>💬 AI 引导</h3>
+              <button class="deepdive-side-toggle" id="deepdiveSideToggle" type="button" title="收起聊天面板">收起 ›</button>
+            </div>
+            <div class="deepdive-side-log" id="deepdiveSideLog" role="region" aria-label="AI 引导对话记录" tabindex="0">
+              <div class="deepdive-hist-fold" id="deepdiveHistFold" hidden>
+                <button type="button" id="deepdiveHistExpandBtn">↑ 展开更早对话</button>
+              </div>
+              <form class="deepdive-side-input" id="deepdiveSideForm">
+                <input id="deepdiveSideInput" aria-label="输入想探索的方向" placeholder="想深入了解什么？例如：新疆旅游攻略 / 学习 AE…">
+                <button type="submit" id="deepdiveSideSend">发送</button>
+              </form>
+            </div>
+          </aside>
+          <div class="deepdive-side-float" id="deepdiveSideFloat">
+            <button id="deepdiveSideOpen" type="button" title="展开聊天面板">打开对话 ‹</button>
+          </div>
+        </div>
       </section>
 
       <div class="llm-instance-dialog" id="llmInstanceDialog" role="dialog" aria-modal="true" aria-labelledby="llmInstanceDialogTitle" hidden>
@@ -1474,4 +1696,1363 @@
   <script src="/shared/dialogue-confirmation.js" defer></script>
   <script src="/shared/source-status.js" defer></script>
   <script src="/web/assets/js/app.js" defer></script>
+<script>
+  // ── 深潜研究 · 页面切换与交互逻辑 ──────────────────────────
+  const DEEP_MAIN_PAGE_IDS = ["homePage","watchLaterPage","favoritesPage","profilePage","chatPage","settingsPage"];
+
+  function openDeepDivePage() {
+    DEEP_MAIN_PAGE_IDS.forEach(id => {
+      const el = document.getElementById(id);
+      if (el) el.setAttribute("hidden", "");
+    });
+    const page = document.getElementById("deepdivePage");
+    if (page) page.removeAttribute("hidden");
+    document.body.classList.add("content-page-open");
+    document.body.classList.remove("chat-page-open", "profile-page-open");
+    const drawer = document.getElementById("sideDrawer");
+    if (drawer) drawer.classList.remove("is-open");
+    window.scrollTo({ top: 0 });
+    initDeepDiveOnce();
+  }
+
+  document.addEventListener("click", function(e) {
+    var btn = e.target.closest(".nav-action");
+    if (btn && btn.id !== "deepdiveBtn") {
+      var dp = document.getElementById("deepdivePage");
+      if (dp && !dp.hidden) dp.setAttribute("hidden", "");
+    }
+  });
+
+  // ── 深潜研究 · 核心交互 ──────────────────────────────────
+  var deepDiveInitialized = false;
+  var deepDiveCurrentSession = null;
+  var deepDiveAwaitingClarify = false;
+  var deepDiveAwaitingRefine = false;
+  var deepDiveBusy = false;
+  var deepDiveCurrentFilter = "all";
+  // 10s 可撤销的延迟提交协调器（惰性初始化：外部脚本是 defer，内联脚本执行时尚未加载）
+  var deepDivePending = null;
+  function getDeepDivePending() {
+    if (deepDivePending) return deepDivePending;
+    var ctor = window.OpenBiliClawPendingActions && window.OpenBiliClawPendingActions.createPendingActionCoordinator;
+    if (!ctor) return null;
+    deepDivePending = ctor({ windowMs: 10000 });
+    return deepDivePending;
+  }
+
+  // ── 深潜 Prompt 自定义（设置页 → 高级功能 → 深潜探索） ────────
+  function deepDivePromptEls() {
+    return {
+      plan: document.getElementById("deepdivePlanPrompt"),
+      execute: document.getElementById("deepdiveExecutePrompt"),
+      refine: document.getElementById("deepdiveRefinePrompt"),
+      status: document.getElementById("deepdivePromptsStatus"),
+      save: document.getElementById("deepdivePromptsSave"),
+      reset: document.getElementById("deepdivePromptsReset")
+    };
+  }
+  function deepDivePromptsStatus(msg, ok) {
+    var els = deepDivePromptEls();
+    if (!els.status) return;
+    els.status.textContent = msg || "";
+    if (ok === true) els.status.setAttribute("data-tone", "success");
+    else if (ok === false) els.status.setAttribute("data-tone", "error");
+    else els.status.removeAttribute("data-tone");
+  }
+  async function deepDiveLoadPrompts() {
+    var els = deepDivePromptEls();
+    if (!els.plan || !els.execute || !els.refine) return;
+    try {
+      var data = await fetch("/api/deepdive/prompts").then(function(r) { return r.json(); });
+      var prompts = data.prompts || {};
+      els.plan.value = prompts.plan || "";
+      els.execute.value = prompts.execute || "";
+      els.refine.value = prompts.refine || "";
+      deepDivePromptsStatus(data.custom && Object.keys(data.custom).length
+        ? "已加载自定义提示词（保存后立即生效）"
+        : "当前使用内置默认提示词", true);
+    } catch (e) {
+      deepDivePromptsStatus("加载深潜提示词失败：" + (e.message || "网络错误"), false);
+    }
+  }
+  async function deepDiveSavePrompts() {
+    var els = deepDivePromptEls();
+    if (!els.plan || !els.execute || !els.refine) return;
+    var payload = {
+      plan: els.plan.value,
+      execute: els.execute.value,
+      refine: els.refine.value
+    };
+    if (els.save) { els.save.disabled = true; els.save.textContent = "保存中…"; }
+    try {
+      var resp = await fetch("/api/deepdive/prompts", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload)
+      });
+      if (!resp.ok) throw new Error("HTTP " + resp.status);
+      deepDivePromptsStatus("已保存，立即生效", true);
+      if (window.showToast) showToast("深潜提示词已保存");
+    } catch (e) {
+      deepDivePromptsStatus("保存失败：" + (e.message || "网络错误"), false);
+      if (window.showToast) showToast("深潜提示词保存失败");
+    } finally {
+      if (els.save) { els.save.disabled = false; els.save.textContent = "保存深潜提示词"; }
+    }
+  }
+  async function deepDiveResetPrompts() {
+    var els = deepDivePromptEls();
+    if (!els.plan) return;
+    if (!window.confirm("确定恢复深潜提示词为内置默认值？当前自定义内容将被清空。")) return;
+    if (els.reset) { els.reset.disabled = true; }
+    try {
+      var resp = await fetch("/api/deepdive/prompts/reset", { method: "POST" });
+      if (!resp.ok) throw new Error("HTTP " + resp.status);
+      var data = await resp.json();
+      var prompts = data.prompts || {};
+      els.plan.value = prompts.plan || "";
+      els.execute.value = prompts.execute || "";
+      els.refine.value = prompts.refine || "";
+      deepDivePromptsStatus("已恢复为内置默认提示词", true);
+      if (window.showToast) showToast("深潜提示词已恢复默认");
+    } catch (e) {
+      deepDivePromptsStatus("恢复失败：" + (e.message || "网络错误"), false);
+    } finally {
+      if (els.reset) { els.reset.disabled = false; }
+    }
+  }
+  function deepDiveBindPromptSettings() {
+    var els = deepDivePromptEls();
+    if (!els.plan || !els.save) return;
+    if (els.save.getAttribute("data-deepdive-bound")) return;
+    els.save.setAttribute("data-deepdive-bound", "1");
+    els.save.addEventListener("click", deepDiveSavePrompts);
+    if (els.reset) els.reset.addEventListener("click", deepDiveResetPrompts);
+    // 打开设置页时加载一次（惰性：元素存在才加载）
+    deepDiveLoadPrompts();
+  }
+  // 设置页切到高级功能时绑定深潜 prompt 控件（页面加载时也尝试一次）
+  (function() {
+    function tryBindDeepDive() {
+      var els = deepDivePromptEls();
+      if (els.plan && els.save) {
+        deepDiveBindPromptSettings();
+        return true;
+      }
+      return false;
+    }
+    if (!tryBindDeepDive()) {
+      // 元素可能还没渲染（设置页隐藏时 DOM 仍在，通常能直接找到）；保险起见监听设置页打开
+      var settingsTabs = document.querySelectorAll("[data-settings-tab]");
+      settingsTabs.forEach(function(tab) {
+        tab.addEventListener("click", function() {
+          window.setTimeout(tryBindDeepDive, 300);
+        });
+      });
+    }
+  })();
+
+  function initDeepDiveOnce() {
+    if (deepDiveInitialized) return;
+    deepDiveInitialized = true;
+
+    var sideLog = document.getElementById("deepdiveSideLog");
+    var sideInput = document.getElementById("deepdiveSideInput");
+    var sideForm = document.getElementById("deepdiveSideForm");
+    var sideSend = document.getElementById("deepdiveSideSend");
+    var sideToggle = document.getElementById("deepdiveSideToggle");
+    var sideOpen = document.getElementById("deepdiveSideOpen");
+    var sidePanel = document.getElementById("deepdiveSide");
+    var newBtn = document.getElementById("deepdiveNewBtn");
+    var sessionsBar = document.getElementById("deepdiveSessionsBar");
+    var cardGrid = document.getElementById("deepdiveCardGrid");
+    var emptyState = document.getElementById("deepdiveEmpty");
+    var filterRow = document.getElementById("deepdiveFilterRow");
+    var allResults = [];
+
+    function api(path, opts) {
+      var url = "/api/deepdive" + path;
+      return fetch(url, {
+        headers: { "Content-Type": "application/json" },
+        ...(opts || {}),
+      }).then(function(r) {
+        if (!r.ok) return r.json().then(function(e) { throw new Error(e.error || r.statusText); });
+        return r.json();
+      });
+    }
+
+    function sideMsg(role, text) {
+      var div = document.createElement("div");
+      div.className = "msg " + role;
+      div.textContent = text;
+      // 插入到输入栏之前（输入栏跟随消息流，是 log 内最后一个元素）
+      var formEl = document.getElementById("deepdiveSideForm");
+      if (formEl && sideLog.contains(formEl)) sideLog.insertBefore(div, formEl);
+      else sideLog.appendChild(div);
+      sideLog.scrollTop = sideLog.scrollHeight;
+    }
+
+    function setTyping(on, message) {
+      var old = sideLog.querySelector(".deepdive-typing");
+      if (old) old.remove();
+      if (on) {
+        var div = document.createElement("div");
+        div.className = "deepdive-typing";
+        div.textContent = message || "AI 正在思考…";
+        // 插入到输入栏之前（输入栏是 log 内最后一个元素，跟随消息流）
+        var form = document.getElementById("deepdiveSideForm");
+        if (form) sideLog.insertBefore(div, form);
+        else sideLog.appendChild(div);
+        sideLog.scrollTop = sideLog.scrollHeight;
+      }
+    }
+
+    function setBusy(v) {
+      deepDiveBusy = v;
+      sideSend.disabled = v;
+      sideInput.placeholder = v ? "处理中，请稍候…" : (deepDiveAwaitingClarify ? "回答上面的澄清问题…" : (deepDiveAwaitingRefine ? "描述想调整的方向…" : (deepDiveCurrentSession ? "继续补充需求，或点「新建探索」…" : "想深入了解什么？")));
+    }
+
+    // ── 卡片渲染（复用主站 video-card 样式） ────────────────
+    function platformName(p) {
+      return {bilibili:"B 站",xhs:"小红书",zhihu:"知乎",youtube:"YouTube",douyin:"抖音"}[p] || p;
+    }
+    function platformIcon(p) {
+      return {bilibili:"B站",xhs:"小红书",zhihu:"知乎",youtube:"YT",douyin:"抖音"}[p] || p;
+    }
+
+    function renderCards(cards) {
+      allResults = cards || [];
+      applyFilter(deepDiveCurrentFilter);
+    }
+
+    function applyFilter(platform) {
+      deepDiveCurrentFilter = platform;
+      var filtered = platform === "all" ? allResults : allResults.filter(function(c) { return c.platform === platform; });
+      cardGrid.innerHTML = "";
+      if (filtered.length === 0) {
+        cardGrid.setAttribute("hidden", "");
+        emptyState.removeAttribute("hidden");
+        return;
+      }
+      emptyState.setAttribute("hidden", "");
+      cardGrid.removeAttribute("hidden");
+      filtered.forEach(function(c) {
+        var card = document.createElement("article");
+        card.className = "video-card";
+        var coverImg = c.cover_url ? '<img src="' + escapeHtml(proxyCover(c.cover_url)) + '" alt="' + escapeHtml(c.title) + '" loading="lazy" referrerpolicy="no-referrer">' : '';
+        var durationBadge = '';
+        // 无封面时用平台色占位（视觉统一）
+        if (!c.cover_url) {
+          var phClass = 'platform-ph-' + (c.platform || 'x');
+          coverImg = '<div class="platform-ph ' + phClass + '" aria-hidden="true"><span>' + platformIcon(c.platform) + '</span></div>';
+        }
+        var statsHtml = c.description ? '<p class="video-stats">' + escapeHtml(c.description.slice(0, 80)) + '</p>' : '';
+        var authorHtml = c.author ? '<span class="up-name">' + escapeHtml(c.author) + '</span> · ' : '';
+        card.innerHTML =
+          '<a class="cover" href="' + escapeHtml(c.url || '#') + '" target="_blank" rel="noopener" aria-label="打开 ' + escapeHtml(c.title) + '">' +
+            coverImg +
+            '<span class="platform" data-platform="' + (c.platform || 'bilibili') + '">' + platformName(c.platform) + '</span>' +
+            durationBadge +
+          '</a>' +
+          '<div>' +
+            '<p class="video-title">' + escapeHtml(c.title) + '</p>' +
+            '<p class="video-meta">' + authorHtml + platformName(c.platform) + ' · 搜索' + '</p>' +
+            statsHtml +
+          '</div>' +
+          '<p class="reason" role="button" tabindex="0" aria-expanded="false"><span class="reason-text">' + escapeHtml(c.description || '搜索结果') + '</span></p>' +
+          '<div class="card-actions" aria-label="搜索结果操作">' +
+            '<div class="card-feedback-icons" aria-label="喜欢或不感兴趣">' +
+              '<button class="feedback-icon-btn" data-action="like" type="button" aria-label="喜欢" title="喜欢"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" aria-hidden="true"><path d="M7 10v10"/><path d="M15 5.2 14 10h5.4a1.8 1.8 0 0 1 1.7 2.2l-1.5 6A2.4 2.4 0 0 1 17.3 20H7"/><path d="M7 10l4.5-5.3A2 2 0 0 1 15 6v4"/></svg></button>' +
+              '<span class="feedback-separator" aria-hidden="true">/</span>' +
+              '<button class="feedback-icon-btn" data-action="dislike" type="button" aria-label="不感兴趣" title="不感兴趣"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" aria-hidden="true"><path d="M17 14V4"/><path d="M9 18.8 10 14H4.6a1.8 1.8 0 0 1-1.7-2.2l1.5-6A2.4 2.4 0 0 1 6.7 4H17"/><path d="M17 14l-4.5 5.3A2 2 0 0 1 9 18v-4"/></svg></button>' +
+              '<span class="feedback-separator" aria-hidden="true">/</span>' +
+              '<button class="feedback-icon-btn" data-action="dismiss" type="button" aria-label="忽略" title="忽略"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M3 3l18 18M9.84 9.91A3 3 0 0 0 12 15c.82 0 1.57-.33 2.11-.87M6.5 6.65A10.45 10.45 0 0 0 2.46 12C3.73 16.06 7.52 19 12 19c1.99 0 3.84-.58 5.4-1.58M11 5.05c.33-.03.66-.05 1-.05 4.48 0 8.27 2.94 9.54 7a10.5 10.5 0 0 1-1.19 2.5"/></svg></button>' +
+              '<span class="feedback-separator" aria-hidden="true">/</span>' +
+              '<button class="feedback-icon-btn watch-later-btn" data-action="watch-later" type="button" aria-label="稍后再看" title="稍后再看" aria-pressed="false"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" aria-hidden="true"><circle cx="12" cy="12" r="9"/><path d="M12 7.5V12l3.2 1.9"/></svg></button>' +
+              '<span class="feedback-separator" aria-hidden="true">/</span>' +
+              '<button class="feedback-icon-btn favorite-btn" data-action="favorite" type="button" aria-label="收藏" title="收藏" aria-pressed="false"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linejoin="round" aria-hidden="true"><path d="M12 3.6l2.65 5.37 5.93.86-4.29 4.18 1.01 5.9L12 17.1l-5.31 2.8 1.01-5.9L3.41 9.83l5.93-.86z"/></svg></button>' +
+            '</div>' +
+            '<div class="comment-field"><input placeholder="想围绕这条聊什么？" aria-label="想围绕这条聊什么？"></div>' +
+            '<button class="small-btn composer-cancel" data-action="cancel-comment" type="button" aria-label="返回" title="返回">‹</button>' +
+            '<button class="small-btn chat-action" data-action="comment" type="button">聊一聊</button>' +
+          '</div>' +
+          '<p class="status-line" aria-live="polite"></p>';
+        card.querySelector(".cover").addEventListener("click", function(e) {
+          e.preventDefault();
+          e.stopPropagation();
+          // 卡片详情弹窗：先预览，再点「打开原链接」才跳转（防误点）
+          if (typeof window.openCardDetail === "function") {
+            window.openCardDetail({
+              title: c.title || "",
+              url: c.url || "",
+              author: c.author || "",
+              description: c.description || "",
+              cover_url: c.cover_url || "",
+              platform: platformName(c.platform) || c.platform || ""
+            });
+          } else if (c.url) {
+            window.open(c.url, "_blank");
+          }
+        });
+        // ── 反馈按钮：喜欢/点踩/忽略/稍后再看/收藏 → 10s 可撤销延迟提交 ──
+        function deepDiveStageFeedback(card, item, action, commitFn) {
+          var pending = getDeepDivePending();
+          if (!pending) return false;
+          var key = (item.platform || 'x') + ':' + (item.bvid || item.url || item.title || '');
+          if (!key || pending.has(key)) return false;
+          var status = card.querySelector('.status-line');
+          var snapshot = {};
+          card.querySelectorAll('.card-feedback-icons [data-action]').forEach(function(b) {
+            snapshot[b.dataset.action] = { pressed: b.getAttribute('aria-pressed'), active: b.classList.contains('is-active') };
+          });
+          var copy = {
+            like: { pending: '已标记喜欢，10 秒内可撤销。', committed: '已记录喜欢' },
+            dislike: { pending: '已标记不感兴趣，10 秒内可撤销。', committed: '已记录不感兴趣' },
+            dismiss: { pending: '已标记忽略，10 秒内可撤销。', committed: '已忽略' },
+            'watch-later': { pending: '已加入稍后再看，10 秒内可撤销。', committed: '已加入稍后再看' },
+            favorite: { pending: '已收藏，10 秒内可撤销。', committed: '已收藏' }
+          }[action] || { pending: '已处理，10 秒内可撤销。', committed: '已处理' };
+          var ok = pending.schedule(key, {
+            commit: function() { return commitFn(); },
+            rollback: function() {
+              card.querySelectorAll('.card-feedback-icons [data-action]').forEach(function(b) {
+                var snap = snapshot[b.dataset.action] || {};
+                b.setAttribute('aria-pressed', snap.pressed || 'false');
+                b.classList.toggle('is-active', !!snap.active);
+                b.disabled = false;
+              });
+              card.classList.remove('is-feedback-pending');
+              status.classList.remove('has-feedback-action');
+              status.textContent = '已撤销反馈';
+            },
+            committed: function() {
+              if (!card.isConnected) return;
+              card.querySelectorAll('.card-feedback-icons [data-action]').forEach(function(b) { b.disabled = false; });
+              card.classList.remove('is-feedback-pending');
+              status.classList.remove('has-feedback-action');
+              // 点赞/稍后再看/收藏 只更新状态文本；点踩/忽略 → 10s 生效后卡片消失
+              if (action === 'dislike' || action === 'dismiss') {
+                var idx = allResults.indexOf(item);
+                if (idx >= 0) allResults.splice(idx, 1);
+                card.remove();
+                if (cardGrid.childElementCount === 0) {
+                  emptyState.removeAttribute('hidden');
+                  cardGrid.setAttribute('hidden', '');
+                }
+                renderFilters();
+                return;
+              }
+              status.textContent = copy.committed;
+            }
+          });
+          if (!ok) return false;
+          card.classList.add('is-feedback-pending');
+          card.querySelectorAll('.card-feedback-icons [data-action]').forEach(function(b) { b.disabled = true; });
+          var clicked = card.querySelector('[data-action="' + action + '"]');
+          if (clicked) { clicked.setAttribute('aria-pressed', 'true'); clicked.classList.add('is-active'); }
+          var undo = document.createElement('button');
+          undo.type = 'button';
+          undo.className = 'feedback-undo-btn';
+          undo.textContent = '撤销';
+          undo.addEventListener('click', function() { pending.undo(key); });
+          status.classList.add('has-feedback-action');
+          status.setAttribute('aria-live', 'polite');
+          status.replaceChildren(document.createTextNode(copy.pending + ' '), undo);
+          return true;
+        }
+
+        // 喜欢/点踩/忽略 → 延迟提交 /api/events
+        ['like','dislike','dismiss'].forEach(function(action) {
+          var btn = card.querySelector('[data-action="' + action + '"]');
+          if (btn) btn.addEventListener("click", function(e) {
+            e.stopPropagation();
+            deepDiveStageFeedback(card, c, action, function() {
+              return fetch('/api/events', {
+                method: 'POST',
+                headers: {'Content-Type': 'application/json'},
+                body: JSON.stringify({
+                  events: [{
+                    type: 'feedback',
+                    source_platform: c.platform || 'bilibili',
+                    title: c.title || '',
+                    url: c.url || '',
+                    timestamp: Date.now(),
+                    event_id: 'deepdive_' + action + '_' + Date.now() + '_' + Math.random().toString(36).slice(2, 8),
+                    metadata: { feedback_type: action, bvid: c.bvid || '', content_id: c.bvid || '' }
+                  }]
+                })
+              }).then(function(r) { if (!r.ok) throw new Error('反馈提交失败'); return r.json(); });
+            });
+          });
+        });
+        // 稍后再看/收藏 → 延迟提交 /api/saved/（注意 extra=forbid，不能传 item_key）
+        ['watch-later','favorite'].forEach(function(action) {
+          var btn = card.querySelector('[data-action="' + action + '"]');
+          if (btn) btn.addEventListener("click", function(e) {
+            e.stopPropagation();
+            var listKind = action === 'watch-later' ? 'watch_later' : 'favorite';
+            // cover_url 补全协议（B站返回 // 开头）
+            var absCover = (c.cover_url || '').startsWith('//') ? 'https:' + c.cover_url : (c.cover_url || '');
+            deepDiveStageFeedback(card, c, action, function() {
+              return fetch('/api/saved/' + listKind, {
+                method: 'POST',
+                headers: {'Content-Type': 'application/json'},
+                body: JSON.stringify({
+                  source_platform: c.platform || 'bilibili',
+                  content_id: c.bvid || '',
+                  content_url: c.url || '',
+                  content_type: 'video',
+                  title: c.title || '',
+                  author_name: c.author || '',
+                  cover_url: absCover
+                })
+              }).then(function(r) {
+                if (!r.ok) throw new Error('保存失败');
+                return r.json();
+              }).then(function(d) {
+                var saved = d && d.saved;
+                if (saved) {
+                  var targetBtn = card.querySelector('[data-action="' + action + '"]');
+                  if (targetBtn) {
+                    targetBtn.setAttribute('aria-pressed', 'true');
+                    targetBtn.title = action === 'watch-later' ? '取消稍后再看' : '取消收藏';
+                  }
+                }
+                return d;
+              });
+            });
+          });
+        });
+        // ── 聊一聊：打开/关闭发送器 + 提交（主站 openCardComposer/closeCardComposer/send-comment 逻辑） ──
+        var status = card.querySelector('.status-line');
+        var chatBtn = card.querySelector('.chat-action');
+        var cancelBtn = card.querySelector('[data-action="cancel-comment"]');
+        var commentInput = card.querySelector('.comment-field input');
+        var cardActions = card.querySelector('.card-actions');
+        var sendIcon = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" aria-hidden="true"><path d="M4 12 20 4l-5 16-3.2-6.8L4 12Z"/><path d="m11.8 13.2 3.7-3.7"/></svg>';
+        function openComposer() {
+          cardActions.classList.add('is-composing');
+          chatBtn.classList.add('is-send');
+          chatBtn.dataset.action = 'send-comment';
+          chatBtn.innerHTML = sendIcon;
+          chatBtn.setAttribute('aria-label', '发送');
+          chatBtn.setAttribute('title', '发送');
+          requestAnimationFrame(function() { if (commentInput) commentInput.focus(); });
+        }
+        function closeComposer() {
+          cardActions.classList.remove('is-composing');
+          chatBtn.classList.remove('is-send');
+          chatBtn.dataset.action = 'comment';
+          chatBtn.textContent = '聊一聊';
+          chatBtn.removeAttribute('aria-label');
+          chatBtn.removeAttribute('title');
+        }
+        if (chatBtn) chatBtn.addEventListener('click', function(e) {
+          e.stopPropagation();
+          if (cardActions.classList.contains('is-composing')) {
+            var note = commentInput ? commentInput.value.trim() : '';
+            if (!note) {
+              status.textContent = '先写一句想聊的内容，再提交这条反馈。';
+              if (commentInput) commentInput.focus();
+              return;
+            }
+            if (commentInput) commentInput.value = '';
+            closeComposer();
+            status.textContent = '已提交聊天线索，卡片会保留在当前结果。';
+            fetch('/api/events', {
+              method: 'POST',
+              headers: {'Content-Type': 'application/json'},
+              body: JSON.stringify({ events: [{
+                type: 'feedback',
+                source_platform: c.platform || 'bilibili',
+                title: c.title || '',
+                url: c.url || '',
+                timestamp: Date.now(),
+                event_id: 'deepdive_comment_' + Date.now() + '_' + Math.random().toString(36).slice(2, 8),
+                metadata: { feedback_type: 'comment', bvid: c.bvid || '', content_id: c.bvid || '', feedback_note: note }
+              }]})
+            }).then(function(r) {
+              if (!r.ok) throw new Error('反馈提交失败');
+              return r.json();
+            }).catch(function(err) {
+              status.textContent = err.message || '反馈提交失败';
+            });
+          } else {
+            openComposer();
+          }
+        });
+        if (cancelBtn) cancelBtn.addEventListener('click', function(e) {
+          e.stopPropagation();
+          closeComposer();
+        });
+        if (commentInput) commentInput.addEventListener('blur', function(e) {
+          var next = e.relatedTarget;
+          if (next && cardActions.contains(next)) return;
+          window.setTimeout(function() {
+            if (!cardActions.classList.contains('is-composing')) return;
+            if (cardActions.contains(document.activeElement)) return;
+            closeComposer();
+          }, 150);
+        });
+        cardGrid.appendChild(card);
+      });
+      renderFilters();
+    }
+
+    function escapeHtml(s) {
+      if (!s) return "";
+      return String(s).replace(/&/g,"&amp;").replace(/</g,"&lt;").replace(/>/g,"&gt;").replace(/"/g,"&quot;");
+    }
+
+    // 封面走主站图片代理（B站图床有防盗链，浏览器直连加载失败）
+    function proxyCover(url) {
+      if (!url) return "";
+      // B站返回协议相对路径（//i0.hdslb.com/...），补全 https:
+      var full = String(url).trim();
+      if (full.startsWith("//")) full = "https:" + full;
+      try { new URL(full); } catch(e) { return ""; }
+      return "/api/image-proxy?url=" + encodeURIComponent(full);
+    }
+
+    function renderFilters() {
+      var platforms = {};
+      allResults.forEach(function(c) { platforms[c.platform] = (platforms[c.platform] || 0) + 1; });
+      var total = allResults.length;
+      var html = '<button class="pill-btn' + (deepDiveCurrentFilter === "all" ? " is-active" : "") + '" data-platform="all" role="tab" aria-selected="' + (deepDiveCurrentFilter === "all" ? "true" : "false") + '">全部 (' + total + ')</button>';
+      Object.keys(platforms).forEach(function(p) {
+        var active = deepDiveCurrentFilter === p;
+        html += '<button class="pill-btn' + (active ? " is-active" : "") + '" data-platform="' + p + '" role="tab" aria-selected="' + (active ? "true" : "false") + '">' + platformName(p) + ' (' + platforms[p] + ')</button>';
+      });
+      filterRow.innerHTML = html;
+      filterRow.querySelectorAll("[data-platform]").forEach(function(btn) {
+        btn.addEventListener("click", function() { applyFilter(this.dataset.platform); });
+      });
+    }
+
+    // ── 会话管理 ────────────────────────────────────────────
+    var deepDiveHistExpanded = false;  // 历史对话是否已展开
+    function sideMsgBefore(role, text, beforeEl) {
+      var div = document.createElement("div");
+      div.className = "msg " + role;
+      div.textContent = text;
+      if (beforeEl) sideLog.insertBefore(div, beforeEl);
+      else sideLog.appendChild(div);
+    }
+    function renderSession(s) {
+      // 右侧聊天面板（历史折叠：默认只渲染最近 10 条，可展开更早）
+      var histFold = document.getElementById("deepdiveHistFold");
+      var form = document.getElementById("deepdiveSideForm");
+      var allMsgs = s.messages || [];
+      // 清空后重排：折叠按钮在最前、输入栏在最后（跟随消息流）
+      sideLog.innerHTML = "";
+      if (histFold) sideLog.appendChild(histFold);
+      if (form) sideLog.appendChild(form);
+      var showFrom = 0;
+      if (allMsgs.length > 10 && !deepDiveHistExpanded) {
+        showFrom = allMsgs.length - 10;
+        if (histFold) histFold.hidden = false;
+      } else {
+        if (histFold) histFold.hidden = true;
+      }
+      for (var i = showFrom; i < allMsgs.length; i++) {
+        var m = allMsgs[i];
+        sideMsgBefore(m.role === "user" ? "user" : "assistant", m.content, form);
+      }
+      sideLog.scrollTop = sideLog.scrollHeight;
+      // 左侧卡片
+      if (s.results && s.results.length) {
+        renderCards(s.results);
+      }
+      setBusy(false);
+    }
+
+    function bindHistExpand() {
+      var btn = document.getElementById("deepdiveHistExpandBtn");
+      if (!btn || btn.dataset.bound) return;
+      btn.dataset.bound = "1";
+      btn.addEventListener("click", function() {
+        deepDiveHistExpanded = true;
+        var fold = document.getElementById("deepdiveHistFold");
+        if (fold) fold.hidden = true;
+        // 重新渲染当前会话完整历史
+        if (deepDiveCurrentSession) renderSession(deepDiveCurrentSession);
+        // 滚动到顶部（展开更早的内容从顶部开始看）
+        sideLog.scrollTop = 0;
+      });
+    }
+    bindHistExpand();
+
+    function clearSession() {
+      // 只清消息，保留输入栏和「展开更早对话」按钮（它们在 log 内部）
+      var histFold = document.getElementById("deepdiveHistFold");
+      var form = document.getElementById("deepdiveSideForm");
+      sideLog.innerHTML = "";
+      if (histFold) sideLog.appendChild(histFold);
+      if (form) sideLog.appendChild(form);
+      deepDiveHistExpanded = false;
+      cardGrid.innerHTML = "";
+      cardGrid.setAttribute("hidden", "");
+      emptyState.removeAttribute("hidden");
+      filterRow.innerHTML = "";
+      allResults = [];
+    }
+
+    async function loadSessions() {
+      try {
+        var data = await api("/sessions");
+        sessionsBar.innerHTML = "";
+        var folders = data.folders || [];
+        var sessions = data.sessions || [];
+        // 建文件夹工具栏
+        var toolbar = document.createElement("div");
+        toolbar.className = "deepdive-tree-toolbar";
+        var addFolderBtn = document.createElement("button");
+        addFolderBtn.type = "button";
+        addFolderBtn.textContent = "＋ 新建文件夹";
+        addFolderBtn.addEventListener("click", async function() {
+          var name = window.prompt("文件夹名字：", "");
+          if (!name) return;
+          name = name.trim();
+          if (!name) return;
+          try {
+            await api("/folders", { method: "POST", body: JSON.stringify({ name: name }) });
+            loadSessions();
+          } catch(err) { sideMsg("system", "建文件夹失败: " + err.message); }
+        });
+        toolbar.appendChild(addFolderBtn);
+        sessionsBar.appendChild(toolbar);
+
+        // 分组：根目录会话 + 各文件夹
+        var rootSessions = sessions.filter(function(s) { return !s.folder; });
+        var folderSessions = {};
+        sessions.forEach(function(s) {
+          if (s.folder) {
+            (folderSessions[s.folder] = folderSessions[s.folder] || []).push(s);
+          }
+        });
+
+        // 渲染文件夹组
+        var root = document.createElement("div");
+        root.className = "deepdive-tree-root";
+
+        folders.forEach(function(folderName) {
+          var group = document.createElement("div");
+          group.className = "deepdive-tree-folder";
+          // 文件夹行
+          var row = document.createElement("div");
+          row.className = "deepdive-folder-row";
+          var toggle = document.createElement("span");
+          toggle.className = "deepdive-folder-toggle";
+          toggle.textContent = "▾";
+          var icon = document.createElement("span");
+          icon.className = "deepdive-folder-icon";
+          icon.textContent = "📁";
+          var name = document.createElement("span");
+          name.className = "deepdive-folder-name";
+          name.textContent = folderName;
+          name.title = folderName;
+          var count = document.createElement("span");
+          count.className = "deepdive-folder-count";
+          var items = folderSessions[folderName] || [];
+          count.textContent = "(" + items.length + ")";
+          // 重命名/删除
+          var renBtn = document.createElement("button");
+          renBtn.type = "button"; renBtn.className = "deepdive-folder-op"; renBtn.textContent = "✎"; renBtn.title = "重命名文件夹";
+          renBtn.addEventListener("click", async function(e) {
+            e.stopPropagation();
+            var newName = window.prompt("重命名文件夹：", folderName);
+            if (!newName) return;
+            newName = newName.trim();
+            if (!newName) return;
+            try {
+              await api("/folders/" + encodeURIComponent(folderName), { method: "PATCH", body: JSON.stringify({ name: newName }) });
+              loadSessions();
+            } catch(err) { sideMsg("system", "重命名失败: " + err.message); }
+          });
+          var delBtn = document.createElement("button");
+          delBtn.type = "button"; delBtn.className = "deepdive-folder-op del"; delBtn.textContent = "✕"; delBtn.title = "删除文件夹（会话移回根目录）";
+          delBtn.addEventListener("click", async function(e) {
+            e.stopPropagation();
+            if (!window.confirm("删除文件夹「" + folderName + "」？其中的探索会移回根目录，不删除会话。")) return;
+            try {
+              await api("/folders/" + encodeURIComponent(folderName), { method: "DELETE" });
+              loadSessions();
+            } catch(err) { sideMsg("system", "删除失败: " + err.message); }
+          });
+          row.appendChild(toggle);
+          row.appendChild(icon);
+          row.appendChild(name);
+          row.appendChild(count);
+          row.appendChild(renBtn);
+          row.appendChild(delBtn);
+          // 折叠/展开
+          row.addEventListener("click", function() {
+            body.classList.toggle("collapsed");
+            toggle.classList.toggle("collapsed");
+          });
+          // 文件夹体
+          var body = document.createElement("div");
+          body.className = "deepdive-tree-folder-body";
+          items.forEach(function(s) { body.appendChild(makeSessionChip(s)); });
+          group.appendChild(row);
+          group.appendChild(body);
+          root.appendChild(group);
+        });
+
+        // 根目录会话
+        rootSessions.forEach(function(s) {
+          root.appendChild(makeSessionChip(s));
+        });
+
+        sessionsBar.appendChild(root);
+      } catch(e) {}
+    }
+
+    function makeSessionChip(s) {
+      var chip = document.createElement("span");
+      chip.className = "deepdive-session-chip" + (deepDiveCurrentSession && s.id === deepDiveCurrentSession.id ? " active" : "");
+      chip.title = s.topic || "未命名";
+      var name = document.createElement("span");
+      name.className = "deepdive-session-name";
+      name.textContent = (s.topic || "未命名").slice(0, 14);
+      chip.appendChild(name);
+      // 移入文件夹按钮（树形收纳）
+      var moveBtn = document.createElement("button");
+      moveBtn.type = "button";
+      moveBtn.className = "deepdive-session-op";
+      moveBtn.textContent = "📂";
+      moveBtn.title = "移动到文件夹";
+      moveBtn.addEventListener("click", async function(e) {
+        e.stopPropagation();
+        try {
+          var data = await api("/sessions");
+          var folders = data.folders || [];
+          var options = ["（根目录）"].concat(folders);
+          var choice = window.prompt("选择目标文件夹（输入名字，留空=根目录）：\n\n" + options.join("\n"));
+          if (choice === null) return;
+          var target = choice.trim() === "" ? "" : choice.trim();
+          await api("/" + s.id + "/move", { method: "POST", body: JSON.stringify({ folder: target }) });
+          loadSessions();
+        } catch(err) { sideMsg("system", "移动失败: " + err.message); }
+      });
+      chip.appendChild(moveBtn);
+      // 重命名按钮
+      var renameBtn = document.createElement("button");
+      renameBtn.type = "button";
+      renameBtn.className = "deepdive-session-op";
+      renameBtn.textContent = "✎";
+      renameBtn.title = "重命名";
+      renameBtn.addEventListener("click", async function(e) {
+        e.stopPropagation();
+        var newName = window.prompt("给探索起个新名字：", s.topic || "");
+        if (newName === null) return;
+        newName = newName.trim();
+        if (!newName) return;
+        try {
+          await api("/" + s.id + "/rename", { method: "PATCH", body: JSON.stringify({ name: newName }) });
+          if (deepDiveCurrentSession && deepDiveCurrentSession.id === s.id) {
+            deepDiveCurrentSession.topic = newName;
+          }
+          loadSessions();
+        } catch(err) { sideMsg("system", "重命名失败: " + err.message); }
+      });
+      chip.appendChild(renameBtn);
+      // 删除按钮
+      var delBtn = document.createElement("button");
+      delBtn.type = "button";
+      delBtn.className = "deepdive-session-op deepdive-session-del";
+      delBtn.textContent = "✕";
+      delBtn.title = "删除探索";
+      delBtn.addEventListener("click", async function(e) {
+        e.stopPropagation();
+        if (!window.confirm("删除探索「" + (s.topic || "未命名") + "」？此操作不可恢复。")) return;
+        try {
+          await api("/" + s.id, { method: "DELETE" });
+          if (deepDiveCurrentSession && deepDiveCurrentSession.id === s.id) {
+            deepDiveCurrentSession = null;
+            deepDiveAwaitingClarify = false;
+            deepDiveAwaitingRefine = false;
+            clearSession();
+            sideMsg("system", "探索已删除。输入新方向开始新的探索。");
+          }
+          loadSessions();
+        } catch(err) { sideMsg("system", "删除失败: " + err.message); }
+      });
+      chip.appendChild(delBtn);
+      // 点击 chip 主体打开会话
+      chip.addEventListener("click", function() { openSession(s.id); });
+      return chip;
+    }
+
+    async function openSession(id) {
+      try {
+        var s = await api("/" + id);
+        deepDiveCurrentSession = s;
+        deepDiveAwaitingClarify = s.status === "planning" || s.status === "clarifying";
+        deepDiveAwaitingRefine = s.status === "displaying";
+        renderSession(s);
+        loadSessions();
+      } catch(e) { sideMsg("system", "加载会话失败: " + e.message); }
+    }
+
+    async function startNew(prompt) {
+      setBusy(true);
+      setTyping(true);
+      try {
+        var s = await api("/start", { method: "POST", body: JSON.stringify({ topic: prompt }) });
+        deepDiveCurrentSession = s;
+        deepDiveAwaitingClarify = true;
+        deepDiveAwaitingRefine = false;
+        renderSession(s);
+        loadSessions();
+      } catch(e) {
+        setTyping(false);
+        sideMsg("system", "开始失败: " + e.message);
+      } finally {
+        setBusy(false);
+      }
+    }
+
+    // ── 事件绑定 ────────────────────────────────────────────
+    sideForm.addEventListener("submit", async function(e) {
+      e.preventDefault();
+      var text = sideInput.value.trim();
+      if (!text || deepDiveBusy) return;
+      sideInput.value = "";
+
+      if (!deepDiveCurrentSession) {
+        await startNew(text);
+        return;
+      }
+
+      setBusy(true);
+      // 轻量搜索进度提示：轮换文案，不做复杂进度条
+      var searchTips = [
+        "别急，正在跨平台搜索中…",
+        "正在问 B站、抖音、小红书…",
+        "搜索结果整理中，马上就好…",
+      ];
+      var tipIdx = 0;
+      setTyping(true, searchTips[0]);
+      var tipTimer = window.setInterval(function() {
+        tipIdx = (tipIdx + 1) % searchTips.length;
+        var old = sideLog.querySelector(".deepdive-typing");
+        if (old) old.textContent = searchTips[tipIdx];
+        sideLog.scrollTop = sideLog.scrollHeight;
+      }, 8000);
+      // 用户消息插入到输入栏之前（输入栏跟随消息流）
+      var sideFormEl = document.getElementById("deepdiveSideForm");
+      sideMsgBefore("user", text, sideFormEl);
+      try {
+        var s;
+        if (deepDiveAwaitingClarify) {
+          s = await api("/" + deepDiveCurrentSession.id + "/clarify", { method: "POST", body: JSON.stringify({ input: text }) });
+          deepDiveAwaitingClarify = false;
+          deepDiveAwaitingRefine = true;
+        } else {
+          s = await api("/" + deepDiveCurrentSession.id + "/refine", { method: "POST", body: JSON.stringify({ input: text }) });
+          deepDiveAwaitingRefine = true;
+        }
+        deepDiveCurrentSession = s;
+        renderSession(s);
+      } catch(err) {
+        setTyping(false);
+        sideMsg("system", "出错: " + err.message);
+      } finally {
+        if (tipTimer) { window.clearInterval(tipTimer); tipTimer = null; }
+        setBusy(false);
+      }
+    });
+
+    // 右侧面板收起/展开
+    sideToggle.addEventListener("click", function() {
+      sidePanel.classList.add("collapsed");
+    });
+    sideOpen.addEventListener("click", function() {
+      sidePanel.classList.remove("collapsed");
+    });
+
+    // 新建探索
+    newBtn.addEventListener("click", function() {
+      deepDiveCurrentSession = null;
+      deepDiveAwaitingClarify = false;
+      deepDiveAwaitingRefine = false;
+      clearSession();
+      sideMsg("system", "新探索已开始。在下方输入你想深入了解的方向，AI 会引导你。");
+      sideInput.focus();
+      setBusy(false);
+    });
+
+    // 移动端：全屏对话 ↔ 结果卡片切换
+    var deepdiveMain = document.querySelector(".deepdive-main");
+    var mobileBack = document.getElementById("deepdiveMobileBack");
+    var mobileChatBtn = document.getElementById("deepdiveMobileChatBtn");
+    function isMobileView() { return window.innerWidth <= 820; }
+    function showDeepDiveResults() {
+      if (!isMobileView()) return;
+      deepdiveMain.classList.add("mobile-visible");
+      sidePanel.classList.add("mobile-hidden");
+    }
+    function showDeepDiveChat() {
+      if (!isMobileView()) return;
+      deepdiveMain.classList.remove("mobile-visible");
+      sidePanel.classList.remove("mobile-hidden");
+      sideInput.focus();
+    }
+    if (mobileBack) mobileBack.addEventListener("click", showDeepDiveResults);
+    if (mobileChatBtn) mobileChatBtn.addEventListener("click", showDeepDiveChat);
+    // 新建探索时切回对话（移动端）
+    newBtn.addEventListener("click", showDeepDiveChat);
+    // 打开会话后（移动端）默认看对话，有结果时仍留在对话让用户自己切
+    // 窗口尺寸跨断点时自动修正显示状态
+    window.addEventListener("resize", function() {
+      if (!isMobileView()) {
+        deepdiveMain.classList.remove("mobile-visible");
+        sidePanel.classList.remove("mobile-hidden");
+      }
+    });
+
+    // 初始化
+    sideMsg("system", "你好！在下方输入一个方向，AI 会引导你探索。");
+    loadSessions();
+  }
+</script>
+<script>
+  // ── 收藏夹（多选批量分类 · 复用深潜 folder 模式） ──────────────
+  (function() {
+    var LIST_KINDS = ["favorite", "watch_later"];
+    var selected = { favorite: {}, watch_later: {} };  // item_key → true
+    var selecting = { favorite: false, watch_later: false };
+    var activeFilter = { favorite: "", watch_later: "" };  // "" = 全部
+
+    function api(path, opts) {
+      opts = opts || {};
+      return fetch("/api/saved" + path, {
+        method: opts.method || "GET",
+        headers: opts.body ? { "Content-Type": "application/json" } : undefined,
+        body: opts.body ? JSON.stringify(opts.body) : undefined
+      }).then(function(r) { return r.json(); });
+    }
+
+    function pageFor(listKind) {
+      return listKind === "favorite"
+        ? document.getElementById("favoritesPage")
+        : document.getElementById("watchLaterPage");
+    }
+    function gridFor(listKind) {
+      return listKind === "favorite"
+        ? document.getElementById("favoritesList")
+        : document.getElementById("watchLaterList");
+    }
+    function barFor(listKind) {
+      return listKind === "favorite"
+        ? document.getElementById("favoritesCollectionsBar")
+        : document.getElementById("watchLaterCollectionsBar");
+    }
+    function batchBarFor(listKind) {
+      return listKind === "favorite"
+        ? document.getElementById("favoritesBatchBar")
+        : document.getElementById("watchLaterBatchBar");
+    }
+
+    // 加载收藏夹 tabs + 批量目标下拉
+    function refreshCollections(listKind) {
+      api("/" + listKind + "/collections").then(function(data) {
+        var collections = data.collections || [];
+        var bar = barFor(listKind);
+        if (!bar) return;
+        var tabs = bar.querySelector(".saved-collections-tabs");
+        tabs.innerHTML = "";
+        var all = document.createElement("button");
+        all.type = "button"; all.className = "pill-btn" + (activeFilter[listKind] === "" ? " active" : "");
+        all.textContent = "全部";
+        all.addEventListener("click", function() {
+          activeFilter[listKind] = "";
+          refreshCollections(listKind);
+          applyFilter(listKind);
+        });
+        tabs.appendChild(all);
+        var un = document.createElement("button");
+        un.type = "button"; un.className = "pill-btn" + (activeFilter[listKind] === "__none__" ? " active" : "");
+        un.textContent = "未分类";
+        un.addEventListener("click", function() {
+          activeFilter[listKind] = "__none__";
+          refreshCollections(listKind);
+          applyFilter(listKind);
+        });
+        tabs.appendChild(un);
+        collections.forEach(function(name) {
+          var b = document.createElement("button");
+          b.type = "button"; b.className = "pill-btn" + (activeFilter[listKind] === name ? " active" : "");
+          b.textContent = name;
+          b.title = "重命名：右键 / 删除：双击";
+          b.addEventListener("click", function() {
+            activeFilter[listKind] = name;
+            refreshCollections(listKind);
+            applyFilter(listKind);
+          });
+          b.addEventListener("dblclick", function(e) {
+            e.stopPropagation();
+            if (!window.confirm("删除收藏夹「" + name + "」？其中的内容会移回未分类。")) return;
+            api("/" + listKind + "/collections/" + encodeURIComponent(name), { method: "DELETE" }).then(function() {
+              if (activeFilter[listKind] === name) activeFilter[listKind] = "";
+              refreshCollections(listKind);
+              refreshList(listKind);
+            });
+          });
+          b.addEventListener("contextmenu", function(e) {
+            e.preventDefault();
+            e.stopPropagation();
+            var newName = window.prompt("重命名收藏夹：", name);
+            if (!newName) return;
+            newName = newName.trim();
+            if (!newName) return;
+            api("/" + listKind + "/collections/" + encodeURIComponent(name), { method: "PATCH", body: { name: newName } }).then(function() {
+              if (activeFilter[listKind] === name) activeFilter[listKind] = newName;
+              refreshCollections(listKind);
+              refreshList(listKind);
+            });
+          });
+          tabs.appendChild(b);
+        });
+        // 批量目标下拉
+        var batchBar = batchBarFor(listKind);
+        if (batchBar) {
+          var sel = batchBar.querySelector(".saved-batch-target");
+          sel.innerHTML = '<option value="">未分类</option>';
+          collections.forEach(function(name) {
+            var opt = document.createElement("option");
+            opt.value = name; opt.textContent = name;
+            sel.appendChild(opt);
+          });
+        }
+      });
+    }
+
+    // 重渲染列表（app.js 的 renderSavedList 会自动调用；这里用于筛选后强制刷新）
+    function refreshList(listKind) {
+      // 通过点击主站已有的刷新逻辑：触发 saved 列表重载
+      var reload = listKind === "favorite" ? "refreshFavorites" : "refreshWatchLater";
+      if (typeof window[reload] === "function") { window[reload](); }
+    }
+
+    // 筛选：过滤当前网格中的卡片（不触发后端重新拉取，直接 DOM 级）
+    function applyFilter(listKind) {
+      var grid = gridFor(listKind);
+      if (!grid) return;
+      var f = activeFilter[listKind];
+      var cards = grid.querySelectorAll(".saved-card");
+      var visible = 0;
+      cards.forEach(function(card) {
+        var col = (card.dataset.collection || "");
+        var match = f === "" ? true : f === "__none__" ? !col : col === f;
+        card.style.display = match ? "" : "none";
+        if (match) visible++;
+      });
+      // 空态处理
+      var page = pageFor(listKind);
+      var emptyId = listKind === "favorite" ? "favoritesEmpty" : "watchLaterEmpty";
+      var empty = document.getElementById(emptyId);
+      if (empty) {
+        if (visible === 0 && cards.length > 0) empty.removeAttribute("hidden");
+        else empty.setAttribute("hidden", "");
+      }
+    }
+
+    // 给卡片注入选择框 + collection 标记（MutationObserver 监听网格变更）
+    var collectionMap = { favorite: {}, watch_later: {} };
+    function refreshCollectionMap(listKind) {
+      api("/" + listKind + "?limit=200").then(function(data) {
+        var map = {};
+        (data.items || []).forEach(function(it) { map[it.item_key] = it.collection || ""; });
+        collectionMap[listKind] = map;
+        var grid = gridFor(listKind);
+        if (grid) {
+          grid.querySelectorAll(".saved-card").forEach(function(card) {
+            card.dataset.collection = map[card.dataset.itemKey] || "";
+          });
+          if (activeFilter[listKind]) applyFilter(listKind);
+        }
+      });
+    }
+    function injectSelectBoxes(listKind) {
+      var grid = gridFor(listKind);
+      if (!grid) return;
+      grid.querySelectorAll(".saved-card").forEach(function(card) {
+        if (card.querySelector(".saved-select-box")) return;  // 已注入
+        var box = document.createElement("div");
+        box.className = "saved-select-box";
+        box.title = "选择/取消";
+        box.addEventListener("click", function(e) {
+          e.preventDefault();
+          e.stopPropagation();
+          var key = card.dataset.itemKey;
+          if (selected[listKind][key]) {
+            delete selected[listKind][key];
+            box.classList.remove("checked");
+            card.classList.remove("is-selected");
+          } else {
+            selected[listKind][key] = true;
+            box.classList.add("checked");
+            card.classList.add("is-selected");
+          }
+          updateBatchBar(listKind);
+        });
+        card.appendChild(box);
+        // 从 collectionMap 填 collection
+        card.dataset.collection = collectionMap[listKind][card.dataset.itemKey] || "";
+      });
+    }
+
+    function updateBatchBar(listKind) {
+      var batchBar = batchBarFor(listKind);
+      if (!batchBar) return;
+      var count = Object.keys(selected[listKind]).length;
+      batchBar.querySelector(".saved-batch-count").textContent = "已选 " + count + " 项";
+      batchBar.querySelector(".saved-batch-apply").disabled = count === 0;
+    }
+
+    function enterSelectMode(listKind) {
+      selecting[listKind] = true;
+      var grid = gridFor(listKind);
+      if (grid) grid.querySelectorAll(".saved-card").forEach(function(c) { c.classList.add("is-selecting"); });
+      var batchBar = batchBarFor(listKind);
+      if (batchBar) batchBar.hidden = false;
+      updateBatchBar(listKind);
+    }
+    function exitSelectMode(listKind) {
+      selecting[listKind] = false;
+      selected[listKind] = {};
+      var grid = gridFor(listKind);
+      if (grid) grid.querySelectorAll(".saved-card").forEach(function(c) {
+        c.classList.remove("is-selecting", "is-selected");
+      });
+      var batchBar = batchBarFor(listKind);
+      if (batchBar) batchBar.hidden = true;
+    }
+
+    function bindBar(listKind) {
+      var bar = barFor(listKind);
+      if (!bar) return;
+      var multi = bar.querySelector(".saved-collections-multi");
+      var add = bar.querySelector(".saved-collections-add");
+      if (multi && !multi.dataset.bound) {
+        multi.dataset.bound = "1";
+        multi.addEventListener("click", function() {
+          if (selecting[listKind]) { exitSelectMode(listKind); multi.textContent = "☑ 多选"; }
+          else { enterSelectMode(listKind); multi.textContent = "✕ 取消多选"; }
+        });
+      }
+      if (add && !add.dataset.bound) {
+        add.dataset.bound = "1";
+        add.addEventListener("click", function() {
+          var name = window.prompt("新建收藏夹名字：", "");
+          if (!name) return;
+          name = name.trim();
+          if (!name) return;
+          api("/" + listKind + "/collections", { method: "POST", body: { name: name } }).then(function() {
+            refreshCollections(listKind);
+          });
+        });
+      }
+      // 批量操作条
+      var batchBar = batchBarFor(listKind);
+      if (batchBar) {
+        var apply = batchBar.querySelector(".saved-batch-apply");
+        var cancel = batchBar.querySelector(".saved-batch-cancel");
+        if (apply && !apply.dataset.bound) {
+          apply.dataset.bound = "1";
+          apply.addEventListener("click", function() {
+            var target = batchBar.querySelector(".saved-batch-target").value;
+            var keys = Object.keys(selected[listKind]);
+            if (!keys.length) return;
+            api("/" + listKind + "/batch-collection", { method: "POST", body: { item_keys: keys, collection: target } }).then(function() {
+              exitSelectMode(listKind);
+              var multi = bar.querySelector(".saved-collections-multi");
+              if (multi) multi.textContent = "☑ 多选";
+              refreshList(listKind);
+            });
+          });
+        }
+        if (cancel && !cancel.dataset.bound) {
+          cancel.dataset.bound = "1";
+          cancel.addEventListener("click", function() {
+            exitSelectMode(listKind);
+            var multi = bar.querySelector(".saved-collections-multi");
+            if (multi) multi.textContent = "☑ 多选";
+          });
+        }
+      }
+      refreshCollections(listKind);
+    }
+
+    // 初始化：绑定两个列表 + MutationObserver 注入选择框 + 从卡片数据读 collection
+    LIST_KINDS.forEach(function(listKind) {
+      bindBar(listKind);
+      var grid = gridFor(listKind);
+      if (grid && !grid.dataset.obsBound) {
+        grid.dataset.obsBound = "1";
+        var obs = new MutationObserver(function() {
+          injectSelectBoxes(listKind);
+          refreshCollectionMap(listKind);
+        });
+        obs.observe(grid, { childList: true, subtree: true });
+      }
+    });
+    // 页面打开时（隐藏的 DOM 仍在）确保绑定一次
+    window.setTimeout(function() {
+      LIST_KINDS.forEach(function(listKind) { bindBar(listKind); });
+    }, 1500);
+  })();
+</script>
+<!-- ── 卡片详情弹窗（全局共享：深潜 + 主站官方卡片） ── -->
+<div class="card-detail-overlay" id="cardDetailOverlay" hidden>
+  <div class="card-detail-modal" role="dialog" aria-modal="true" aria-label="内容预览">
+    <button class="card-detail-close" id="cardDetailClose" type="button" aria-label="关闭预览" title="关闭">×</button>
+    <div class="card-detail-cover" id="cardDetailCover">
+      <span class="platform-badge" id="cardDetailPlatform"></span>
+    </div>
+    <div class="card-detail-body">
+      <h3 class="card-detail-title" id="cardDetailTitle"></h3>
+      <p class="card-detail-author" id="cardDetailAuthor"></p>
+      <p class="card-detail-desc" id="cardDetailDesc"></p>
+      <div class="card-detail-actions">
+        <span class="card-detail-hint">再次点击下方按钮打开原链接</span>
+        <button class="card-detail-open-btn" id="cardDetailOpen" type="button">打开原链接 ↗</button>
+      </div>
+    </div>
+  </div>
+</div>
+<script>
+  // ── 卡片详情弹窗（深潜 + 主站官方卡片共用） ──────────────────
+  (function() {
+    var overlay = document.getElementById("cardDetailOverlay");
+    var detailCover = document.getElementById("cardDetailCover");
+    var detailPlatform = document.getElementById("cardDetailPlatform");
+    var detailTitle = document.getElementById("cardDetailTitle");
+    var detailAuthor = document.getElementById("cardDetailAuthor");
+    var detailDesc = document.getElementById("cardDetailDesc");
+    var detailOpen = document.getElementById("cardDetailOpen");
+    var detailClose = document.getElementById("cardDetailClose");
+    var currentUrl = "";
+
+    function escapeHtml(s) {
+      if (!s) return "";
+      return String(s).replace(/&/g,"&amp;").replace(/</g,"&lt;").replace(/>/g,"&gt;").replace(/"/g,"&quot;");
+    }
+    function proxyCover(url) {
+      if (!url) return "";
+      var full = String(url).trim();
+      if (full.startsWith("//")) full = "https:" + full;
+      try { new URL(full); } catch(e) { return ""; }
+      return "/api/image-proxy?url=" + encodeURIComponent(full);
+    }
+
+    // 打开弹窗：data = {title, url, author, description, cover_url, platform}
+    window.openCardDetail = function(data) {
+      if (!data || !data.title) return;
+      currentUrl = data.url || "";
+      // 清空旧的封面
+      detailCover.querySelectorAll("img").forEach(function(img) { img.remove(); });
+      // 封面（优先真实封面，无则平台色占位）
+      var coverSrc = proxyCover(data.cover_url);
+      if (coverSrc) {
+        var img = document.createElement("img");
+        img.src = coverSrc;
+        img.alt = data.title;
+        img.referrerPolicy = "no-referrer";
+        detailCover.insertBefore(img, detailPlatform);
+      } else {
+        var ph = document.createElement("div");
+        ph.className = "platform-ph platform-ph-" + (data.platform || "x");
+        ph.style.minHeight = "200px";
+        ph.textContent = data.platform || "内容";
+        detailCover.insertBefore(ph, detailPlatform);
+      }
+      detailPlatform.textContent = data.platform || "";
+      detailTitle.textContent = data.title;
+      detailAuthor.textContent = data.author || "";
+      detailDesc.textContent = data.description || "";
+      detailOpen.disabled = !currentUrl;
+      detailOpen.textContent = currentUrl ? "打开原链接 ↗" : "无可用链接";
+      overlay.hidden = false;
+      overlay.classList.remove("is-closing");
+      document.body.style.overflow = "hidden";
+    };
+    function closeCardDetail() {
+      if (overlay.hidden) return;
+      overlay.classList.add("is-closing");
+      window.setTimeout(function() {
+        overlay.hidden = true;
+        overlay.classList.remove("is-closing");
+        document.body.style.overflow = "";
+      }, 160);
+    }
+    window.closeCardDetail = closeCardDetail;
+    if (detailClose) detailClose.addEventListener("click", function(e) { e.stopPropagation(); closeCardDetail(); });
+    if (overlay) overlay.addEventListener("click", function(e) {
+      if (e.target === overlay) closeCardDetail();
+    });
+    if (detailOpen) detailOpen.addEventListener("click", function(e) {
+      e.stopPropagation();
+      if (currentUrl) window.open(currentUrl, "_blank", "noopener,noreferrer");
+      closeCardDetail();
+    });
+    document.addEventListener("keydown", function(e) {
+      if (e.key === "Escape") closeCardDetail();
+    });
+
+    // ── 主站官方卡片拦截（不动 512KB bundle）──
+    // 官方卡片封面是原生 <a href target="_blank">，用捕获阶段拦截：
+    // 点击封面 → 打开详情弹窗，阻止原生跳转；弹窗内再点「打开原链接」才跳转。
+    document.addEventListener("click", function(e) {
+      // 只处理主站推荐网格里的卡片封面（深潜卡片已自带 handler，不重复拦截）
+      if (overlay && !overlay.hidden) return;
+      var cover = e.target.closest("#videoGrid .video-card .cover, #videoGrid .video-card .cover a");
+      if (!cover) return;
+      var card = cover.closest(".video-card");
+      if (!card) return;
+      var link = cover.closest("a") || (cover.tagName === "A" ? cover : null);
+      // 若弹窗内已打开或点击的是反馈按钮区域，不拦截
+      if (e.target.closest(".card-actions, .card-feedback-icons, .comment-field, .reason, [data-action]")) return;
+      // 提取卡片数据（从 DOM）
+      var titleEl = card.querySelector(".video-title");
+      var authorEl = card.querySelector(".up-name") || card.querySelector(".video-meta .up-link") || card.querySelector(".video-meta");
+      var descEl = card.querySelector(".reason-text");
+      var platEl = card.querySelector(".platform");
+      var img = card.querySelector(".cover img");
+      var rawCover = "";
+      if (img) {
+        var src = img.getAttribute("src") || "";
+        if (src.indexOf("/api/image-proxy?url=") === 0) {
+          try { rawCover = decodeURIComponent(src.split("url=")[1]); } catch(err) {}
+        } else if (src && src.indexOf("http") === 0) {
+          rawCover = src;
+        }
+      }
+      var authorText = "";
+      if (authorEl) {
+        authorText = authorEl.textContent || "";
+        if (authorEl.classList.contains("video-meta")) {
+          // 主站 .video-meta 是「作者 · 主题 · 时间」拼接，只取第一段（作者）
+          var seg = authorText.split("·")[0] || "";
+          authorText = seg.trim();
+        }
+      }
+      e.preventDefault();
+      e.stopPropagation();
+      if (typeof window.openCardDetail === "function") {
+        window.openCardDetail({
+          title: titleEl ? titleEl.textContent : "",
+          url: link ? link.href : "",
+          author: authorText,
+          description: descEl ? descEl.textContent : "",
+          cover_url: rawCover,
+          platform: platEl ? platEl.textContent : ""
+        });
+      }
+    }, true);  // 捕获阶段：先于 app.js 的 bubble 阶段 handler
+  })();
+</script>
 </body></html>


### PR DESCRIPTION
> 💡 **灵感来源**：[#114](https://github.com/whiteguo233/OpenBiliClaw/issues/114)「深潜研究/专题探索」功能请求，感谢 [@DongLanQwQ0](https://github.com/DongLanQwQ0) 提出这个很有价值的方向！（commit 已含 Co-authored-by）

# 深潜研究（Deep Dive）：AI 引导的多平台定向检索

## 功能简介

与 OpenBiliClaw 现有的被动推荐互补，新增「深潜研究」——用户主动提出方向，AI 引导澄清需求、生成跨平台搜索计划、抓取真实内容并以卡片呈递；不满意可随时修正，AI 重新搜索。

```
用户提方向 → AI 引导澄清 → 生成搜索计划 → 多平台抓取 → 卡片呈递 → 用户修正 → 再抓
```

---

## 核心特性

### 🧠 AI 引导全流程
- 输入方向 → LLM 生成**澄清问题**（场景化：如新疆旅游会问「南疆还是北疆？几天？预算？」，学 AE 会问「零基础还是有基础？学习目的？」）
- 回答 → LLM 生成**结构化搜索计划**（多平台关键词组 JSON）
- 随时修正方向（「去掉徒步景点」「改成 9 月」）→ 重新生成搜索计划再搜索

### 🔍 四平台真实搜索（带封面）
**平台源动态匹配你设置的平台源**——web 设置里开关平台后深潜立即跟随（每次请求重新读取配置），下面 4 个是示例：

| 平台 | 方式 |
|------|------|
| B站 | 官方 API 真实搜索（含封面、bvid、UP主、播放量）|
| 抖音 | 浏览器扩展任务队列（plugin 机制，规避风控）|
| 小红书 | 浏览器扩展任务队列 |
| 知乎 | 搜索链接卡兜底（平台无开放搜索 API）|

**封面的坑**：B站图床防盗链 → 走 `/api/image-proxy` 代理 + 域名白名单；协议相对路径 `//` 补全 `https:`；抖音返回的 `cover` 是 dict 结构 → 取 `url_list[0]` + ast 兜底解析。全部真实可加载。

### 🎴 完整卡片交互
- 喜欢 / 不感兴趣 / 忽略 / 稍后再看 / 收藏 / 聊一聊，**10 秒可撤销**延迟提交（复用主站 pending-actions 机制，惰性初始化防 defer 竞态）
- **点踩/忽略 10 秒生效后卡片自动消失**（渐隐动画），10 秒内可撤销；这个功能**顺便给主 web 首页也加上了**
- **卡片详情弹窗**（毛玻璃 blur(22px)）：点击卡片先**预览**（封面大图 + 标题/作者/简介/平台），弹窗内**再点一次「打开原链接」才跳转**——防错点误跳；**主站首页卡片复用同一套弹窗**（document 捕获阶段拦截原生 `<a>` 跳转，零改 bundle）
- **聊一聊接入真实 AI 对话**：提交后除记录 feedback 信号外，还会创建对话 turn（与主 Web 共享 session），AI 在对话面板真实回复

### 📁 会话管理
- **SQLite 持久化**（独立 `deepdive_sessions.db`，不污染主库），重启不丢，可删除/重命名
- **树形文件夹收纳**（Win11 文件管理器风格）：建文件夹 / 移动会话 / 折叠展开（箭头旋转动画）/ 重命名 / 删除（删除文件夹时会话移回根目录不丢失）
- **右侧 AI 对话面板**：
  - **输入栏动态跟随消息流**——不固定在最底部，消息增多时输入栏跟着下移（放在消息列表内部作为最后一个元素）
  - **历史对话折叠**——默认只渲染最近 10 条，点「展开更早对话」加载全部并滚到顶部
  - **搜索进度提示**——「别急，正在跨平台搜索中…」8 秒轮换文案（轻量，不搞复杂进度条）

### 🗂️ 收藏夹多选批量分类
稍后再看 / 收藏页面：
- **建收藏夹 + 多选批量归类**——点「多选」勾选多条内容，一键归入目标收藏夹；筛选 tabs（全部/未分类/各收藏夹）
- **小心思设计**：每个收藏夹 tab **鼠标移上去才会显示** ✎重命名 / ✕删除 小按钮——平时界面干净，hover 时才暴露管理入口，避免误触（早期用「双击删除、右键重命名」太隐蔽且双击易误删，已改掉）
- 删除收藏夹有确认弹窗，内容自动移回未分类

### 🔀 智能聚合（去重 + 排序）
复用主站 `discovery/engine.py` 的机制做三层处理：
1. **身份去重**：`platform:content_id`（bvid 等）优先，URL 兜底，最后 `platform:title:author`
2. **标题归一化去重**：去空白后跨平台同标题只留高分（如 B站 95 分 + 抖音 90 分同标题 → 留 B站）
3. **平台混合排序**：真实结果优先、链接卡兜底靠后，再按平台权重 + 原始分排序

### ⚙️ 可定制
- 设置页 → 高级功能 → 「深潜探索」：**plan/execute/refine 三个 LLM Prompt 可自定义**，编辑框预填官方默认值，附「保存」+「一键恢复默认」
- **持久化设计**：不塞进 config.toml（主站 `save_config()` 会整个重写文件，存未知段会被覆盖丢失）→ 独立 `deepdive_prompts.json`，与主站配置完全隔离、零风险

---

## 实现要点

- **独立模块**：`deepdive/session.py`（SQLite 会话管理）+ `deepdive/engine.py`（LLM 引导引擎），不嵌入被动推荐 runtime，冲突面小
- **前端零改动 512KB 主 bundle**：全部内联 JS/CSS，独立内嵌页面（`#deepdivePage` section），CSS 用主站主题变量自动跟随深浅色
- **移动端**：<820px 全屏对话模式，卡片区/对话区切换按钮，resize 跨断点自动修正
- **API**：start / clarify / refine / get / list / delete / rename / folders / prompts / collections（共 16+ 端点）
- **动态平台源**：每次请求前重读配置，web 设置开关平台后深潜立即跟随

---

## 与 Issue #114 的对应

- ✅ 左侧栏新增选项卡（「深潜研究」一级导航）
- ✅ 用户输入框自由描述方向
- ✅ 初始询问 + 澄清问题（场景化提问，如新疆/AE 各一套）
- ✅ 多轮搜索与卡片呈递（四平台）
- ✅ 动态修正（「去掉徒步景点」「改成 9 月」→ 重新搜索）
- ✅ 多会话独立存储与切换（SQLite + 树形文件夹）
- ⚠️ 部分后置：终止/暂停控制条（MVP 砍掉，后续可加）、话题无关拒绝（当前用户自助新建会话）

---

## 测试情况

- **全链路**：开始 → 澄清 → 跨平台搜索（B站/抖音/小红书真实带封面）→ 卡片反馈 → 修正 → 持久化 → 树形收纳
- **浏览器实测**：卡片详情弹窗（打开/遮罩关闭/ESC/跳转）、收藏夹多选批量分类（2 项一键归类）、历史折叠（25 条默认显示 10 条、展开全显）、搜索提示轮换、主站首页点踩消失（20→19 张）、深潜聊一聊 AI 真实回复，均验证通过
- **主站 512KB bundle 无改动**，深潜模块不影响原有推荐流程