### PR TITLE
fix: match quoted TOML instance sections in agent_bootstrap

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,7 @@
 
 ## 未发布
 
+- **修复 bootstrap 二次运行追加重复 TOML 实例段（issue #174）**：`agent_bootstrap` 的 section 匹配现在忽略裸键/引号键差异，`[llm.instances.openai]` 与 `[llm.instances."openai"]` 视为同一表，避免 `tomllib` 报 `Cannot declare ... twice`。
 - **修复非 DeepSeek 安装被默认空 Key 实例拦截（issue #176）**：`agent_bootstrap` 选择其他 LLM provider 时，会自动停用样例中的无 API Key DeepSeek 实例并从 `default_chain` 移除；已有 DeepSeek Key 的备选实例保持不变，`init` 不再要求用户手改 `config.toml`。
 - **修复 Windows PowerShell 5.1 安装器在 clone 成功后静默退出（issue #177）**：`install.ps1` 现在在检查 `$LASTEXITCODE` 前捕获 `git clone` 的 stderr；PS 5.1 不再把 Git 的正常进度输出误判为终止错误，完整 clone 会继续运行 bootstrap，真实 clone 失败仍会显示 Git 原始诊断并清理临时日志。
 - **修复桌面 Web 关闭自动续页后后台仍消耗可换库存（issue #81）**：已有推荐卡片时切回标签页、配置应用和状态水合不再请求可能触发首屏补池的 `/api/recommendations`，只同步 runtime / 库存状态；只有空列表首屏或用户明确手动刷新才读取推荐快照，已显示卡片和库存开关边界保持稳定。

--- a/scripts/agent_bootstrap.py
+++ b/scripts/agent_bootstrap.py
@@ -1822,6 +1822,57 @@ def read_simple_toml(path: Path) -> dict[str, Any]:
         return tomllib.load(handle)
 
 
+def _toml_table_path(header: str) -> tuple[str, ...]:
+    """Normalize ``[a.b."c"]`` / ``[a.b.c]`` to ``('a', 'b', 'c')``.
+
+    Backend rewrites of config.toml often quote dotted keys
+    (``[llm.instances."openai"]``). Those tables are the same as the bare-key
+    form the bootstrap editor writes (``[llm.instances.openai]``).
+    """
+
+    text = header.strip()
+    if text.startswith("[") and text.endswith("]"):
+        text = text[1:-1].strip()
+        if text.startswith("[") and text.endswith("]"):
+            text = text[1:-1].strip()
+    parts: list[str] = []
+    buf: list[str] = []
+    quote = ""
+    index = 0
+    while index < len(text):
+        char = text[index]
+        if quote:
+            if char == "\\" and index + 1 < len(text):
+                buf.append(text[index + 1])
+                index += 2
+                continue
+            if char == quote:
+                quote = ""
+            else:
+                buf.append(char)
+            index += 1
+            continue
+        if char in {'"', "'"}:
+            quote = char
+            index += 1
+            continue
+        if char == ".":
+            parts.append("".join(buf).strip())
+            buf = []
+            index += 1
+            continue
+        buf.append(char)
+        index += 1
+    parts.append("".join(buf).strip())
+    return tuple(part for part in parts if part)
+
+
+def _toml_section_matches(header_line: str, section: str) -> bool:
+    """True when a TOML header names the same table as ``section``."""
+
+    return _toml_table_path(header_line) == _toml_table_path(f"[{section}]")
+
+
 def set_toml_raw_value(content: str, section: str, key: str, rendered_value: str) -> str:
     """Rewrite one scalar/array value under ``[section]``.
 
@@ -1844,7 +1895,7 @@ def set_toml_raw_value(content: str, section: str, key: str, rendered_value: str
             if in_section:
                 insert_at = index
                 break
-            in_section = stripped == section_header
+            in_section = _toml_section_matches(stripped, section)
             if in_section:
                 section_found = True
                 insert_at = index + 1
@@ -1921,14 +1972,13 @@ def clear_toml_string_value(content: str, section: str, key: str) -> tuple[str, 
     """
 
     new_line = f'{key} = ""'
-    section_header = f"[{section}]"
     lines = content.splitlines()
     in_section = False
     changed = False
     for index, raw_line in enumerate(lines):
         stripped = raw_line.strip()
         if stripped.startswith("[") and stripped.endswith("]"):
