### PR TITLE
feat(llm): add OrcaRouter provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -850,7 +850,7 @@ OpenBiliClaw/
 |------|------|
 | 后端 | Python 3.11+ |
 | 浏览器插件 | TypeScript + Chrome Extension (Manifest V3) |
-| LLM | 同一 Provider 类型可建多个独立 Base URL / token / model 实例，并配置全局及模块有序降级链；首次迁移自动保留旧配置备份，`config-export-legacy` 可生成旧版副本；内置 Gemini / DeepSeek / OpenAI / Claude / OpenRouter / Ollama，兼容任意 OpenAI 协议服务；OpenAI 可实验性复用 Codex CLI OAuth |
+| LLM | 同一 Provider 类型可建多个独立 Base URL / token / model 实例，并配置全局及模块有序降级链；首次迁移自动保留旧配置备份，`config-export-legacy` 可生成旧版副本；内置 Gemini / DeepSeek / OpenAI / Claude / OpenRouter / OrcaRouter / Ollama，兼容任意 OpenAI 协议服务；OpenAI 可实验性复用 Codex CLI OAuth |
 | B 站交互 | 自研 API 客户端 (WBI 签名 · v_voucher 自动恢复 · 速率控制) |
 | 小红书交互 | 扩展 DOM/state 元数据提取 + 插件任务调度；search / creator 在后台标签执行，search 用 MAIN-world 页面响应桥避开隐藏页虚拟 DOM 限制；仅滚动型初始化会前台打开 `/explore` 并点击页面 profile 入口（零后端爬取） |
 | 抖音交互 | 扩展 DOM + MAIN-world 被动 fetch tap + 插件任务调度；初始化导入发布 / 收藏 / 点赞 / 关注信号，search / hot / feed discovery 从抖音首页模拟 DOM 操作触发加载，search/feed 被动收集页面响应 / 渲染结果，hot 可用热榜 `group_id` seed 走已登录页面 related fallback（零后端代登录） |

--- a/README_EN.md
+++ b/README_EN.md
@@ -841,7 +841,7 @@ OpenBiliClaw/
 |--------|-----------|
 | Backend | Python 3.11+ |
 | Browser Extension | TypeScript + Chrome Extension (Manifest V3) |
-| LLM | Multiple independent Base URL / token / model instances per provider type, with ordered global and per-module failover chains; first migration keeps a permanent legacy backup and `config-export-legacy` creates an old-version copy; built-in Gemini / DeepSeek / OpenAI / Claude / OpenRouter / Ollama; any OpenAI-compatible endpoint works; OpenAI can experimentally reuse Codex CLI OAuth |
+| LLM | Multiple independent Base URL / token / model instances per provider type, with ordered global and per-module failover chains; first migration keeps a permanent legacy backup and `config-export-legacy` creates an old-version copy; built-in Gemini / DeepSeek / OpenAI / Claude / OpenRouter / OrcaRouter / Ollama; any OpenAI-compatible endpoint works; OpenAI can experimentally reuse Codex CLI OAuth |
 | Bilibili API | Custom client (WBI signing · v_voucher auto-recovery · rate control) |
 | Xiaohongshu | Extension DOM/state extraction + task dispatch; search/creator run in background tabs and search uses a MAIN-world page-response bridge when hidden virtual DOM is absent; only scrolling init opens `/explore` in the foreground and clicks the profile entry; no backend crawling |
 | Douyin | Extension DOM + MAIN-world passive fetch tap + task dispatch; init imports post / favorite / like / follow signals; search / hot / feed discovery starts from the Douyin home page and uses DOM interactions to trigger loading; search/feed passively collect page responses / rendered results, and hot can use a hot-board `group_id` seed as a logged-in related fallback; no backend login crawling |

--- a/config.example.toml
+++ b/config.example.toml
@@ -1,7 +1,7 @@
 # OpenBiliClaw configuration example
 # Copy this file to config.toml and edit as needed.
 # 首次运行如果缺少 config.toml，程序会自动基于本文件生成模板。
-# 使用远程模型（OpenAI / Claude / Gemini / DeepSeek / OpenRouter）时，需要为调用链中的实例填写 api_key。
+# 使用远程模型（OpenAI / Claude / Gemini / DeepSeek / OpenRouter / OrcaRouter）时，需要为调用链中的实例填写 api_key。
 # 本地 Ollama 主要用于向量检索（embedding, bge-m3）。作为聊天 provider 属高级用法：
 # 捆绑的 Ollama 只装了 embedding 模型，小体积本地聊天模型达不到内容管线质量线，
 # 因此图形向导 / init / bootstrap 都不再推荐把它当聊天默认。确要如此的高级用户可手动
@@ -61,7 +61,7 @@ default_chain = ["deepseek"]
 concurrency = 4
 # Global request timeout for all LLM providers (seconds).
 # Applies to OpenAI / Claude / Gemini / DeepSeek / Ollama / OpenRouter /
-# openai_compatible. Allowed range: 10..1200. Default 1200s (20 minutes).
+# OrcaRouter / openai_compatible. Allowed range: 10..1200. Default 1200s (20 minutes).
 timeout = 1200
 # 新实例请直接在桌面设置页创建。手工配置时复制下面的完整表，
 # 给每个渠道一个稳定且唯一的 ID，再把 ID 加进 default_chain：
@@ -76,6 +76,17 @@ timeout = 1200
 # api_flavor = ""
 #
 # default_chain = ["deepseek", "relay-backup"]
+#
+# [llm.instances.orcarouter]
+# name = "OrcaRouter 聚合"
+# provider_type = "orcarouter"
+# enabled = true
+# api_key = "sk-orca-..."
+# model = "openai/gpt-4o"
+# base_url = "https://api.orcarouter.ai/v1"
+# reasoning_effort = "medium"
+#
+# default_chain = ["deepseek", "orcarouter"]
 
 [llm.instances.deepseek]
 name = "DeepSeek 官方"
@@ -212,7 +223,7 @@ executable = ""
 headed = false
 
 # ── 海外网络路由（仅作用于海外客户端）──
-# 作用范围：OpenAI / Claude / Gemini / DeepSeek / OpenRouter / openai_compatible
+# 作用范围：OpenAI / Claude / Gemini / DeepSeek / OpenRouter / OrcaRouter / openai_compatible
 # 的 chat + embedding、YouTube(yt-dlp)、X(twitter-cli)、Reddit(rdt-cli /
 # OpenCLI)、Bangumi(api.bgm.tv 与封面 CDN lain.bgm.tv 均为海外 Cloudflare,
 # 国内网络直连易超时,需走代理)、GitHub 自动更新、Codex OAuth。

--- a/docs/agent-install.md
+++ b/docs/agent-install.md
@@ -276,7 +276,7 @@ questions, then re-run bootstrap with those flags.
 
 v0.3.95+ embedding safety net (`should_auto_wire_embedding`): when
 `[llm.embedding].provider` would otherwise stay empty — e.g. the chat
