### PR TITLE
fix(install): escape $InstallDir: in install.ps1 (issue #157)

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,8 @@
 
 ## 未发布
 
+- **修复 Windows 一键安装脚本解析错误（issue #157）**：`scripts/install.ps1` 第 238 行 `"Cannot merge checkout into $InstallDir: ..."` 中，双引号内的 `$InstallDir:` 被 PowerShell 解析为「驱动器/作用域限定变量引用」（类似 `$env:PATH`），因 `:` 后紧跟非变量名字符触发 `Variable reference is not valid`，导致整个脚本在 parse 阶段即失败、原生 Windows 一键安装必现挂掉。现改为 `${InstallDir}` 括号定界写法，脚本可正常解析执行。全局复查确认其余 `$var:` 均为合法的 `$env:` / `$script:` 作用域限定或单引号/反引号转义场景；新增回归测试 `test_install_ps1_has_no_bare_variable_colon_in_double_quotes` 拦截双引号内的裸 `$var:` 写法。
+
 ## v0.3.205：证据驱动时效推荐与可靠性升级（2026-08-14）
 
 - **发布与市场状态**：`backend-v0.3.205`、`extension-v0.3.205`、`desktop-v0.3.205` 与聚合 `openbiliclaw-v0.3.205` 均指向提交 `a49af312`；聚合 Latest Release 已附两份扩展 ZIP 与四份桌面安装器。Chrome Web Store 已上传 `0.3.205` 并进入 `PENDING_REVIEW`；Firefox AMO 已接受 listed `0.3.205`，文件状态为 `unreviewed`。AMO `eula_policy` API 仍返回 HTTP 406，manifest 数据类别、reviewer notes、商店描述和随包隐私政策已提交。

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -235,7 +235,7 @@ function Clone-IntoUserDataRoot {
         $dest = Join-Path $InstallDir $entry.Name
         if (Test-Path $dest) {
             Remove-Item -Recurse -Force $tmp -ErrorAction SilentlyContinue
-            Log-Err "Cannot merge checkout into $InstallDir: destination exists: $dest"
+            Log-Err "Cannot merge checkout into ${InstallDir}: destination exists: $dest"
             exit 1
         }
         Move-Item -LiteralPath $entry.FullName -Destination $InstallDir

--- a/tests/test_install_contract_docs.py
+++ b/tests/test_install_contract_docs.py
@@ -1,3 +1,4 @@
+import re
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent
@@ -227,3 +228,38 @@ def test_installers_can_clone_code_into_existing_packaged_data_root() -> None:
     assert "Test-UserDataOnlyRoot" in install_ps1
     assert "Clone-IntoUserDataRoot" in install_ps1
     assert "_is_user_data_only_root" in bootstrap
+
+
+# Legitimate PowerShell scope / provider qualifiers that may appear as `$name:`
+# inside double-quoted strings (e.g. `$env:PATH`, `$script:ReuseFrom`).
+_PS_SCOPE_PROVIDERS = {
+    "env",
+    "variable",
+    "function",
+    "alias",
+    "global",
+    "local",
+    "script",
+    "private",
+    "using",
+    "workflow",
+}
+
+
+def test_install_ps1_has_no_bare_variable_colon_in_double_quotes() -> None:
+    install_ps1 = _read("scripts/install.ps1")
+
+    # In a double-quoted PowerShell string, `$name:` is parsed as a
+    # scope/provider-qualified reference (like `$env:PATH`). When `name` is a
+    # plain variable the `:` is followed by a non-name character and the whole
+    # script fails to parse with "Variable reference is not valid" — this is
+    # exactly the one-command-install breakage from issue #157. `${InstallDir}:`
+    # (braced) is the correct escaping; `$env:` / `$script:` and a
+    # backtick-escaped `` `$name `` are legitimate and must stay allowed.
+    for match in re.finditer(r"\$([A-Za-z_][A-Za-z0-9_]*):", install_ps1):
+        name = match.group(1)
+        escaped = install_ps1[match.start() - 1 : match.start()] == "`"
+        assert name in _PS_SCOPE_PROVIDERS or escaped, (
+            f"scripts/install.ps1 has a bare `$name:` variable reference at "
+            f"offset {match.start()}; use `${{{name}}}:` in double-quoted strings."
+        )


### PR DESCRIPTION
## 摘要
修复 `scripts/install.ps1` 第 238 行双引号内的 `$InstallDir:` 被 PowerShell 解析为作用域限定变量引用导致的 parse 阶段错误（`Variable reference is not valid`），原生 Windows 一键安装必现失败。改为 `${InstallDir}` 定界写法。

## 变更
- `scripts/install.ps1`：`$InstallDir:` → `${InstallDir}`
- `tests/test_install_contract_docs.py`：新增回归测试拦截双引号内裸 `$var:` 写法
- `docs/changelog.md`：未发布区块新增条目

## 测试
- `uv run --with pytest --no-project python -m pytest tests/test_install_contract_docs.py -q` → 15 passed

Closes #157