-            in_section = stripped == section_header
+            in_section = _toml_section_matches(stripped, section)
             continue
         if not in_section:
             continue

--- a/tests/test_agent_bootstrap.py
+++ b/tests/test_agent_bootstrap.py
@@ -1670,12 +1670,8 @@ def test_set_toml_raw_value_matches_quoted_instance_section() -> None:
     import tomllib
 
     content = '[llm.instances."openai"]\nenabled = true\napi_key = "sk-old"\n'
-    updated = bootstrap.set_toml_raw_value(
-        content, "llm.instances.openai", "enabled", "false"
-    )
-    updated = bootstrap.set_toml_string_value(
-        updated, "llm.instances.openai", "api_key", "sk-new"
-    )
+    updated = bootstrap.set_toml_raw_value(content, "llm.instances.openai", "enabled", "false")
+    updated = bootstrap.set_toml_string_value(updated, "llm.instances.openai", "api_key", "sk-new")
     assert updated.count("[llm.instances") == 1
     parsed = tomllib.loads(updated)
     assert parsed["llm"]["instances"]["openai"]["enabled"] is False
@@ -1695,7 +1691,7 @@ def test_clear_toml_string_value_matches_quoted_section() -> None:
 
 
 def test_toml_table_path_equates_bare_and_quoted_keys() -> None:
-    assert bootstrap._toml_table_path('[llm.instances.openai]') == (
+    assert bootstrap._toml_table_path("[llm.instances.openai]") == (
         "llm",
         "instances",
         "openai",
@@ -1710,4 +1706,3 @@ def test_toml_table_path_equates_bare_and_quoted_keys() -> None:
         "instances",
         "openai-compatible",
     )
-

--- a/tests/test_agent_bootstrap.py
+++ b/tests/test_agent_bootstrap.py
@@ -1664,3 +1664,50 @@ def test_stale_entry_is_not_duplicated_on_refold() -> None:
         init_status=_init_status("failed"),
     )
     assert twice["missing"].count(bootstrap.STALE_COOKIE_MISSING_ENTRY) == 1
+
+
+def test_set_toml_raw_value_matches_quoted_instance_section() -> None:
+    import tomllib
+
+    content = '[llm.instances."openai"]\nenabled = true\napi_key = "sk-old"\n'
+    updated = bootstrap.set_toml_raw_value(
+        content, "llm.instances.openai", "enabled", "false"
+    )
+    updated = bootstrap.set_toml_string_value(
+        updated, "llm.instances.openai", "api_key", "sk-new"
+    )
+    assert updated.count("[llm.instances") == 1
+    parsed = tomllib.loads(updated)
+    assert parsed["llm"]["instances"]["openai"]["enabled"] is False
+    assert parsed["llm"]["instances"]["openai"]["api_key"] == "sk-new"
+
+
+def test_clear_toml_string_value_matches_quoted_section() -> None:
+    import tomllib
+
+    content = '[llm.instances."openai"]\nbase_url = "https://relay.example/v1"\n'
+    updated, changed = bootstrap.clear_toml_string_value(
+        content, "llm.instances.openai", "base_url"
+    )
+    assert changed
+    assert updated.count("[llm.instances") == 1
+    assert tomllib.loads(updated)["llm"]["instances"]["openai"]["base_url"] == ""
+
+
+def test_toml_table_path_equates_bare_and_quoted_keys() -> None:
+    assert bootstrap._toml_table_path('[llm.instances.openai]') == (
+        "llm",
+        "instances",
+        "openai",
+    )
+    assert bootstrap._toml_table_path('[llm.instances."openai"]') == (
+        "llm",
+        "instances",
+        "openai",
+    )
+    assert bootstrap._toml_table_path('[llm.instances."openai-compatible"]') == (
+        "llm",
+        "instances",
+        "openai-compatible",
+    )
+


### PR DESCRIPTION
## Summary

`set_toml_raw_value()` compared section headers as raw strings. After the backend rewrote `[llm.instances.openai]` to `[llm.instances."openai"]`, a second bootstrap run appended a duplicate table and `tomllib` failed with `Cannot declare ... twice`.

## Changes

- Normalize bare and quoted TOML table paths so `[llm.instances.openai]` and `[llm.instances."openai"]` are the same section
- Apply the same match in `clear_toml_string_value()`
- Add regression tests for quoted instance sections

## Test plan

- [x] `pytest tests/test_agent_bootstrap.py -k toml`

Fixes #174