-provider is Claude / DeepSeek / OpenRouter (which can't embed) and you
+provider is Claude / DeepSeek / OpenRouter / OrcaRouter (which can't embed) and you
 never passed `--embedding-provider` — bootstrap auto-writes
 `provider=ollama, model=bge-m3` and pulls the model, so semantic dedup
 isn't silently disabled (the symptom is recommendations repeating
@@ -308,11 +308,16 @@ user chooses an OpenAI-compatible gateway / preset path.
 | 4. **Gemini 官方** | `gemini-2.5-flash`(稳定;可选 gemini-3-flash-preview / gemini-3.1-pro-preview 旗舰 Public Preview 需付费项目) | Google AI Studio 申请 Key | ✅ 需要 | 免费档每天 1500 次 |
 | 5. **Claude 官方** | `claude-sonnet-4-6`(1M ctx;可选 claude-haiku-4-5 便宜 / claude-opus-4-7 旗舰) | Anthropic console | ✅ 需要 | $3-$75/M,按 token,质量高 |
 | 6. **OpenRouter** | `openai/gpt-5-nano`(格式 `<vendor>/<model>`) | 一个 Key 跑多家 | ✅ 需要 | 按调用计费 |
-| 7. **本地 Ollama**（完全免费 / 离线 / 不要 Key） | `qwen2.5:7b`(中文好;可选 llama3.2 / gemma2 / mistral / deepseek-r1) | 16GB+ 内存,能接受 1–3 分钟首次响应 | ❌ 不需要 | ✅ 免费 / ⚠️ CPU 推理慢 |
+| 7. **OrcaRouter** | `openai/gpt-4o`(格式 `<vendor>/<model>`) | 一个 Key 跑 150+ 模型 / 网关级零信任安全 | ✅ 需要 | 按调用计费 |
+
+> **本地 Ollama 不在聊天 provider 菜单里**（v0.3.176+）：随装的 Ollama 只带
+> embedding 模型 `bge-m3`，小体积本地聊天模型达不到内容管线质量线。需要本地
+> 聊天模型时到桌面设置页手动配置，或显式 `--provider ollama --llm-model qwen2.5:7b`
+> 走完全离线路径（见下方「Hardware caveat for local Ollama」）。
 
 > ⚠️ **不要把选项 3 (OpenAI 官方) 和选项 2 (协议兼容) 混淆**:走 OpenAI API 官方端点选 3;走任何"OpenAI 协议兼容"的第三方 / 自建服务选 2。
 
-**AI agent 决策建议**: **默认引导 #1 DeepSeek**(几毛钱搞定);用户明确说"我有中转站 Key / OneAPI / 通义 / 智谱 / Kimi / MiniMax / Yi / Azure / vLLM 等任何 OpenAI 兼容服务"→ 引导 #2(进子菜单后再细分);用户明确说"用 OpenAI / Gemini / Claude 官方"才走 #3-5;Ollama 仅在用户明确要求"本地 / 离线"时引导。
+**AI agent 决策建议**: **默认引导 #1 DeepSeek**(几毛钱搞定);用户明确说"我有中转站 Key / OneAPI / 通义 / 智谱 / Kimi / MiniMax / Yi / Azure / vLLM 等任何 OpenAI 兼容服务"→ 引导 #2(进子菜单后再细分);用户明确说"用 OpenAI / Gemini / Claude 官方"才走 #3-5;用户提到"OrcaRouter / 一个 Key 跑多家模型 + 安全网关"→ 引导 #7;Ollama 仅在用户明确要求"本地 / 离线"时用显式 `--provider ollama` 走离线路径。
 
 **选项 2 的核心场景:你买了第三方中转站 / OneAPI 的 Key**,想用人民币付钱跑 OpenAI / Claude / 国产模型 —— 这是国内绝大多数用户用这个选项的真正原因。子菜单 9 个 preset 中,**第 1 个就是中转站(默认)**:
 
@@ -380,7 +385,7 @@ under ¥1 for most users. That's the actual zero-friction path. Ollama
 remains a first-class option for people who genuinely want offline /
 no-key setups, but should not be sold as "新手友好".
 
-**Hardware caveat for option 7 (Ollama)**: tell the user upfront —
+**Hardware caveat for local Ollama**: tell the user upfront —
 "本地模型的首次响应会比较慢（CPU 推理），内存建议 16GB 以上。如果你介意等待，
 选 1 或 2 更顺。" Don't wave them into Ollama if they have a 4-core
 Windows laptop with 8 GB.
@@ -426,7 +431,7 @@ flags from Step 3. DeepSeek has no embeddings endpoint, so recommend
 local Ollama bge-m3 unless the user explicitly wants Gemini / OpenAI
 embedding. `--embedding-provider ""` now means "do not enable embedding".
 
-#### Options 3-6 (OpenAI 官方 / Gemini / Claude / OpenRouter):
+#### Options 3-7 (OpenAI 官方 / Gemini / Claude / OpenRouter / OrcaRouter):
 
 Substitute the right vendor name and Key URL:
 
@@ -434,13 +439,14 @@ Substitute the right vendor name and Key URL:
 - Gemini: https://aistudio.google.com/apikey
 - Claude: https://console.anthropic.com/ → Settings → API Keys
 - OpenRouter: https://openrouter.ai/keys
+- OrcaRouter: https://www.orcarouter.ai/keys
 
 Run with `--provider <name> --llm-api-key <KEY>` plus the Step 3
 embedding flags. Don't ask for Base URL. Embedding is independent from
 the primary LLM; if the user wants embedding, pass an explicit
 `--embedding-provider` and its model/key fields.
 
-#### Option 3 (Ollama, fully offline / no key):
+#### Ollama (fully offline / no key, via `--provider ollama`):
 
 **You don't need to ask the user to install Ollama themselves.** Since
 v0.3.10, `agent_bootstrap.py` auto-installs Ollama (macOS via `brew`,

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -449,7 +449,7 @@ flowchart LR
 微博的个人 bootstrap 采用同一类隔离任务边界，但不是普通行为采集：`weibo_tasks` → `/api/sources/weibo/next-task` → 带 `openbiliclaw_weibo_task=1` 的 `m.weibo.cn` tab → 同源 `/api/config` / `/api/account/getuid` 与收藏、关注、mentions GET → `/api/sources/weibo/task-result`。`SUBP + ALF` 只在扩展本地作为登录布尔提示，游客 `SUB` 不算凭据；任务结果必须带正 uid，后端按账号与 scope 去重后才进入 profile event ingress。失败/登录墙/挑战页/部分 scope 不会伪装成 healthy empty，已采 rows 仍留在 staged result 中。
 
 ### LLM Providers (`llm/`)
-- 统一的多模型接口（OpenAI / Claude / Gemini / DeepSeek / Ollama / OpenRouter）
+- 统一的多模型接口（OpenAI / Claude / Gemini / DeepSeek / Ollama / OpenRouter / OrcaRouter）
 - `[llm.instances.<id>]` 为每个端点保存独立 `provider_type` / Base URL / token / model；registry 以实例 ID 注册，同一个 adapter 可实例化多次。`default_chain` 可包含任意数量实例，失败与限流 cooldown 都只影响当前实例
 - `LLMService` 通过 caller bucket 选择 `[llm.routes.soul/discovery/recommendation/evaluation]`：默认继承全局链，`inherit=false` 时执行模块自己的完整链并严格禁止 spill 到全局链。旧 provider/model override 会投影为等价实例或派生实例
 - `LLMRegistry.complete_chain()` 执行有序链，`complete_provider()` 精确探测一个实例；响应携带最终 `instance_id`。Ollama chat 实例必须显式配置 model，仅有服务地址或独立 `bge-m3` embedding 不会注册 chat、更不会猜 `llama3`

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,8 @@
 
 ## 未发布
 
+- **新增 OrcaRouter 聚合 provider**：`provider_type="orcarouter"` 以 OpenAI 兼容协议接入 OrcaRouter（`https://api.orcarouter.ai/v1`），一个 Key 跑 150+ 模型；复用统一超时 / 重试 / 错误归一化 / JSON mode 与 per-call model 覆盖，`reasoning_effort` 按 OpenAI 风格顶层标量透传、不发送网关拒绝的嵌套 `reasoning` 对象。四表面契约：后端 registry / 配置、API `/api/config`、CLI 向导与 `agent_bootstrap`、桌面 Web 设置页均已接入，`config.example.toml` 提供实例模板。
+
 ## v0.3.206：with-embedding 崩溃修复与可靠性提升（2026-08-15）
 
 - **项目首页与 README 重新对齐**：补齐一直遗漏的 YouTube / X 来源卡，使首页明确展示 B 站、小红书、抖音、YouTube、X、知乎、Reddit、Linux.do、Bangumi、V2EX、微博与开放 Web；首屏补回“本地运行、只为一个人构建、反馈可调教”的定位，产品入口从过时的“只有浏览器侧边栏”更新为浏览器插件、桌面 Web、移动 Web、Flutter 与 DSH 五端，并修正中文微博文案误用英文、Firefox、架构分层、聚合 Release 说明以及静态 HTML / 中文词典漂移。

--- a/docs/docker-deployment.md
+++ b/docs/docker-deployment.md
@@ -8,7 +8,7 @@
 
 - [Docker](https://docs.docker.com/get-docker/) 20.10+
 - [Docker Compose](https://docs.docker.com/compose/install/) V2（`docker compose` 命令）
-- 一个 LLM API Key（OpenAI / Claude / Gemini / DeepSeek / OpenRouter）—— **Embedding 用 compose 自带的 Ollama 不再需要单独申请**
+- 一个 LLM API Key（OpenAI / Claude / Gemini / DeepSeek / OpenRouter / OrcaRouter）—— **Embedding 用 compose 自带的 Ollama 不再需要单独申请**
 
 ### 自带 Ollama embedding sidecar（bge-m3 已烤进镜像,离线开箱即用）
 
@@ -272,6 +272,7 @@ base_url = "https://relay.example.com/v1"
 | `openai` | ✅ | 已有 OpenAI 账户 | base_url 留空 = `https://api.openai.com/v1`；自带 embedding endpoint |
 | `claude` | ✅ | Anthropic 账户 | 高质量推理；无 embedding 接口，需独立配置 `[llm.embedding]` |
 | `openrouter` | ✅ | 想一个 Key 跑多家模型 | 按调用计费；embedding 不可靠，建议独立配置 Ollama / Gemini / OpenAI embedding |
+| `orcarouter` | ✅ | 一个 Key 跑 150+ 模型 + 网关级零信任安全 | 按调用计费；无 embedding 接口，需独立配置 `[llm.embedding]` |
 | `ollama` | ❌ | 完全离线 / 不要 Key / 16GB+ 内存 | CPU 推理首次响应慢（10-60s）。Docker 里的 Ollama chat 实例必须把 `base_url` 设成 `http://host.docker.internal:11434/v1` 才能访问宿主机 |
 | OpenAI 协议兼容自建网关（高级） | ✅ 通常需要 | 自己有 vLLM / LMStudio / Azure / OneAPI / 团队 LLM 网关 | 使用 `provider_type="openai_compatible"`，必须显式配置 `base_url`。**普通用户不要选这个** |
 

--- a/docs/modules/cli.md
+++ b/docs/modules/cli.md
@@ -800,13 +800,14 @@ OpenBiliClaw 需要一个语言模型来理解你的兴趣、写推荐文案。
  4   Gemini 官方                           默认 gemini-2.5-flash (稳定 / 便宜)。Google AI Studio 申请 Key,免费档每天 1500 次够用
  5   Claude 官方                           默认 claude-sonnet-4-6。Anthropic console,按 token 付费,质量高
  6   OpenRouter 聚合                       默认 openai/gpt-5-nano。一个 Key 跑多家模型,按调用计费
+ 7   OrcaRouter 聚合                       默认 openai/gpt-4o。一个 Key 跑 150+ 模型,网关级零信任安全
 
 Tip:不确定就选 1 (DeepSeek),¥0.001/千 token 几乎免费,月度通常 ¥0.5-2。已经买了中转站 / OneAPI Key 选 2 (协议兼容)。本地 Ollama 仅用于向量检索(embedding),不作为聊天服务商;如需本地聊天模型请到设置页手动配置。
 
 请输入序号或名称（默认 1=DeepSeek） [1]:
 
 # (随后只问被选中那一项实际需要的字段——
-#  例如选 1/3/4/5/6: 只问 API Key + 模型名；
+#  例如选 1/3/4/5/6/7: 只问 API Key + 模型名；
 #  选 2: 进协议兼容 preset 子菜单，按需问 Base URL + API Key + 模型名)
 #
 # 注意（v0.3.176+）：本地 Ollama 已不再出现在聊天 provider 菜单里——随装的

--- a/docs/modules/config.md
+++ b/docs/modules/config.md
@@ -211,7 +211,7 @@ base_url = "https://api.deepseek.com"
 | 键 | 类型 | 默认值 | 说明 |
 |----|------|--------|------|
 | `name` | string | 实例 ID | 设置页显示名称，可重复 |
-| `provider_type` | string | `""` | 适配器类型：`openai` / `claude` / `gemini` / `deepseek` / `ollama` / `openrouter` / `openai_compatible` |
+| `provider_type` | string | `""` | 适配器类型：`openai` / `claude` / `gemini` / `deepseek` / `ollama` / `openrouter` / `orcarouter` / `openai_compatible` |
 | `enabled` | bool | `true` | 是否允许注册和引用；停用实例不能留在任何链里 |
 | `api_key` | string | `""` | 此实例自己的凭据；API 默认只回显掩码 |
 | `model` | string | `""` | 此实例固定使用的聊天模型 |
@@ -297,6 +297,19 @@ base_url = "https://api.deepseek.com"
 | `reasoning_effort` | string | `"medium"` | 通过 OpenRouter `reasoning.effort` 统一映射目标厂商；空渠道调用不发送（adapter 没有 per-model mandatory metadata，不能安全地对强制推理模型发 `none`） |
 
 > `http_referer` 和 `x_title` 都是可选项；留空时不会阻止请求发送。
+
+#### OrcaRouter（`provider_type = "orcarouter"`）
+
+[OrcaRouter](https://www.orcarouter.ai) 是 OpenAI 协议兼容的模型路由网关，一个 Key 即可按需路由 150+ 模型，并在网关层提供默认拒绝的零信任安全。它继承 OpenAI 系 adapter 的超时 / 重试 / 错误归一化 / JSON mode / per-call model 语义。
+
+| 键 | 类型 | 默认值 | 说明 |
+|----|------|--------|------|
+| `api_key` | string | `""` | OrcaRouter API Key |
+| `model` | string | `"openai/gpt-4o"` | OrcaRouter 路由的模型名（`<vendor>/<model>` 或平台别名） |
+| `base_url` | string | `"https://api.orcarouter.ai/v1"` | OrcaRouter API 地址 |
+| `reasoning_effort` | string | `"medium"` | 保留以对齐统一配置面；网关把推理参数原样转发给上游路由，非推理模型会以 HTTP 400 拒绝，因此适配器**不发送** `reasoning_effort` / `reasoning`，推理模型使用自身默认档位 |
+
+> OrcaRouter 没有 embedding 接口；需要向量化时在 `[llm.embedding]` 独立配置 Ollama / Gemini / OpenAI 等。
 
 #### OpenAI-compatible（`provider_type = "openai_compatible"`）
 

--- a/docs/modules/llm.md
+++ b/docs/modules/llm.md
@@ -20,7 +20,8 @@
 
 | 任务 | 状态 | 说明 |
 |------|------|------|
-| 2.1 Provider 实现 | ✅ | OpenAI / Claude / Gemini / DeepSeek / Ollama / OpenRouter / OpenAI-compatible，带 retry + 超时 |
+| 2.1 Provider 实现 | ✅ | OpenAI / Claude / Gemini / DeepSeek / Ollama / OpenRouter / OrcaRouter / OpenAI-compatible，带 retry + 超时 |
+| v0.3.x OrcaRouter Provider 支持 | ✅ | 新增 `OrcaRouterProvider`（OpenAI 兼容协议）：一个 Key 跑 150+ 模型，默认 `openai/gpt-4o`，默认端点 `https://api.orcarouter.ai/v1`；沿用统一超时 / 重试 / 错误归一化 / JSON mode 与 per-call model 覆盖。网关把 `reasoning_effort` 与嵌套 `reasoning` 对象都原样转发给上游路由，非推理模型会以 HTTP 400 拒绝（已对 `openai/gpt-4o` 实测），因此适配器**不发送任何推理参数**，推理模型使用自身默认档位 |
 | 2.2 Provider Registry | ✅ | 多端点实例注册 + 全局 / 模块有序链 + 实例级 cooldown + health check |
 | 2.3 Prompt 管理与 Service | ✅ | Prompt 构建器 + LLMService 门面 |
 | 画像整理裁决 prompt | ✅ | `build_profile_consolidation_prompt()` 保持静态 system + 确定性 user JSON；likes 从“仅严格同义”调整为“是否重复占用同一推荐意图”，允许合并“搞笑 / 娱乐搞笑”这类无新增选择价值的同粒度标签，同时明确保留“篮球 / NBA”“AI技术 / AI视频技术”等会改变召回范围的父子兴趣。每个簇携带 `known_distinct_pairs`，模型不得重判或合并用户回滚 / 当前策略已确认分开的 pair；代码侧仍作相同约束的强校验。dislikes 继续只合并近乎同义项并严禁向上泛化 |
@@ -39,14 +40,14 @@
 | v0.3.147+ Prompt layer cache | ✅ | `profile_prompt_layers()` 把结构化画像拆为 `profile_core` / `profile_life_context` / `profile_interests` / `profile_style_context` / `profile_recent_context`，从稳定到易变排序；`PromptLayerRenderCache` 按层 digest 复用已渲染 JSON prompt block，供 discovery eval、推荐分类 / 文案 / delight 和统一关键词 planner 共享，画像核心不变时 provider 看到的前缀保持 byte-stable |
 | v0.3.144+ 缓存前缀保护 | ✅ | `LLMService.complete_with_core_memory()` / `complete_structured_task()` / `complete_multimodal_structured_task()` 支持 `inject_core_memory=False`，供候选 eval、推荐分类 / delight、跨平台关键词生成、awareness / insight / speculation / profile build、初始化偏好分析这类已自带完整结构化上下文的路径跳过重复 memory 注入；`build_soul_profile_prompt()` 也保持静态 system，并把 tone / preference / awareness / insight 放在巨大 history 前，稳定 provider prompt-cache 前缀 |
 | v0.3.150+ DeepSeek thinking 显式关闭 | ✅ | `DeepSeekProvider.complete(..., reasoning_effort="")` 会向 DeepSeek 请求体写入 `thinking={"type":"disabled"}`。DeepSeek v4 默认开启 thinking，单纯省略字段并不会关闭 reasoning；配置页 LLM 探测和短结构化任务因此能真正避免 thinking 先耗尽输出预算后返回空 `content` |
-| 统一 reasoning effort 默认与映射 | ✅ | 支持原生档位的 provider 默认统一为 `medium`：OpenAI 官方 GPT-5/o-series 分别写入 Chat `reasoning_effort` 或 Responses `reasoning.effort`；Claude 4.6+ 写入 `output_config.effort`；Gemini 3 写入 `thinking_level`，Gemini 2.5 按当前输出上限用 50% thinking budget 近似中档；DeepSeek 将 portable `medium` 按官方规则归一为 native `high`；OpenRouter 用 `reasoning.effort` 跨厂商映射。泛 OpenAI-compatible 无法可靠推断能力：空值不发送，只有新版实例中用户明确填写的非空值才按 OpenAI 字段透传；Ollama 不发送伪参数 |
+| 统一 reasoning effort 默认与映射 | ✅ | 支持原生档位的 provider 默认统一为 `medium`：OpenAI 官方 GPT-5/o-series 分别写入 Chat `reasoning_effort` 或 Responses `reasoning.effort`；Claude 4.6+ 写入 `output_config.effort`；Gemini 3 写入 `thinking_level`，Gemini 2.5 按当前输出上限用 50% thinking budget 近似中档；DeepSeek 将 portable `medium` 按官方规则归一为 native `high`；OpenRouter 用 `reasoning.effort` 跨厂商映射。OrcaRouter 网关把推理参数原样转发给上游路由、非推理模型以 HTTP 400 拒绝，因此**不发送** `reasoning_effort` / `reasoning`（推理模型用自身默认档位）。泛 OpenAI-compatible 无法可靠推断能力：空值不发送，只有新版实例中用户明确填写的非空值才按 OpenAI 字段透传；Ollama 不发送伪参数 |
 | 渠道 caller 默认无 reasoning | ✅ | `LLMService` 将 `discovery.*` / `recommendation.*` / `sources.*` / `yt_search.*` / `runtime.bilibili_extension_search.*` 以及三类轻量 eval caller 的未指定 effort 解析为 `""`；显式 caller 参数始终优先。DeepSeek 将空值真正关闭 thinking；OpenAI / Claude / Gemini 在模型不能完全关闭时选最低安全档；OpenRouter 因未持有 per-model mandatory metadata 而省略该字段，避免向强制推理模型发送 `none` 后 400。Soul / 画像与长场景继续使用 provider 的 `medium`（或用户配置值） |
 | v0.3.150+ reasoning-only 诊断与兼容端点自愈 | ✅ | OpenAI-compatible / DeepSeek / OpenRouter / Ollama native 返回 HTTP 200 且含 `reasoning_content` / `reasoning` / `thinking`、但最终 `content` 为空时，错误会明确提示 `returned reasoning but no final content` 并带 `finish_reason`，避免和完全空响应混淆。泛 OpenAI-compatible 首请求仍保持标准兼容：空 effort 不发送非标准字段；若调用方明确传 `reasoning_effort=""`，端点却在去掉 `response_format` 后仍返回 reasoning-only，provider 才追加一次 `thinking={"type":"disabled"}` 重试，修复 SenseNova/DeepSeek relay 把输出预算全部耗在默认 thinking 的情况。 |
 | v0.3.117+ reasoning-first 探活 | ✅ | `LLMProvider.health_check()` 与配置页 LLM 测试探针统一使用 `max_tokens=4096`，避免 SenseNova 等 OpenAI-compatible reasoning-first 模型先产出 `message.reasoning`、尚未到 `message.content` 就被截断，从而误报空响应；通用 health check 同时显式传 `reasoning_effort=""`，所以 DeepSeek 不会让一次连通性探针继承 `medium/high/max`、扩成 16K/32K thinking 请求后在 init 门禁内假超时 |
 | LLM Provider 实例路由 v2 | ✅ | `[llm.instances.<id>]` 把 adapter 类型与渠道端点解耦，同类型可配置多个 Base URL / token / model；`default_chain` 是任意长度全局故障切换链，`[llm.routes.<module>]` 默认继承，也可拥有自己的有序链。模块自定义链耗尽后不会越界 spill 到全局链 |
 | 实例模型发现与可编辑选择 | ✅ | PC Web、插件与 setup 把当前未保存实例交给 `POST /api/config/discover-models`，后端精确调用该端点的 OpenAI-compatible `GET /models`，不保存配置；模型和 Effort 都是可手填的 combobox，发现失败保留原输入。该草稿端点在 active registry 无法构建的 degraded 恢复态仍精确放行，不会被旧配置造成的 503 阻断。协议只标准化模型列表，没有 effort capability 枚举，因此 Effort 选项是本地 advisory，不冒充服务端事实 |
 | v0.3.75 Per-module LLM 路由生效 | ✅ | `LLMService` 按 caller bucket 路由 soul / discovery / recommendation / evaluation；旧 `[llm.<module>] provider/model` 会无损投影为 v2 模块实例链，保留兼容但不再是推荐写法 |
-| v0.3.75 Provider per-call model | ✅ | OpenAI / Claude / Gemini / DeepSeek / Ollama / OpenRouter / OpenAI-compatible 的 `complete(..., model=...)` 支持单次模型覆盖，不修改 provider 实例默认 `_model` |
+| v0.3.75 Provider per-call model | ✅ | OpenAI / Claude / Gemini / DeepSeek / Ollama / OpenRouter / OrcaRouter / OpenAI-compatible 的 `complete(..., model=...)` 支持单次模型覆盖，不修改 provider 实例默认 `_model` |
 | 体验优化：B站动态语气 | ✅ | 推荐、画像总结和聊天 prompt 统一接入 `ToneProfile`，在“老B友”基础上按用户画像微调语气 |
 | v0.3.0 Ollama embedding 兜底 | ✅ | `OllamaProvider.embed()` 走原生 `/api/embeddings`，配合 `bge-m3` 模型可在 Mac/Win/Linux CPU 跑相似度计算，不需要额外的 embedding API Key |
 | v0.3.0 EmbeddingService 双层缓存 | ✅ | L1 内存 + L2 SQLite 持久化；`build_embedding_service` 按 provider 自动选默认 model（gemini→gemini-embedding-001 / openai→text-embedding-3-small / ollama→bge-m3） |
@@ -57,7 +58,7 @@
 | v0.3.155 Ollama embedding 诊断 + 自修 | ✅ | `llm/ollama_diagnostics.py`：`diagnose_ollama_embedding()` 把向量模型不可用分类为 `not_running` / `model_missing` / `model_broken` / `model_path_encoding` / `disk_full` / `network` / `model_oom` / `error`（先 `/api/tags` 判定服务与模型在位，再真打一次 embed——覆盖"模型在列表里但加载失败"的 500 场景）。`model_path_encoding` 专指 Windows 非 ASCII 用户名 / mojibake 路径导致 `llama-server` 无法从 `.ollama\models` 加载模型的失败，重新拉取不会修复，需迁移模型目录或手动设置 `OLLAMA_MODELS` 到纯英文路径；`model_oom` 从旧 `model_broken` 中拆出，明确内存不足时重拉无效；`disk_full` 既识别 pull / probe 错误文本，也会在拉取前检查 `OLLAMA_MODELS` / 托管模型目录所在卷是否至少有约 2.0GB 空间；`network` 区分无法访问 registry 的下载源问题与本地模型损坏。`pull_ollama_model()` 经原生 `/api/pull` 流式拉取 / 重拉模型并回调进度；两者均 `trust_env=False` 且可注入 `httpx.MockTransport` 测试。`OllamaProvider.embed()` 失败日志附带响应体错误片段（此前只有裸状态码）。供 `/api/init-status` 的 `embedding_check`/`embedding_detail` 与 `POST /api/embedding/repair` 一键修复使用（见 [init 模块](init.md)）。v0.3.206+：识别 Windows 访问违规崩溃（`0xc0000005` / `access violation`），在 `model_broken` 内给出「一键重拉 → 重启 → 内存/虚拟内存 → 杀软白名单 → 升级」排序清单，不再只提示「下载不完整或内存不足」 |
 | v0.3.97 EmbeddingService 实时探活 | ✅ | `EmbeddingService.probe()` 绕过 L1/L2 缓存直接打一次 provider，返回是否拿到非空向量；供 `/api/health.embedding_ready` 做**实时**就绪判定（缓存命中的旧成功不会掩盖 provider 已掉线 / 模型没拉）。`/api/health` 侧自带 TTL + single-flight，probe 不缓存结果、每次都真打 |
 | v0.3.114 配置页服务探测 | ✅ | `POST /api/config/probe-service` 对用户当前表单草稿做无写入真实探测：LLM 走临时 `LLMRegistry.complete_provider()`，embedding 走临时 `EmbeddingService.probe()`，结果供 PCWeb / 插件设置页行内展示。它属于 degraded 恢复控制面：不依赖失败的 active registry；也属于 guided init 写端门控的只读例外，初始化运行时仍可测试。真实 LLM 请求始终经过 RuntimeContext 的稳定 total gate；LLM 实例 / 链的外层 deadline 按配置 clamp 到 10–120 秒，桌面与 popup 使用 125 秒请求预算以覆盖本地 Ollama 冷启动。 |
-| v0.3.20 Embedding fallback 能力识别 | ✅ | `LLMProvider.supports_embedding` 类属性显式声明 provider 是否真的有 embeddings endpoint。Claude / DeepSeek / OpenRouter 标 `False`（前者无 API、后两者继承自 OpenAIProvider 但实际后端不路由 embeddings）；OpenAI / Gemini / Ollama 标 `True`。当前只在 `[llm.embedding].fallback_provider` 非空时尝试一个显式备选 provider |
+| v0.3.20 Embedding fallback 能力识别 | ✅ | `LLMProvider.supports_embedding` 类属性显式声明 provider 是否真的有 embeddings endpoint。Claude / DeepSeek / OpenRouter / OrcaRouter 标 `False`（前者无 API、其余继承自 OpenAIProvider 但实际后端不路由 embeddings）；OpenAI / Gemini / Ollama 标 `True`。当前只在 `[llm.embedding].fallback_provider` 非空时尝试一个显式备选 provider |
 | v0.3.89.1 OpenRouter embedding 显式路径 | ✅ | `[llm.embedding].provider = "openrouter"` 会构造独立 `OpenRouterProvider`（必须配 `model = "<vendor>/<model>"`）。它不参与 chat 实例链；embedding 自己未填凭据 / headers 时，可兼容借用首个启用的同类型 chat 实例，旧 `[llm.openrouter]` 也继续可读 |
 | v0.3.20 OpenAI Provider embed | ✅ | `OpenAIProvider.embed()` 走 `/v1/embeddings`，默认 `text-embedding-3-small`。OpenAI 用户没显式配 embedding 时不再静默返回 None。失败返回 `[]`（与 Ollama / Gemini 一致），调用方降级处理 |
 | v0.3.31 DeepSeek 空内容兜底 | ✅ | DeepSeek 返回 HTTP 200 但 `content=""` 时，provider 会重试一次；`reasoning_effort` 开启时仍先关闭 thinking 重试，普通模式则原参数重试，避免 explore / structured task 因一次空内容直接降级为空结果 |
@@ -80,7 +81,7 @@
 | v0.3.x 避雷探针多样性 prompt | ✅ | `build_avoidance_generation_prompt` 会携带 `existing_avoidance_details`，让 LLM 看到已有 active 的 `source_mode`、`source_signal`、体验轴和 specifics；system prompt 要求同一 `source_mode` + 同一粗主题 / 证据源只生成一个候选，已有 AI positive_boundary 时不再输出 AI 教程 / 测评 / 趋势换皮项 |
 | v0.3.x 第三方 API 网关适配（issue #72） | ✅ | Claude 实例的 `base_url` 可指向任意 Anthropic 协议网关；OpenAI / OpenAI-compatible 实例的 `api_flavor` 可选 Chat Completions 或 Responses。每个实例独立持有渠道 URL / token / model，所以同一 adapter 的多个网关可同时注册并互为降级；非法组合由配置校验 blocking 拦截 |
 | v0.3.162+ 托管 Ollama 生命周期自愈 | ✅ | `runtime/ollama_supervisor.py` 记录托管 daemon 的完整启动规格并新增 watchdog；`with-embedding` 私有 11435 daemon 纳入一键修复与崩溃自动拉起（详见下方[托管 Ollama 生命周期](#托管-ollama-生命周期v03162)） |
-| v0.3.165 海外网络三模式 | ✅ | `OpenAIProvider` / `ClaudeProvider` / `GeminiProvider`（含 DeepSeek / OpenRouter 子类与 embedding 实例）同时接收 `proxy` 与 `trust_env`。registry 统一读取 `[network].mode`：`direct` 注入忽略环境代理的 SDK transport，`system` 保留 SDK 环境继承，`custom` 注入指定代理并强制 `trust_env=False`。**Ollama 工厂不读该策略**——本地 / CN 直连由 `tests/test_network_proxy_isolation.py` 守卫 |
+| v0.3.165 海外网络三模式 | ✅ | `OpenAIProvider` / `ClaudeProvider` / `GeminiProvider`（含 DeepSeek / OpenRouter / OrcaRouter 子类与 embedding 实例）同时接收 `proxy` 与 `trust_env`。registry 统一读取 `[network].mode`：`direct` 注入忽略环境代理的 SDK transport，`system` 保留 SDK 环境继承，`custom` 注入指定代理并强制 `trust_env=False`。**Ollama 工厂不读该策略**——本地 / CN 直连由 `tests/test_network_proxy_isolation.py` 守卫 |
 | v0.3.166 国内网关代理豁免 | ✅ | registry 按每个实例的 `base_url` 独立裁决代理，委托 `network.is_domestic_endpoint()`。国内大模型网关与 localhost / 内网自建端点即使全局为 `system` / `custom` 也强制直连；同一链里的境外实例仍走全局代理策略 |
 | Issue #113 CA 环境防护 | ✅ | `network.set_outbound_proxy(..., mode="system")` 在任何继承环境的 SDK 客户端构造前检查 `SSL_CERT_FILE` / `SSL_CERT_DIR` / `REQUESTS_CA_BUNDLE` / `CURL_CA_BUNDLE`。只移除指向不存在目标的失效覆盖，让 httpx / OpenSSL 回退到默认可信 CA store；有效私有 CA、`HTTPS_PROXY` 等代理变量和 TLS 验证均保持不变，避免 Windows 遗留 CA 路径导致所有客户端在发请求前直接 `FileNotFoundError`。 |
 | Issue #113 task-local 后台准入 bypass | ✅ | 内部 scope 通过 `ContextVar` 只影响当前异步上下文；scope 内 `LLMService.complete_with_core_memory()` 跳过库存敏感的后台 admission，但仍经过总 provider gate，退出 scope 后自动恢复。guided init 仅在阶段 2/3 使用，并行 discovery 不继承该 scope；既有公开 API 签名不变。 |
@@ -108,6 +109,7 @@ from openbiliclaw.llm import (
     OllamaProvider,
     OpenAIProvider,
     OpenRouterProvider,
+    OrcaRouterProvider,
 )
 
 # 创建 provider
@@ -140,6 +142,12 @@ provider = OpenRouterProvider(
     model="openai/gpt-4o-mini",
     http_referer="https://example.com",
     x_title="OpenBiliClaw",
+)
+
+provider = OrcaRouterProvider(
+    api_key="sk-orca-...",
+    model="openai/gpt-4o",
+    base_url="https://api.orcarouter.ai/v1",
 )
 
 provider = GeminiProvider(
@@ -224,7 +232,7 @@ POST /api/config/discover-models
 
 该接口同样不写配置。请求携带 `instance_id` 与当前页面的 `config.llm` 草稿；后端在内存副本中应用草稿，精确使用该实例自己的 Base URL、API Key、网络策略与认证方式调用 OpenAI-compatible `GET /models`。保存过的 masked key 会按配置更新的既有规则保留真实密钥，响应只返回排序去重后的模型 ID、耗时和安全错误，不回传凭据。它与草稿探测一起列入 degraded 精确 allow-list，因此旧 active registry 坏掉时仍可用 replacement draft 找模型。
 
-- 支持 `openai` / `deepseek` / `openrouter` / `ollama` / `openai_compatible`；其他原生协议返回 `ok=false` 与继续手填的说明。
+- 支持 `openai` / `deepseek` / `openrouter` / `orcarouter` / `ollama` / `openai_compatible`；其他原生协议返回 `ok=false` 与继续手填的说明。
 - 拉取失败、端点没有实现 `/models` 或列表为空都不会覆盖页面里已经输入的模型。
 - OpenAI Models API 只提供 ID 等基础元数据，没有标准字段声明某模型支持哪些 reasoning effort。响应里的 `reasoning_efforts` 因此标记为 `local_advisory`，用于方便选择而不是服务端能力承诺，输入框始终允许手填。
 
@@ -602,7 +610,7 @@ force-quit 残留场景；收养只做记录、绝不发信号，但让 watchdog
 3. **Protocol DI**：`SupportsComplete` Protocol 解耦了调用方和具体实现，测试时可注入 Fake
 4. **Prompt 集中管理**：所有 prompt 在 `prompts.py` 中定义，不散落在各模块
 5. **统一上下文注入**：`complete_with_core_memory()` / `complete_structured_task()` 默认负责把核心记忆注入到 Soul 相关任务里；已在 `user_input` 自带完整结构化上下文的高频任务可传 `inject_core_memory=False`，或通过 `llm.task_options.without_core_memory_kwargs()` 在兼容旧 stub 的前提下关闭注入，避免动态 core memory 破坏 provider prompt-cache 前缀
-6. **OpenAI-compatible 复用**：DeepSeek、OpenRouter 这类兼容 OpenAI 协议的 provider 复用同一套重试、超时和错误归一化逻辑，只在子类中注入默认地址或额外请求头
+6. **OpenAI-compatible 复用**：DeepSeek、OpenRouter、OrcaRouter 这类兼容 OpenAI 协议的 provider 复用同一套重试、超时和错误归一化逻辑，只在子类中注入默认地址或额外请求头
 7. **Gemini 独立适配**：Gemini 走官方 `google-genai` SDK，不强行复用 OpenAI-compatible 抽象；provider 内部负责把统一 `messages` 渲染成 quickstart 风格的单文本 prompt
 8. **Gemini 可选依赖降级**：环境里缺少 `google-genai` 时，`llm` 包和 registry 仍可正常导入；只有真正实例化 Gemini provider 时才会给出明确缺依赖错误。守卫捕获的是 `ImportError` 而非仅 `ModuleNotFoundError`（issue #80）——SDK 装上了但其原生传递依赖加载失败（如 Termux/Android 下 `cryptography` 的 manylinux 轮子 dlopen 失败）同样降级而不是让 CLI 启动即崩，实例化报错会附带底层 import 失败详情
 9. **Prompt 风格集中收口**：推荐、画像和聊天的“老B友”语气由共享 `ToneProfile` 驱动，不允许各模块各自发散成不同人格

--- a/docs/openclaw-quickstart.md
+++ b/docs/openclaw-quickstart.md
@@ -87,7 +87,8 @@ python3 scripts/agent_bootstrap.py --mode docker --interactive-confirm --wait-fo
    - **4) Gemini 官方** —— 默认 `gemini-2.5-flash`(稳定);免费档每天 1500 次。可选 gemini-3-flash-preview / gemini-3.1-pro-preview(旗舰,Public Preview,需付费项目) / gemini-3.1-flash-lite-preview(最便宜)
    - **5) Claude 官方** —— 默认 `claude-sonnet-4-6`(1M ctx),按 token 付费,质量高。可选 claude-haiku-4-5(便宜) / claude-opus-4-7(旗舰)
    - **6) OpenRouter 聚合** —— 默认 `openai/gpt-5-nano`;格式 `<vendor>/<model>`(如 anthropic/claude-sonnet-4-6 / google/gemini-2.5-flash)
-   - **7) 本地 Ollama（完全离线）** —— 默认 `qwen2.5:7b`(中文好);可选 llama3.2 / gemma2 / mistral / deepseek-r1。无 Key / 16GB+ 内存
+   - **7) OrcaRouter 聚合** —— 默认 `openai/gpt-4o`;格式 `<vendor>/<model>`。一个 Key 跑 150+ 模型,网关级零信任安全
+   - **本地 Ollama（完全离线,不在交互菜单里）** —— 默认 `qwen2.5:7b`(中文好);可选 llama3.2 / gemma2 / mistral / deepseek-r1。无 Key / 16GB+ 内存。需要时用 `--provider ollama` 显式选择或到桌面设置页配置
 2. **Phase 2 — 给所选服务填配置**：每个选项只问该选项需要的字段。**所有 provider 在 prompt 模型名前都会显示一行"可选/常见模型"提示**(DeepSeek 列 v4-flash / v4-pro,OpenAI 列 gpt-4o-mini / gpt-4o / gpt-4-turbo,Gemini / Claude / Ollama 同样,OpenAI 协议兼容子菜单见上 9 个 preset),用户主动确认而不是回车跳过一个不知道是啥的字符串。Ollama 不问 Key(自动装 + 拉模型);自建网关 / 其它路径强制手填模型名(写错会 404)。
 3. **Phase 3 — Embedding（向量化，3 选 1 + 高级）**：默认推荐 **本地 Ollama bge-m3**（免费、离线、效果够用），其次 Gemini（云端、效果最好但要 Key），也可以选择暂不启用。Embedding 与主 LLM 独立，不再默认跟随主 LLM。高级选项里有"自定义 OpenAI 兼容 endpoint"。
 4. **Phase 4 — Per-module 覆盖**（高级，默认跳过）：可单独给 soul / discovery / recommendation / evaluation 指定不同模型。

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -613,7 +613,7 @@ trusted LAN ─ HTTPS（可选）──→ TLS Proxy :8443 ─ loopback/Compose 
 │  ┌──────────────────────────┐  ┌────────────────────────┐   │
 │  │ OpenAI / Claude / Gemini │  │ EmbeddingService       │   │
 │  │ DeepSeek / Ollama /      │  │ L1 内存 + L2 SQLite    │   │
-│  │ OpenRouter + Codex OAuth │  │ Ollama bge-m3 兜底可选  │   │
+│  │ OpenRouter / OrcaRouter  │  │ Ollama bge-m3 兜底可选  │   │
 │  └──────────────────────────┘  └────────────────────────┘   │
 │  可选视觉 / 弹幕预热：质心、关键帧、完整 document embedding；endpoint provenance + stable slot retry │
 │  Desktop bundle: official Ollama.app runtime (ollama + runner dylibs/assets) │

--- a/scripts/agent_bootstrap.py
+++ b/scripts/agent_bootstrap.py
@@ -89,6 +89,7 @@ SUPPORTED_PROVIDERS = (
     "deepseek",
     "ollama",
     "openrouter",
+    "orcarouter",
     "openai_compatible",
 )
 REMOTE_PROVIDERS = (
@@ -97,6 +98,7 @@ REMOTE_PROVIDERS = (
     "gemini",
     "deepseek",
     "openrouter",
+    "orcarouter",
     "openai_compatible",
 )
 
@@ -106,7 +108,7 @@ REMOTE_PROVIDERS = (
 # pulls the embedding model (otherwise embeddings silently fall back at
 # runtime to whatever the registry can find — see registry.py
 # build_embedding_service).
-PROVIDERS_WITHOUT_EMBED = ("claude", "deepseek", "openrouter")
+PROVIDERS_WITHOUT_EMBED = ("claude", "deepseek", "openrouter", "orcarouter")
 
 
 def ensure_local_no_proxy() -> str:
@@ -184,6 +186,7 @@ HUMAN_LLM_MENU: tuple[tuple[str, str, str], ...] = (
     ("gemini", "Gemini 官方", "gemini-2.5-flash"),
     ("claude", "Claude 官方", "claude-sonnet-4-6"),
     ("openrouter", "OpenRouter 聚合", "openai/gpt-5-nano"),
+    ("orcarouter", "OrcaRouter 聚合", "openai/gpt-4o"),
 )
 
 HUMAN_OPENAI_COMPAT_PRESETS: tuple[str, ...] = (
@@ -204,6 +207,7 @@ PROVIDER_MODEL_DEFAULTS: dict[str, str] = {
     "gemini": "gemini-2.5-flash",
     "claude": "claude-sonnet-4-6",
     "openrouter": "openai/gpt-5-nano",
+    "orcarouter": "openai/gpt-4o",
     "ollama": "qwen2.5:7b",
 }
 
@@ -211,6 +215,7 @@ PROVIDER_BASE_URL_DEFAULTS: dict[str, str] = {
     "deepseek": "https://api.deepseek.com",
     "ollama": "http://127.0.0.1:11434/v1",
     "openrouter": "https://openrouter.ai/api/v1",
+    "orcarouter": "https://api.orcarouter.ai/v1",
 }
 
 
@@ -2028,6 +2033,7 @@ def _ensure_llm_instance(project_dir: Path, provider: str) -> str:
         "deepseek": "DeepSeek",
         "ollama": "Ollama",
         "openrouter": "OpenRouter",
+        "orcarouter": "OrcaRouter",
         "openai_compatible": "OpenAI-compatible",
     }
     update_config_secret(
@@ -2052,6 +2058,7 @@ def _ensure_llm_instance(project_dir: Path, provider: str) -> str:
         "gemini",
         "deepseek",
         "openrouter",
+        "orcarouter",
     }:
         update_config_secret(config_path, section, "reasoning_effort", "medium")
     return instance_id

--- a/src/openbiliclaw/api/app.py
+++ b/src/openbiliclaw/api/app.py
@@ -975,6 +975,7 @@ _RESETTABLE_CONFIG_FIELDS = {
     "llm.gemini.api_key": ("llm", "gemini", "api_key"),
     "llm.deepseek.api_key": ("llm", "deepseek", "api_key"),
     "llm.openrouter.api_key": ("llm", "openrouter", "api_key"),
+    "llm.orcarouter.api_key": ("llm", "orcarouter", "api_key"),
     "llm.openai_compatible.api_key": ("llm", "openai_compatible", "api_key"),
     "llm.embedding.api_key": ("llm", "embedding", "api_key"),
 }
@@ -16558,6 +16559,7 @@ def create_app(
                 ollama=_provider_out(_legacy_provider_projection("ollama")),
                 openrouter=_provider_out(_legacy_provider_projection("openrouter")),
                 openai_compatible=_provider_out(_legacy_provider_projection("openai_compatible")),
+                orcarouter=_provider_out(_legacy_provider_projection("orcarouter")),
                 embedding=EmbeddingConfigOut(
                     provider=cfg.llm.embedding.provider,
                     model=cfg.llm.embedding.model,
@@ -17439,6 +17441,7 @@ def create_app(
                 "deepseek",
                 "ollama",
                 "openrouter",
+                "orcarouter",
                 "openai_compatible",
             }:
                 return "", None
@@ -17515,6 +17518,7 @@ def create_app(
             "deepseek",
             "ollama",
             "openrouter",
+            "orcarouter",
             "openai_compatible",
         ):
             if provider_name in llm_data and isinstance(llm_data[provider_name], dict):
@@ -17674,7 +17678,7 @@ def create_app(
             ):
                 return []
             return ["none", "minimal", "low", "medium", "high", "xhigh", "max"]
-        if normalized_provider in {"openai_compatible", "openrouter"}:
+        if normalized_provider in {"openai_compatible", "openrouter", "orcarouter"}:
             return ["none", "minimal", "low", "medium", "high", "xhigh", "max"]
         if normalized_provider == "deepseek":
             return ["none", "high", "max"]
@@ -17725,6 +17729,7 @@ def create_app(
             "openai",
             "deepseek",
             "openrouter",
+            "orcarouter",
             "ollama",
             "openai_compatible",
         }:

--- a/src/openbiliclaw/api/models.py
+++ b/src/openbiliclaw/api/models.py
@@ -2054,6 +2054,8 @@ class LLMConfigOut(BaseModel):
     openrouter: LLMProviderConfigOut = Field(default_factory=LLMProviderConfigOut)
     # v0.3.32+ — generic OpenAI-protocol-compatible provider.
     openai_compatible: LLMProviderConfigOut = Field(default_factory=LLMProviderConfigOut)
+    # OrcaRouter model-routing gateway (OpenAI-compatible).
+    orcarouter: LLMProviderConfigOut = Field(default_factory=LLMProviderConfigOut)
     embedding: EmbeddingConfigOut = Field(default_factory=EmbeddingConfigOut)
     soul: ModuleLLMConfigOut = Field(default_factory=ModuleLLMConfigOut)
     discovery: ModuleLLMConfigOut = Field(default_factory=ModuleLLMConfigOut)

--- a/src/openbiliclaw/cli.py
+++ b/src/openbiliclaw/cli.py
@@ -1606,6 +1606,8 @@ _PROVIDER_DEFAULTS: dict[str, dict[str, str]] = {
     "ollama": {"base_url": "http://127.0.0.1:11434/v1", "model": "qwen2.5:7b"},
     # OpenRouter: route to OpenAI's cheapest current-gen by default.
     "openrouter": {"base_url": "https://openrouter.ai/api/v1", "model": "openai/gpt-5-nano"},
+    # OrcaRouter: OpenAI-compatible model routing gateway (sk-orca- key).
+    "orcarouter": {"base_url": "https://api.orcarouter.ai/v1", "model": "openai/gpt-4o"},
 }
 
 
@@ -1616,6 +1618,7 @@ _PROVIDER_HINTS: dict[str, str] = {
     "deepseek": "DeepSeek 官方（OpenAI 兼容协议）",
     "ollama": "本地 Ollama（无需 Key）",
     "openrouter": "OpenRouter 聚合",
+    "orcarouter": "OrcaRouter 聚合（OpenAI 兼容协议）",
 }
 
 
@@ -1647,6 +1650,10 @@ _PROVIDER_MODEL_HINT: dict[str, str] = {
     "openrouter": (
         "默认 openai/gpt-5-nano。OpenRouter 模型名格式: <vendor>/<model>,"
         "如 anthropic/claude-sonnet-4-6 / google/gemini-2.5-flash"
+    ),
+    "orcarouter": (
+        "默认 openai/gpt-4o。OrcaRouter 模型名格式: <vendor>/<model>,"
+        "如 anthropic/claude-opus-4.8 / z-ai/glm-5.2"
     ),
     "ollama": (
         "常见模型: qwen2.5:7b (默认 / 中文好) / llama3.2 (Meta 新版) / "
@@ -2169,6 +2176,11 @@ _LLM_MENU: tuple[tuple[str, str, str], ...] = (
         "openrouter",
         "OpenRouter 聚合",
         "默认 openai/gpt-5-nano。一个 Key 跑多家模型,按调用计费",
+    ),
+    (
+        "orcarouter",
+        "OrcaRouter 聚合",
+        "默认 openai/gpt-4o。一个 Key 跑 150+ 模型,网关级零信任安全",
     ),
 )
 

--- a/src/openbiliclaw/config.py
+++ b/src/openbiliclaw/config.py
@@ -68,6 +68,7 @@ _SUPPORTED_CHAT_PROVIDERS = {
     "deepseek",
     "ollama",
     "openrouter",
+    "orcarouter",
     "openai_compatible",
 }
 _LLM_INSTANCE_ID_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,63}$")
@@ -78,6 +79,7 @@ _LLM_PROVIDER_DISPLAY_NAMES = {
     "deepseek": "DeepSeek",
     "ollama": "Ollama",
     "openrouter": "OpenRouter",
+    "orcarouter": "OrcaRouter",
     "openai_compatible": "OpenAI-compatible",
 }
 _MIN_POOL_TARGET_COUNT = 1
@@ -202,6 +204,7 @@ _REMOTE_PROVIDER_FIELDS = {
     "gemini": "llm.gemini.api_key",
     "deepseek": "llm.deepseek.api_key",
     "openrouter": "llm.openrouter.api_key",
+    "orcarouter": "llm.orcarouter.api_key",
     # v0.3.32+ — generic OpenAI-protocol-compatible provider (Groq /
     # Together / Azure OpenAI / vLLM / self-hosted, etc.). Distinct from
     # ``openai`` so users can run both in parallel (chat = openai for
@@ -481,6 +484,8 @@ class LLMConfig:
     # v0.3.32+ generic OpenAI-protocol-compatible provider. Always
     # requires an explicit base_url (otherwise it would just be ``openai``).
     openai_compatible: LLMProviderConfig = field(default_factory=LLMProviderConfig)
+    # OrcaRouter model-routing gateway (OpenAI-compatible, ``sk-orca-`` key).
+    orcarouter: LLMProviderConfig = field(default_factory=LLMProviderConfig)
     embedding: EmbeddingConfig = field(default_factory=EmbeddingConfig)
     # Per-module overrides (empty = use global default)
     soul: ModuleLLMConfig = field(default_factory=ModuleLLMConfig)
@@ -2035,6 +2040,7 @@ def _build_config(
         ollama=_provider_config("ollama"),
         openrouter=_provider_config("openrouter"),
         openai_compatible=_provider_config("openai_compatible"),
+        orcarouter=_provider_config("orcarouter"),
         embedding=EmbeddingConfig(
             **_filter_dataclass_kwargs(
                 EmbeddingConfig,
@@ -4066,6 +4072,7 @@ def _collect_config_issues(config: Config) -> list[ConfigIssue]:
         "ollama": config.llm.ollama,
         "openrouter": config.llm.openrouter,
         "openai_compatible": config.llm.openai_compatible,
+        "orcarouter": config.llm.orcarouter,
     }
 
     provider_config = provider_configs.get(provider_name)
@@ -4923,6 +4930,7 @@ def _render_config_toml(
         lines.extend(_render_provider_section("deepseek", config.llm.deepseek))
         lines.extend(_render_provider_section("ollama", config.llm.ollama))
         lines.extend(_render_provider_section("openrouter", config.llm.openrouter))
+        lines.extend(_render_provider_section("orcarouter", config.llm.orcarouter))
         lines.extend(_render_provider_section("openai_compatible", config.llm.openai_compatible))
     lines.extend(
         [
@@ -5358,13 +5366,21 @@ def _render_provider_section(name: str, provider: LLMProviderConfig) -> list[str
     lines = [f"[llm.{name}]"]
     lines.append(f"api_key = {_toml_string(provider.api_key)}")
     lines.append(f"model = {_toml_string(provider.model)}")
-    if name in {"openai", "claude", "deepseek", "ollama", "openrouter", "openai_compatible"}:
+    if name in {
+        "openai",
+        "claude",
+        "deepseek",
+        "ollama",
+        "openrouter",
+        "orcarouter",
+        "openai_compatible",
+    }:
         lines.append(f"base_url = {_toml_string(provider.base_url)}")
     if name == "openai":
         lines.append(f"auth_mode = {_toml_string(provider.auth_mode)}")
     if name in {"openai", "openai_compatible"}:
         lines.append(f"api_flavor = {_toml_string(provider.api_flavor)}")
-    if name in {"openai", "claude", "gemini", "deepseek", "openrouter"}:
+    if name in {"openai", "claude", "gemini", "deepseek", "openrouter", "orcarouter"}:
         lines.append(f"reasoning_effort = {_toml_string(provider.reasoning_effort)}")
     if name == "openrouter":
         lines.append(f"http_referer = {_toml_string(provider.http_referer)}")

--- a/src/openbiliclaw/llm/__init__.py
+++ b/src/openbiliclaw/llm/__init__.py
@@ -18,6 +18,7 @@ from .gemini_provider import GeminiProvider
 from .ollama_provider import OllamaProvider
 from .openai_provider import DeepSeekProvider, OpenAIProvider
 from .openrouter_provider import OpenRouterProvider
+from .orcarouter_provider import OrcaRouterProvider
 from .registry import (
     RegistryBuildError,
     RegistrySummary,
@@ -48,6 +49,7 @@ __all__ = [
     "OllamaProvider",
     "OpenAIProvider",
     "OpenRouterProvider",
+    "OrcaRouterProvider",
     "RegistryBuildError",
     "RegistrySummary",
     "LLMProviderExecutionError",

--- a/src/openbiliclaw/llm/orcarouter_provider.py
+++ b/src/openbiliclaw/llm/orcarouter_provider.py
@@ -1,0 +1,71 @@
+"""OrcaRouter provider built on the OpenAI-compatible client."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .base import DEFAULT_REASONING_EFFORT
+from .openai_provider import OpenAIProvider
+
+
+class OrcaRouterProvider(OpenAIProvider):
+    """OrcaRouter model-routing gateway provider.
+
+    OrcaRouter exposes 150+ models from OpenAI, Anthropic, Google, DeepSeek,
+    Qwen, MiniMax, xAI and others behind a single OpenAI-compatible endpoint
+    and API key (``sk-orca-``).
+
+    Reasoning params are intentionally never sent. The gateway forwards
+    ``reasoning_effort`` (and OpenRouter's nested ``reasoning`` object)
+    verbatim to the upstream route, and upstream models that don't expose
+    reasoning reject the argument with HTTP 400 (verified against
+    ``openai/gpt-4o``). Reasoning-capable routes pick up their own model
+    default when the field is omitted, so leaving it off is safe for both
+    families. ``_openai_reasoning_effort`` therefore always returns ``None``
+    and ``_extra_body`` stays empty.
+    """
+
+    # OrcaRouter routes most chat models, but its embeddings coverage is
+    # spotty per-route — fall back to ollama / gemini by default, matching
+    # the OpenRouter adapter's behavior.
+    supports_embedding = False
+
+    def __init__(
+        self,
+        api_key: str,
+        model: str = "openai/gpt-4o",
+        base_url: str = "https://api.orcarouter.ai/v1",
+        timeout: float = 1200.0,
+        proxy: str = "",
+        trust_env: bool = True,
+        reasoning_effort: str = DEFAULT_REASONING_EFFORT,
+    ) -> None:
+        super().__init__(
+            api_key=api_key,
+            model=model,
+            base_url=base_url,
+            provider_name="orcarouter",
+            timeout=timeout,
+            proxy=proxy,
+            trust_env=trust_env,
+            reasoning_effort=reasoning_effort,
+        )
+
+    def _openai_reasoning_effort(self, model: str, effort: str) -> str | None:
+        """Never emit ``reasoning_effort`` on the wire.
+
+        OrcaRouter forwards the scalar to the upstream route, which rejects
+        it (HTTP 400) when the model has no reasoning mode. Reasoning-capable
+        models fall back to their own default when the field is omitted.
+        """
+        del model, effort
+        return None
+
+    def _extra_body(self, *, reasoning_effort: str | None = None) -> dict[str, Any]:
+        """No provider-specific request body fields.
+
+        OrcaRouter rejects OpenRouter's nested ``reasoning`` object on
+        non-reasoning routes, so nothing is added here.
+        """
+        del reasoning_effort
+        return {}

--- a/src/openbiliclaw/llm/registry.py
+++ b/src/openbiliclaw/llm/registry.py
@@ -17,6 +17,7 @@ from .gemini_provider import GeminiProvider, gemini_sdk_available
 from .ollama_provider import OllamaProvider
 from .openai_provider import DeepSeekProvider, OpenAIProvider
 from .openrouter_provider import OpenRouterProvider
+from .orcarouter_provider import OrcaRouterProvider
 
 if TYPE_CHECKING:
     from openbiliclaw.config import Config
@@ -63,6 +64,7 @@ def build_llm_registry(
         ("deepseek", _maybe_deepseek_provider(config, overrides)),
         ("ollama", _maybe_ollama_provider(config, overrides)),
         ("openrouter", _maybe_openrouter_provider(config, overrides)),
+        ("orcarouter", _maybe_orcarouter_provider(config, overrides)),
         ("openai_compatible", _maybe_openai_compatible_provider(config, overrides)),
     ]
 
@@ -218,6 +220,7 @@ def _build_instance_provider(
         "deepseek": _maybe_deepseek_provider,
         "ollama": _maybe_ollama_provider,
         "openrouter": _maybe_openrouter_provider,
+        "orcarouter": _maybe_orcarouter_provider,
         "openai_compatible": _maybe_openai_compatible_provider,
     }
     factory = factories.get(provider_type)
@@ -931,6 +934,25 @@ def _maybe_openrouter_provider(
             config.llm.openrouter.base_url or "https://openrouter.ai/api/v1"
         ),
         reasoning_effort=config.llm.openrouter.reasoning_effort,
+    )
+
+
+def _maybe_orcarouter_provider(
+    config: Config, overrides: dict[str, LLMProvider]
+) -> LLMProvider | None:
+    if "orcarouter" in overrides:
+        return overrides["orcarouter"]
+    if not config.llm.orcarouter.api_key.strip():
+        return None
+    base_url = config.llm.orcarouter.base_url or "https://api.orcarouter.ai/v1"
+    return OrcaRouterProvider(
+        api_key=config.llm.orcarouter.api_key,
+        model=config.llm.orcarouter.model or "openai/gpt-4o",
+        base_url=base_url,
+        timeout=float(config.llm.timeout),
+        proxy=_outbound_proxy(base_url),
+        trust_env=_outbound_trust_env(base_url),
+        reasoning_effort=config.llm.orcarouter.reasoning_effort,
     )
 
 

--- a/src/openbiliclaw/web/desktop/assets/js/app.js
+++ b/src/openbiliclaw/web/desktop/assets/js/app.js
@@ -8628,6 +8628,7 @@ ${cardFeedbackBarHtml()}`;
       gemini: "Gemini",
       deepseek: "DeepSeek",
       openrouter: "OpenRouter",
+      orcarouter: "OrcaRouter",
       ollama: "Ollama",
       openai_compatible: "OpenAI-compatible"
     };
@@ -8637,6 +8638,7 @@ ${cardFeedbackBarHtml()}`;
       gemini: { model: "gemini-2.5-flash", base_url: "" },
       deepseek: { model: "deepseek-v4-flash", base_url: "https://api.deepseek.com" },
       openrouter: { model: "openai/gpt-4o-mini", base_url: "https://openrouter.ai/api/v1" },
+      orcarouter: { model: "openai/gpt-4o", base_url: "https://api.orcarouter.ai/v1" },
       ollama: { model: "qwen2.5:7b", base_url: "http://127.0.0.1:11434/v1" },
       openai_compatible: { model: "", base_url: "" }
     };
@@ -8644,6 +8646,7 @@ ${cardFeedbackBarHtml()}`;
       "openai",
       "deepseek",
       "openrouter",
+      "orcarouter",
       "ollama",
       "openai_compatible"
     ]);
@@ -8965,7 +8968,7 @@ ${cardFeedbackBarHtml()}`;
         x_title: providerType === "openrouter"
           ? getInput("llmInstanceTitle").trim()
           : "",
-        reasoning_effort: ["openai", "claude", "gemini", "deepseek", "openrouter", "openai_compatible"].includes(providerType)
+        reasoning_effort: ["openai", "claude", "gemini", "deepseek", "openrouter", "orcarouter", "openai_compatible"].includes(providerType)
           ? getInput("llmInstanceReasoning").trim()
           : "",
         num_ctx: providerType === "ollama"
@@ -9041,7 +9044,7 @@ ${cardFeedbackBarHtml()}`;
         const visible =
           (kind === "openai-auth" && providerType === "openai") ||
           (kind === "openai-protocol" && ["openai", "openai_compatible"].includes(providerType)) ||
-          (kind === "reasoning" && ["openai", "claude", "gemini", "deepseek", "openrouter", "openai_compatible"].includes(providerType)) ||
+          (kind === "reasoning" && ["openai", "claude", "gemini", "deepseek", "openrouter", "orcarouter", "openai_compatible"].includes(providerType)) ||
           (kind === "ollama" && providerType === "ollama") ||
           (kind === "openrouter" && providerType === "openrouter");
         field.hidden = !visible;
@@ -9158,7 +9161,7 @@ ${cardFeedbackBarHtml()}`;
         api_flavor: ["openai", "openai_compatible"].includes(providerType) ? getInput("llmInstanceApiFlavor") : "",
         http_referer: providerType === "openrouter" ? getInput("llmInstanceReferer").trim() : "",
         x_title: providerType === "openrouter" ? getInput("llmInstanceTitle").trim() : "",
-        reasoning_effort: ["openai", "claude", "gemini", "deepseek", "openrouter", "openai_compatible"].includes(providerType) ? getInput("llmInstanceReasoning") : "",
+        reasoning_effort: ["openai", "claude", "gemini", "deepseek", "openrouter", "orcarouter", "openai_compatible"].includes(providerType) ? getInput("llmInstanceReasoning") : "",
         num_ctx: providerType === "ollama" ? Math.max(0, getIntInput("llmInstanceNumCtx", 0)) : 0
       };
       closeLlmInstanceDialog();

--- a/src/openbiliclaw/web/desktop/index.html
+++ b/src/openbiliclaw/web/desktop/index.html
@@ -1321,7 +1321,7 @@
             <label class="settings-field"><span>实例名称</span><input id="llmInstanceName" autocomplete="off" placeholder="例如：DeepSeek 官方"></label>
             <label class="settings-field"><span>实例 ID</span><input id="llmInstanceId" autocomplete="off" spellcheck="false" placeholder="deepseek-main" aria-describedby="llmInstanceIdHint"></label>
             <p class="settings-note-inline llm-instance-id-hint" id="llmInstanceIdHint">保存后 ID 不可修改；调用链通过它稳定引用实例。</p>
-            <label class="settings-field"><span>Provider 类型</span><select id="llmInstanceProviderType" translate="no"><option value="openai">OpenAI</option><option value="claude">Claude</option><option value="gemini">Gemini</option><option value="deepseek">DeepSeek</option><option value="openrouter">OpenRouter</option><option value="ollama">Ollama</option><option value="openai_compatible">OpenAI-compatible</option></select></label>
+            <label class="settings-field"><span>Provider 类型</span><select id="llmInstanceProviderType" translate="no"><option value="openai">OpenAI</option><option value="claude">Claude</option><option value="gemini">Gemini</option><option value="deepseek">DeepSeek</option><option value="openrouter">OpenRouter</option><option value="orcarouter">OrcaRouter</option><option value="ollama">Ollama</option><option value="openai_compatible">OpenAI-compatible</option></select></label>
             <label class="settings-field"><span>状态</span><select id="llmInstanceEnabled"><option value="on">启用</option><option value="off">停用</option></select></label>
             <label class="settings-field full">
               <span>模型</span>

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -735,6 +735,40 @@ def test_validate_runtime_config_requires_openrouter_api_key() -> None:
         validate_runtime_config(config)
 
 
+def test_build_config_supports_orcarouter_provider() -> None:
+    config = _build_config(
+        {
+            "llm": {
+                "default_provider": "orcarouter",
+                "orcarouter": {
+                    "api_key": "sk-orca-test",
+                    "model": "openai/gpt-4o",
+                    "base_url": "https://api.orcarouter.ai/v1",
+                    "reasoning_effort": "high",
+                },
+            }
+        }
+    )
+
+    assert config.llm.default_provider == "orcarouter"
+    assert config.llm.orcarouter.api_key == "sk-orca-test"
+    assert config.llm.orcarouter.model == "openai/gpt-4o"
+    assert config.llm.orcarouter.base_url == "https://api.orcarouter.ai/v1"
+    assert config.llm.orcarouter.reasoning_effort == "high"
+
+
+def test_validate_runtime_config_requires_orcarouter_api_key() -> None:
+    config = Config(
+        llm=LLMConfig(
+            default_provider="orcarouter",
+            orcarouter=LLMProviderConfig(api_key="", model="openai/gpt-4o"),
+        )
+    )
+
+    with pytest.raises(ConfigError, match="llm.orcarouter.api_key"):
+        validate_runtime_config(config)
+
+
 def test_build_config_supports_openai_compatible_provider() -> None:
     """v0.3.32+ — generic OpenAI-protocol-compatible provider with its
     own [llm.openai_compatible] block. Distinct from [llm.openai]."""

--- a/tests/test_desktop_web_config_probe.py
+++ b/tests/test_desktop_web_config_probe.py
@@ -70,7 +70,7 @@ def test_desktop_web_instance_editor_persists_deepseek_reasoning_effort() -> Non
     js = (ROOT / "src/openbiliclaw/web/desktop/assets/js/app.js").read_text(encoding="utf-8")
 
     assert (
-        '["openai", "claude", "gemini", "deepseek", "openrouter", '
+        '["openai", "claude", "gemini", "deepseek", "openrouter", "orcarouter", '
         '"openai_compatible"].includes(providerType)'
     ) in js
     assert "reasoning_effort:" in js

--- a/tests/test_llm_providers.py
+++ b/tests/test_llm_providers.py
@@ -26,6 +26,7 @@ from openbiliclaw.llm.gemini_provider import GeminiProvider, gemini_sdk_availabl
 from openbiliclaw.llm.ollama_provider import OllamaProvider
 from openbiliclaw.llm.openai_provider import DeepSeekProvider, OpenAIProvider
 from openbiliclaw.llm.openrouter_provider import OpenRouterProvider
+from openbiliclaw.llm.orcarouter_provider import OrcaRouterProvider
 
 
 def _openai_response(content: str = "ok") -> SimpleNamespace:
@@ -1318,6 +1319,91 @@ async def test_openrouter_channel_empty_omits_unsafe_disable_for_mandatory_model
     )
 
     assert "extra_body" not in captured
+
+
+def test_orcarouter_provider_defaults() -> None:
+    provider = OrcaRouterProvider(api_key="test-key", model="openai/gpt-4o")
+
+    assert provider.name == "orcarouter"
+    assert provider.base_url == "https://api.orcarouter.ai/v1"
+    # OrcaRouter does not use OpenRouter attribution headers.
+    assert provider._extra_headers() == {}
+    # OrcaRouter forwards reasoning args to the upstream route, which
+    # rejects them on non-reasoning models (HTTP 400 against gpt-4o), so
+    # the adapter never sends reasoning_effort or a provider-specific body.
+    assert provider._extra_body(reasoning_effort="medium") == {}
+    assert provider._openai_reasoning_effort("openai/gpt-4o", "high") is None
+
+
+@pytest.mark.asyncio
+async def test_orcarouter_provider_omits_reasoning_effort(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """OrcaRouter never sends ``reasoning_effort`` or a nested ``reasoning``
+    object: the gateway forwards both to the upstream model, which rejects
+    them on non-reasoning routes (verified against ``openai/gpt-4o``)."""
+    provider = OrcaRouterProvider(api_key="test-key", model="openai/gpt-4o")
+    captured: dict[str, object] = {}
+
+    async def fake_request(**kwargs: object) -> SimpleNamespace:
+        captured.update(kwargs)
+        return _openai_response("orcarouter-ok")
+
+    monkeypatch.setattr(provider, "_request_with_retry", fake_request)
+
+    response = await provider.complete(
+        [{"role": "user", "content": "hi"}],
+        reasoning_effort="high",
+    )
+
+    assert response.content == "orcarouter-ok"
+    assert "reasoning_effort" not in captured
+    assert "extra_body" not in captured
+
+
+@pytest.mark.asyncio
+async def test_orcarouter_channel_empty_omits_reasoning_effort(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    provider = OrcaRouterProvider(api_key="test-key", model="openai/gpt-4o")
+    captured: dict[str, object] = {}
+
+    async def fake_request(**kwargs: object) -> SimpleNamespace:
+        captured.update(kwargs)
+        return _openai_response("ok")
+
+    monkeypatch.setattr(provider, "_request_with_retry", fake_request)
+
+    await provider.complete(
+        [{"role": "user", "content": "hi"}],
+        reasoning_effort="",
+    )
+
+    assert "reasoning_effort" not in captured
+    assert "extra_body" not in captured
+
+
+@pytest.mark.asyncio
+async def test_orcarouter_provider_inherits_per_call_model_override(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    provider = OrcaRouterProvider(api_key="test-key", model="openai/gpt-4o")
+    captured: dict[str, object] = {}
+
+    async def fake_request(**kwargs: object) -> SimpleNamespace:
+        captured.update(kwargs)
+        return _openai_response("orcarouter-ok")
+
+    monkeypatch.setattr(provider, "_request_with_retry", fake_request)
+
+    response = await provider.complete(
+        [{"role": "user", "content": "hi"}],
+        model="anthropic/claude-opus-4.8",
+    )
+
+    assert response.content == "orcarouter-ok"
+    assert captured["model"] == "anthropic/claude-opus-4.8"
+    assert provider._model == "openai/gpt-4o"
 
 
 @pytest.mark.skipif(not gemini_sdk_available(), reason="google-genai is not installed")

--- a/tests/test_llm_registry.py
+++ b/tests/test_llm_registry.py
@@ -142,6 +142,38 @@ def test_build_llm_registry_registers_openrouter() -> None:
     assert "openrouter" in registry.available_providers
 
 
+def test_build_llm_registry_registers_orcarouter() -> None:
+    config = Config(
+        llm=LLMConfig(
+            default_provider="orcarouter",
+            orcarouter=LLMProviderConfig(
+                api_key="sk-orca-test",
+                model="openai/gpt-4o",
+            ),
+        )
+    )
+
+    registry = build_llm_registry(config)
+
+    assert registry.default_provider == "orcarouter"
+    assert "orcarouter" in registry.available_providers
+    provider = registry.get("orcarouter")
+    assert provider.name == "orcarouter"
+    assert provider.base_url == "https://api.orcarouter.ai/v1"
+
+
+def test_build_llm_registry_omits_orcarouter_without_api_key() -> None:
+    config = Config(
+        llm=LLMConfig(
+            default_provider="deepseek",
+            deepseek=LLMProviderConfig(api_key="sk-deepseek", model="deepseek-v4-flash"),
+        )
+    )
+    registry = build_llm_registry(config)
+
+    assert "orcarouter" not in registry.available_providers
+
+
 def test_build_llm_registry_registers_openai_compatible() -> None:
     """v0.3.32+ — openai_compatible is a first-class registered provider,
     distinct from openai. Both can coexist in the same registry."""


### PR DESCRIPTION
## feat(llm): add OrcaRouter provider

Adds a named **[OrcaRouter](https://www.orcarouter.ai)** provider built on the OpenAI-compatible client, mirroring the existing OpenRouter wiring. OrcaRouter is a model-routing gateway that exposes 150+ models from OpenAI, Anthropic, Google, DeepSeek and others behind a single OpenAI-compatible endpoint and API key (`sk-orca-`).

### What's included

- **`OrcaRouterProvider`** (`src/openbiliclaw/llm/orcarouter_provider.py`) — default `base_url` `https://api.orcarouter.ai/v1`, default model `openai/gpt-4o`; inherits the shared timeout / retry / error-normalization / JSON-mode / per-call model override semantics from `OpenAIProvider`.
- **Registry + config + API + CLI + web + bootstrap** — `orcarouter` is wired into `build_llm_registry`, the `config.toml` schema (`[llm.orcarouter]`), `GET /api/config` (`LLMConfigOut`), the CLI interactive provider menu, the desktop web UI provider select, and `scripts/agent_bootstrap.py` provider lists (so `--provider orcarouter` works).
- **Docs** — provider table, config reference, CLI menu, agent-install, docker-deployment, architecture/spec diagrams, README (CN/EN), `config.example.toml`, and `docs/changelog.md` updated.
- **Tests** — registry registration, config round-trip, desktop-web probe, and provider wire-behavior tests (4 OrcaRouter cases).

### Reasoning notes

The gateway forwards `reasoning_effort` (and the nested `reasoning` object) verbatim to the upstream route; non-reasoning models reject them with HTTP 400 (verified live against `openai/gpt-4o`). The adapter therefore never sends reasoning args — reasoning-capable models fall back to their own default effort. The `reasoning_effort` config field is kept for schema alignment but is not transmitted.

### Local validation

- `pytest tests/test_llm_providers.py tests/test_llm_registry.py tests/test_config.py tests/test_desktop_web_config_probe.py tests/test_agent_bootstrap.py` → **497 passed, 17 skipped, 5 failed** (all pre-existing environment failures: `google-genai` not installed ×2, missing `socksio`, Windows `data_path`/`NO_PROXY` quirks — confirmed identical on a clean baseline)
- `ruff check src/ tests/ scripts/agent_bootstrap.py` → **clean**
- `mypy src/` → identical to baseline (17 pre-existing missing-stub errors; none in the new/changed code)
- **Live L3 test** → `OrcaRouterProvider.complete()` against `https://api.orcarouter.ai/v1` with the default `openai/gpt-4o` model returned `ORCAROUTER_L3_OK` with correct usage.

### Security

It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

I'm an engineer on the OrcaRouter team.
