### PR TITLE
fix: send CSRF header from setup wizard

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,7 @@
 
 ## 未发布
 
+- **修复密码门禁下首次设置模型保存返回 403（issue #171）**：setup 向导的同源请求统一携带既有 `X-OBC-Auth: 1` CSRF 请求头与 Cookie，覆盖模型配置保存、模型发现和向量模型修复；后端 CSRF 策略保持不变。
 - **自动打开的任务标签页默认静音（issue #163）**：扩展新增 `background/task-tab.ts` 的共享助手 `createTaskTab()`，B 站搜索兜底、小红书、抖音、知乎、Reddit、Linux.do、V2EX、微博、YouTube 及原生保存/E2E 新开标签页统一在创建后立即 `tabs.update(tabId, { muted: true })`，避免抖音等自动播放内容在电脑无人值守时突然出声。Chrome 的 `tabs.create` 不支持 `muted`，因此跨 Chrome / Firefox / Safari 统一采用「先 create、再 update 静音」；静音跨后续导航保持，用户可在标签栏手动取消，静音失败不阻断任务。复用用户已有标签页的路径保持原样。
 
 ## v0.3.207：补货提速与搜索后端升级（2026-08-15）

--- a/src/openbiliclaw/web/setup/index.html
+++ b/src/openbiliclaw/web/setup/index.html
@@ -268,7 +268,12 @@
       const controller = new AbortController();
       const timer = setTimeout(() => controller.abort(), timeoutMs);
       try {
-        return await fetch(url, { ...options, signal: controller.signal });
+        return await fetch(url, {
+          ...options,
+          credentials: "same-origin",
+          headers: { ...(options.headers || {}), "X-OBC-Auth": "1" },
+          signal: controller.signal,
+        });
       } catch (error) {
         if (error?.name === "AbortError") throw new Error(`请求等待超过 ${Math.ceil(timeoutMs / 1000)} 秒`);
         throw error;
@@ -817,8 +822,10 @@
       btn.disabled = true; btn.innerHTML = '<span class="spin"></span>保存中…';
       clearMsg("#msg0");
       try {
-        const r = await fetch("/api/config", {
-          method: "PUT", headers: { "Content-Type": "application/json" }, body: JSON.stringify(payload),
+        const r = await fetchWithTimeout("/api/config", {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(payload),
         });
         if (r.status === 401) {
           // Remote browser + auth enabled: /api/config is session-gated (only

--- a/tests/test_web_guided_init.py
+++ b/tests/test_web_guided_init.py
@@ -444,6 +444,18 @@ def test_setup_wizard_config_save_401_points_to_login_instead_of_dead_end() -> N
     assert '<a href="/web">' in setup_html
 
 
+def test_setup_wizard_protected_requests_use_csrf_auth_fetch_contract() -> None:
+    """Password-authenticated setup writes must use the shared CSRF-aware fetch."""
+    setup_html = Path("src/openbiliclaw/web/setup/index.html").read_text(encoding="utf-8")
+
+    assert 'credentials: "same-origin"' in setup_html
+    assert '"X-OBC-Auth": "1"' in setup_html
+    assert 'const r = await fetch("/api/config", {' not in setup_html
+    assert 'const r = await fetchWithTimeout("/api/config", {' in setup_html
+    assert '"/api/config/discover-models"' in setup_html
+    assert '"/api/embedding/repair"' in setup_html
+
+
 def test_web_surfaces_offer_embedding_repair_and_progress() -> None:
     """Both web init checklists expose one-click model download + live progress.
 


### PR DESCRIPTION
Fixes #171

## What changed

- Make the `/setup/` fetch helper send `credentials: "same-origin"` and the existing `X-OBC-Auth: 1` CSRF header.
- Route the model configuration `PUT /api/config` through that helper so password-authenticated setup can continue past the model step.
- Add a static regression contract and an entry in the unreleased changelog.

## Root cause

The password gate correctly rejects cookie-authenticated unsafe requests without the CSRF header. The desktop SPA already sends the header, but the setup wizard used a separate fetch path that omitted it. Model discovery and embedding repair already use the shared setup helper, so they are covered by the same fix.

The backend CSRF policy is unchanged.

## Validation

- `uv run pytest tests/test_web_guided_init.py tests/test_web_llm_instance_routing.py tests/test_api_auth.py -q` — 120 passed
- `uv run pytest tests/test_web_guided_init_e2e.py -q` — 39 passed
- `uv run pytest -q` — 8368 passed, 106 skipped
- `uv run ruff check src/ tests/` — passed
- `uv run ruff format --check tests/test_web_guided_init.py` — passed
