### PR TITLE
fix: map --llm-preset relay to openai_compatible

### DIFF
--- a/docs/agent-install.md
+++ b/docs/agent-install.md
@@ -377,7 +377,7 @@ python3 scripts/agent_bootstrap.py --llm-preset self-hosted \
   --llm-model meta-llama/Llama-3.3-70B-Instruct ...
 ```
 
-`--llm-base-url` / `--llm-model` 单独传时会**覆盖**对应 preset 字段(per-field override),给你 escape hatch 而不强制走 preset 默认。`--llm-preset` 隐式锁 `--provider=openai`,显式传不同 provider 会冲突报错。
+`--llm-base-url` / `--llm-model` 单独传时会**覆盖**对应 preset 字段(per-field override),给你 escape hatch 而不强制走 preset 默认。`--llm-preset` 隐式锁 `--provider=openai_compatible`（这样中转站 DeepSeek 等模型会走“可关闭 thinking”的通用 OpenAI 兼容适配器，避免 `max_tokens` 被隐藏推理耗尽）；显式传不同 provider 会冲突报错，历史遗留的 `--provider openai` 会被自动 remap 为 `openai_compatible`。
 
 **Why DeepSeek default, not Ollama**: previous versions called Ollama
 "推荐新手 / 白嫖" but in practice CPU inference on a 16 GB Mac is slow

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,7 @@
 
 ## 未发布
 
+- **修复 `--llm-preset` 写入 `openai` 导致中转站 DeepSeek 推理 token 耗尽（issue #175）**：`agent_bootstrap` 的 OpenAI 兼容 preset（`relay` / `kimi` / `qwen` / ...）现在隐式写入 `provider_type="openai_compatible"`，使通用 OpenAI 兼容适配器能对中转站 DeepSeek 关闭 thinking；历史 `--provider openai` 与 preset 组合自动 remap，显式非兼容 provider 仍冲突报错。同步更新 `docs/agent-install.md` 的 preset 说明。
 - **修复 bootstrap 二次运行追加重复 TOML 实例段（issue #174）**：`agent_bootstrap` 的 section 匹配现在忽略裸键/引号键差异，`[llm.instances.openai]` 与 `[llm.instances."openai"]` 视为同一表，避免 `tomllib` 报 `Cannot declare ... twice`。
 - **补充 PR #182 贡献者致谢**：README 中英文与贡献指南正式记录 [@LHMQ878](https://github.com/LHMQ878) 对 `agent_bootstrap` 引号键 TOML 实例段 section 匹配修复的贡献。
 - **修复非 DeepSeek 安装被默认空 Key 实例拦截（issue #176）**：`agent_bootstrap` 选择其他 LLM provider 时，会自动停用样例中的无 API Key DeepSeek 实例并从 `default_chain` 移除；已有 DeepSeek Key 的备选实例保持不变，`init` 不再要求用户手改 `config.toml`。

--- a/scripts/agent_bootstrap.py
+++ b/scripts/agent_bootstrap.py
@@ -887,8 +887,9 @@ def build_arg_parser() -> argparse.ArgumentParser:
         help=(
             "Override the chosen provider's base_url. Required for OpenAI-"
             "compatible gateways (Azure / vLLM / LMStudio / OneAPI / 任意 "
-            "OpenAI 兼容服务). The 'openai' provider is a protocol family, "
-            "not a vendor — point it anywhere that speaks /v1/chat/completions."
+            "OpenAI 兼容服务). --llm-preset already implies "
+            "provider=openai_compatible; pass --provider openai only for "
+            "the official OpenAI endpoint."
         ),
     )
     parser.add_argument(
@@ -3888,14 +3889,8 @@ def apply_llm_preset_args(args: Any) -> int | None:
     if not getattr(args, "llm_preset", None):
         return None
     preset = LLM_PRESETS.get(args.llm_preset, {})
-    implied = (
-        "openai_compatible"
-        if args.llm_preset in HUMAN_OPENAI_COMPAT_PRESETS
-        else "openai"
-    )
-    if not args.provider or (
-        args.provider == "openai" and implied == "openai_compatible"
-    ):
+    implied = "openai_compatible" if args.llm_preset in HUMAN_OPENAI_COMPAT_PRESETS else "openai"
+    if not args.provider or (args.provider == "openai" and implied == "openai_compatible"):
         args.provider = implied
     elif args.provider != implied:
         emit(

--- a/scripts/agent_bootstrap.py
+++ b/scripts/agent_bootstrap.py
@@ -132,8 +132,9 @@ def ensure_local_no_proxy() -> str:
 
 # Mirror of cli.py's _OPENAI_COMPAT_PRESETS for non-interactive (AI agent
 # driven) installs. Keep the model defaults in sync with cli.py — when
-# updating one, update the other. Each preset implies provider="openai"
-# (the universal Bearer-auth + /v1/chat/completions client).
+# updating one, update the other. Each preset implies
+# provider="openai_compatible" so DeepSeek-backed relays can disable
+# thinking instead of burning max_tokens on hidden reasoning.
 LLM_PRESETS: dict[str, dict[str, str]] = {
     "kimi": {
         "base_url": "https://api.moonshot.ai/v1",
@@ -913,7 +914,7 @@ def build_arg_parser() -> argparse.ArgumentParser:
             "Shortcut for OpenAI-protocol-compatible services. Picks the "
             "preset's canonical Base URL + default model so AI-agent-driven "
             "installs don't have to remember each vendor's endpoint. "
-            "Implies --provider=openai. --llm-base-url / --llm-model still "
+            "Implies --provider=openai_compatible. --llm-base-url / --llm-model still "
             "override the preset on a per-field basis. Presets: "
             "kimi (Moonshot), minimax (M2.7), qwen (DashScope), zhipu (GLM), "
             "yi (零一万物), self-hosted (vLLM/LMStudio), relay (中转站/OneAPI), "
@@ -3876,35 +3877,55 @@ def run(args: argparse.Namespace) -> int:
     return 5
 
 
+def apply_llm_preset_args(args: Any) -> int | None:
+    """Resolve ``--llm-preset`` onto provider / base_url / model.
+
+    Returns an exit code on conflict; ``None`` when args were applied or
+    when no preset was requested. Never overrides an explicit
+    ``--llm-base-url`` / ``--llm-model``.
+    """
+
+    if not getattr(args, "llm_preset", None):
+        return None
+    preset = LLM_PRESETS.get(args.llm_preset, {})
+    implied = (
+        "openai_compatible"
+        if args.llm_preset in HUMAN_OPENAI_COMPAT_PRESETS
+        else "openai"
+    )
+    if not args.provider or (
+        args.provider == "openai" and implied == "openai_compatible"
+    ):
+        args.provider = implied
+    elif args.provider != implied:
+        emit(
+            BootstrapResult(
+                "error",
+                "preset_provider_conflict",
+                {
+                    "reason": (
+                        f"--llm-preset implies provider={implied} but you "
+                        f"passed --provider={args.provider}. Drop one of them."
+                    )
+                },
+            )
+        )
+        return 2
+    if args.llm_base_url is None and preset.get("base_url"):
+        args.llm_base_url = preset["base_url"]
+    if args.llm_model is None and preset.get("model"):
+        args.llm_model = preset["model"]
+    return None
+
+
 def main() -> int:
     parser = build_arg_parser()
     args = parser.parse_args()
     # Resolve --llm-preset before run() so the rest of the pipeline
-    # sees concrete provider/base_url/model values. The preset implies
-    # provider=openai but never overrides explicit user-provided
-    # --llm-base-url / --llm-model.
-    if getattr(args, "llm_preset", None):
-        preset = LLM_PRESETS.get(args.llm_preset, {})
-        if not args.provider:
-            args.provider = "openai"
-        elif args.provider != "openai":
-            emit(
-                BootstrapResult(
-                    "error",
-                    "preset_provider_conflict",
-                    {
-                        "reason": (
-                            f"--llm-preset implies provider=openai but you "
-                            f"passed --provider={args.provider}. Drop one of them."
-                        )
-                    },
-                )
-            )
-            return 2
-        if args.llm_base_url is None and preset.get("base_url"):
-            args.llm_base_url = preset["base_url"]
-        if args.llm_model is None and preset.get("model"):
-            args.llm_model = preset["model"]
+    # sees concrete provider/base_url/model values.
+    preset_error = apply_llm_preset_args(args)
+    if preset_error is not None:
+        return preset_error
     try:
         return run(args)
     except KeyboardInterrupt:

--- a/tests/test_agent_bootstrap.py
+++ b/tests/test_agent_bootstrap.py
@@ -1706,3 +1706,42 @@ def test_toml_table_path_equates_bare_and_quoted_keys() -> None:
         "instances",
         "openai-compatible",
     )
+
+
+def test_llm_preset_relay_uses_openai_compatible_provider(tmp_path: Path) -> None:
+    args = bootstrap.build_arg_parser().parse_args(
+        ["--project-dir", str(tmp_path), "--llm-preset", "relay"]
+    )
+    assert bootstrap.apply_llm_preset_args(args) is None
+    assert args.provider == "openai_compatible"
+
+
+def test_llm_preset_relay_remaps_historical_openai_provider(tmp_path: Path) -> None:
+    args = bootstrap.build_arg_parser().parse_args(
+        [
+            "--project-dir",
+            str(tmp_path),
+            "--llm-preset",
+            "relay",
+            "--provider",
+            "openai",
+        ]
+    )
+    assert bootstrap.apply_llm_preset_args(args) is None
+    assert args.provider == "openai_compatible"
+
+
+def test_llm_preset_keeps_explicit_non_compat_provider_as_conflict(
+    tmp_path: Path,
+) -> None:
+    args = bootstrap.build_arg_parser().parse_args(
+        [
+            "--project-dir",
+            str(tmp_path),
+            "--llm-preset",
+            "relay",
+            "--provider",
+            "deepseek",
+        ]
+    )
+    assert bootstrap.apply_llm_preset_args(args) == 2


### PR DESCRIPTION
## Summary

`--llm-preset relay` wrote `provider_type=openai`. That path uses the generic OpenAI client and does not disable DeepSeek thinking. On a relay serving `deepseek-v4-flash`, `max_tokens` is spent on hidden reasoning and discovery finishes with `finish_reason=length`.

## Changes

- OpenAI-compatible presets (`relay`, `kimi`, `qwen`, ...) now resolve to `provider=openai_compatible`
- Historical `--provider openai` with those presets is remapped instead of keeping the broken type
- An explicit non-compatible `--provider` still conflicts
- Regression tests for the preset resolver

## Test plan

- [x] `pytest tests/test_agent_bootstrap.py -k llm_preset`

Fixes #175
