### PR TITLE
feat: 高峰时段错峰 — 后台 LLM 调用推迟到 DeepSeek 半价空闲时段

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -449,6 +449,20 @@ enabled = true
 # Manual CLI/API requests remain explicit and are not blocked by this switch.
 pause_on_extension_disconnect = false
 extension_disconnect_grace_seconds = 90
+# Peak-hour deferral: when true, daemon-owned background LLM calls pause inside
+# the peak windows below (Beijing time), so they land in cheaper off-peak slots
+# (DeepSeek bills off-peak at half price). Interactive traffic (dialogue,
+# sentiment, config probes) is never deferred. Refill keeps an emergency floor:
+# when the servable pool drops below peak_refill_floor, refill still runs inside
+# a peak window so the feed never starves. Maintenance traffic (profile
+# consolidation, speculation, proactive pushes) is fully deferred.
+pause_during_peak_hours = false
+# Peak window spec "HH:MM-HH:MM,HH:MM-HH:MM" in Beijing time (UTC+8).
+# Default matches DeepSeek's official peak hours.
+peak_hours = "09:00-12:00,14:00-18:00"
+# Servable pool count at/below which refill bypasses peak deferral.
+# 0 means "never bypass" (peak fully blocks refill too).
+peak_refill_floor = 30
 # Legacy compatibility field. The current runtime does not consume this cron;
 # discovery is driven by the refresh loop, pool deficits, event thresholds, and
 # per-strategy refresh intervals below.

--- a/docs/modules/runtime.md
+++ b/docs/modules/runtime.md
@@ -596,6 +596,9 @@ XHS / 抖音 / YouTube / 知乎 / Reddit / V2EX 的插件任务桥保留两层�
 | `scheduler.enabled` | `true` | 后台 LLM / embedding 总开关。 |
 | `scheduler.pause_on_extension_disconnect` | `false` | 浏览器插件断开后是否暂停后台 LLM / embedding 工作。 |
 | `scheduler.extension_disconnect_grace_seconds` | `90` | 插件断开后的宽限秒数。 |
+| `scheduler.pause_during_peak_hours` | `false` | 高峰时段错峰：开启后 daemon-owned 后台 LLM 调用在 `peak_hours`（北京时间）窗口内暂停，落到更便宜的空闲时段（DeepSeek 空闲半价）。交互流量（对话 / sentiment / 配置探测）永不错峰；补货在池子跌破 `peak_refill_floor` 时仍允许紧急补货，避免白天断供；维护流量（画像合并、speculation、proactive push）完全推迟。 |
+| `scheduler.peak_hours` | `"09:00-12:00,14:00-18:00"` | 高峰窗口规格 `"HH:MM-HH:MM,HH:MM-HH:MM"`，北京时间（UTC+8）。默认与 DeepSeek 官方高峰一致。 |
+| `scheduler.peak_refill_floor` | `30` | 高峰时段补货的紧急水位：servable 池子可用数等于或低于该值时补货绕过高峰暂停照常执行；`0` 表示高峰完全禁止补货。 |
 | `scheduler.refresh_check_interval_seconds` | `60` | `ContinuousRefreshController` 主循环轮询间隔。 |
 | `scheduler.signal_event_threshold` | `6` | 累计多少条 discovery-trigger 新行为事件后触发 `search + related_chain`；该计数只表示 discovery refresh 水位，不表示画像待处理队列。 |
 | `scheduler.trending_refresh_minutes` | `3` | `trending` 策略最小刷新间隔（分钟）。v0.3.186 起单位由小时改为分钟；旧键 `trending_refresh_hours` 读取时按 ×60 换算。 |

--- a/src/openbiliclaw/api/app.py
+++ b/src/openbiliclaw/api/app.py
@@ -16854,6 +16854,9 @@ def create_app(
                 auto_update_check_interval_hours=cfg.scheduler.auto_update_check_interval_hours,
                 auto_update_allow_prerelease=cfg.scheduler.auto_update_allow_prerelease,
                 auto_update_allowed_remotes=list(cfg.scheduler.auto_update_allowed_remotes),
+                pause_during_peak_hours=cfg.scheduler.pause_during_peak_hours,
+                peak_hours=cfg.scheduler.peak_hours,
+                peak_refill_floor=cfg.scheduler.peak_refill_floor,
             ),
             discovery=DiscoveryConfigOut(
                 unified_keyword_planner_enabled=cfg.discovery.unified_keyword_planner_enabled,

--- a/src/openbiliclaw/api/models.py
+++ b/src/openbiliclaw/api/models.py
@@ -2301,6 +2301,9 @@ class SchedulerConfigOut(BaseModel):
     auto_update_check_interval_hours: int = 6
     auto_update_allow_prerelease: bool = False
     auto_update_allowed_remotes: list[str] = Field(default_factory=list)
+    pause_during_peak_hours: bool = False
+    peak_hours: str = "09:00-12:00,14:00-18:00"
+    peak_refill_floor: int = Field(default=30, ge=0)
 
 
 class SoulConfigOut(BaseModel):

--- a/src/openbiliclaw/config.py
+++ b/src/openbiliclaw/config.py
@@ -114,6 +114,9 @@ _DEFAULT_SPECULATOR_IDLE_INTERVAL_MINUTES = 30
 _DEFAULT_FEEDBACK_BATCH_THRESHOLD = 3
 _MIN_AUTO_UPDATE_CHECK_INTERVAL_HOURS = 1
 _DEFAULT_AUTO_UPDATE_CHECK_INTERVAL_HOURS = 6
+# Peak-hour deferral (DeepSeek off-peak half-price). Beijing time, UTC+8.
+_DEFAULT_PEAK_HOURS = "09:00-12:00,14:00-18:00"
+_DEFAULT_PEAK_REFILL_FLOOR = 30
 # Unified keyword planner (Discover backpressure refactor P1, spec §6).
 # All defaults are the owner-approved starting baseline; see
 # docs/plans/2026-06-14-discover-backpressure-refactor-design.md §6 and
@@ -1008,6 +1011,20 @@ class SchedulerConfig:
     # 2026-07-28 经真实 A/B 三道门与 A/A 噪声控制后默认开启；false 保留为
     # 逐字节回退到旧反馈批线的紧急开关。
     unified_interest_line: bool = True
+    # Peak-hour deferral for daemon-owned background LLM work. When true,
+    # background loops pause inside ``peak_hours`` (Beijing time) so calls
+    # land in cheaper off-peak windows (DeepSeek bills off-peak at half
+    # price). Interactive traffic (dialogue / sentiment / config probes) is
+    # never deferred. Refill keeps an emergency floor: when the servable
+    # pool drops below ``peak_refill_floor``, refill runs even inside a
+    # peak window so the feed never starves. Maintenance traffic (profile
+    # consolidation, speculation, proactive pushes) is fully deferred.
+    pause_during_peak_hours: bool = False
+    # Peak window spec "HH:MM-HH:MM,HH:MM-HH:MM" in Beijing time (UTC+8).
+    peak_hours: str = _DEFAULT_PEAK_HOURS
+    # Servable pool count at/below which refill bypasses peak deferral.
+    # 0 means "never bypass" (peak fully blocks refill too).
+    peak_refill_floor: int = _DEFAULT_PEAK_REFILL_FLOOR
     # Default off. The auto-updater pulls from GitHub releases and
     # restarts the backend when a newer version is detected, but it has
     # historically caused restart loops when the local
@@ -2583,6 +2600,16 @@ def _build_config(
                         # never engaged on a live backend.
                         default=True,
                     ),
+                    "pause_during_peak_hours": _coerce_bool(
+                        sched_raw.get("pause_during_peak_hours"),
+                        default=False,
+                    ),
+                    "peak_hours": _normalize_peak_hours(sched_raw.get("peak_hours")),
+                    "peak_refill_floor": _normalize_scheduler_int(
+                        sched_raw.get("peak_refill_floor"),
+                        default=_DEFAULT_PEAK_REFILL_FLOOR,
+                        min_value=0,
+                    ),
                 },
                 section="scheduler",
             )
@@ -3524,6 +3551,27 @@ def _normalize_source_incremental_hours(
             raise ValueError("source incremental interval must be an integer in 0..168")
         return default
     return parsed
+
+
+def _normalize_peak_hours(value: object) -> str:
+    """Normalize a peak-window spec to ``"HH:MM-HH:MM,HH:MM-HH:MM"`` form.
+
+    Malformed or empty values fall back to the default Beijing peak window
+    (DeepSeek official: 09:00-12:00, 14:00-18:00).  The runtime gate
+    (``runtime/presence.py``) re-parses the normalized string leniently, so
+    this only needs to keep the config value a well-formed string.
+    """
+    if value is None:
+        return _DEFAULT_PEAK_HOURS
+    text = str(value).strip()
+    if not text:
+        return _DEFAULT_PEAK_HOURS
+    # Light validation: at least one "HH:MM-HH:MM" pair must survive.
+    from openbiliclaw.runtime.presence import parse_peak_windows
+
+    if not parse_peak_windows(text):
+        return _DEFAULT_PEAK_HOURS
+    return text
 
 
 def _normalize_inspiration_breadth(value: object) -> str:
@@ -5198,6 +5246,10 @@ def _render_config_toml(
             f"pool_target_count = {config.scheduler.pool_target_count}",
             f"copy_ready_target_count = {config.scheduler.copy_ready_target_count}",
             f"account_sync_interval_hours = {config.scheduler.account_sync_interval_hours}",
+            "pause_during_peak_hours = "
+            f"{_toml_bool(config.scheduler.pause_during_peak_hours)}",
+            f"peak_hours = {_toml_string(config.scheduler.peak_hours)}",
+            f"peak_refill_floor = {config.scheduler.peak_refill_floor}",
             "source_incremental_enabled = "
             f"{_toml_bool(config.scheduler.source_incremental_enabled)}",
             f"source_incremental_hours = {config.scheduler.source_incremental_hours}",

--- a/src/openbiliclaw/runtime/presence.py
+++ b/src/openbiliclaw/runtime/presence.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 import threading
 import time
+from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -13,6 +14,15 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 _DEFAULT_EXTENSION_DISCONNECT_GRACE_SECONDS = 90
+
+# Peak-hour deferral defaults (DeepSeek bills off-peak at half price).
+# Peak window spec format: "HH:MM-HH:MM,HH:MM-HH:MM" in Beijing time
+# (UTC+8, no DST — a fixed offset needs no tzdata, which is absent from
+# the python:3.11-slim runtime image).
+_DEFAULT_PEAK_HOURS = "09:00-12:00,14:00-18:00"
+_DEFAULT_PEAK_REFILL_FLOOR = 30
+
+_BEIJING_TZ = timezone(timedelta(hours=8))
 
 
 class PresenceTracker:
@@ -68,9 +78,99 @@ class PresenceTracker:
         }
 
 
-def background_llm_work_allowed(scheduler: object, presence: PresenceTracker) -> bool:
-    """Return whether daemon-owned background LLM / embedding work may run."""
+def parse_peak_windows(spec: str) -> list[tuple[int, int]]:
+    """Parse a peak-window spec like ``"09:00-12:00,14:00-18:00"``.
+
+    Returns a list of ``(start_minutes, end_minutes)`` pairs within
+    ``[0, 1440)``, where the start is inclusive and the end is exclusive
+    (09:00 counts as peak, 12:00 does not). Malformed or empty specs
+    return ``[]`` — callers treat that as "no peak windows, never defer".
+    """
+    windows: list[tuple[int, int]] = []
+    for chunk in str(spec or "").split(","):
+        chunk = chunk.strip()
+        if not chunk or "-" not in chunk:
+            continue
+        start_s, _, end_s = chunk.partition("-")
+        try:
+            start_h, start_m = (int(part) for part in start_s.strip().split(":", 1))
+            end_h, end_m = (int(part) for part in end_s.strip().split(":", 1))
+        except (TypeError, ValueError):
+            continue
+        start = start_h * 60 + start_m
+        end = end_h * 60 + end_m
+        if not (0 <= start < 1440 and 0 <= end <= 1440) or start >= end:
+            continue
+        windows.append((start, end))
+    return windows
+
+
+def _now_in_peak_windows(
+    now_utc: datetime,
+    windows: list[tuple[int, int]],
+) -> bool:
+    """Return whether ``now_utc`` falls inside any Beijing-time peak window."""
+    if not windows:
+        return False
+    beijing = now_utc.astimezone(_BEIJING_TZ)
+    minutes = beijing.hour * 60 + beijing.minute
+    return any(start <= minutes < end for start, end in windows)
+
+
+def _peak_hour_deferral_active(
+    scheduler: object,
+    *,
+    pool_available: int | None = None,
+    now_utc: datetime | None = None,
+) -> bool:
+    """Return whether peak-hour deferral currently blocks background LLM work.
+
+    Only engages when the scheduler opts in via ``pause_during_peak_hours``.
+    Non-refill traffic (``pool_available is None``, e.g. profile maintenance
+    or proactive pushes) is fully blocked inside a peak window. Refill
+    traffic passes only when the servable pool is below
+    ``peak_refill_floor`` — an emergency top-up so the feed never starves
+    during peak hours.
+    """
+    if not bool(getattr(scheduler, "pause_during_peak_hours", False)):
+        return False
+    spec = str(getattr(scheduler, "peak_hours", "") or _DEFAULT_PEAK_HOURS)
+    windows = parse_peak_windows(spec)
+    if not windows:
+        return False
+    if now_utc is None:
+        now_utc = datetime.now(timezone.utc)
+    if not _now_in_peak_windows(now_utc, windows):
+        return False
+    if pool_available is None:
+        return True
+    floor = int(getattr(scheduler, "peak_refill_floor", _DEFAULT_PEAK_REFILL_FLOOR) or 0)
+    if floor <= 0:
+        return True
+    return int(pool_available) >= floor
+
+
+def background_llm_work_allowed(
+    scheduler: object,
+    presence: PresenceTracker,
+    *,
+    pool_available: int | None = None,
+    now_utc: datetime | None = None,
+) -> bool:
+    """Return whether daemon-owned background LLM / embedding work may run.
+
+    ``pool_available`` marks the caller as refill traffic (the servable pool
+    count) so peak-hour deferral can keep an emergency floor; ``None`` means
+    non-refill (maintenance / push) traffic. ``now_utc`` is injectable for
+    tests.
+    """
     if not bool(getattr(scheduler, "enabled", True)):
+        return False
+    if _peak_hour_deferral_active(
+        scheduler,
+        pool_available=pool_available,
+        now_utc=now_utc,
+    ):
         return False
     if not bool(getattr(scheduler, "pause_on_extension_disconnect", False)):
         return True
@@ -90,4 +190,8 @@ def background_llm_work_allowed(scheduler: object, presence: PresenceTracker) ->
     return presence.is_present(grace_seconds=grace)
 
 
-__all__ = ["PresenceTracker", "background_llm_work_allowed"]
+__all__ = [
+    "PresenceTracker",
+    "background_llm_work_allowed",
+    "parse_peak_windows",
+]

--- a/src/openbiliclaw/runtime/refresh.py
+++ b/src/openbiliclaw/runtime/refresh.py
@@ -493,6 +493,11 @@ class ContinuousRefreshController:
     _last_pool_maintenance_scan_at: datetime | None = field(default=None, init=False)
     _last_empty_plan_diag_at: datetime | None = field(default=None, init=False)
     _last_empty_plan_fingerprint: tuple[int] | None = field(default=None, init=False)
+    # Peak-hour deferral: cached servable-pool count so refill loops can pass
+    # ``pool_available`` to the LLM gate without re-reading the DB every tick.
+    # Invalidated after a short TTL; refresh loops re-read on demand.
+    _peak_pool_available: int = field(default=0, init=False)
+    _peak_pool_available_at: float = field(default=0.0, init=False)
     _suppressed_empty_plan_count: int = field(default=0, init=False)
     # Pool-share fairness (spec 2026-07-20, Phase 4): last per-family
     # (available, target, deficit) snapshot. The per-source deficit summary is
@@ -536,8 +541,13 @@ class ContinuousRefreshController:
         "feedback",
     ]
 
-    def _llm_work_allowed(self) -> bool:
-        """Return whether daemon-owned background LLM / embedding work can run."""
+    def _llm_work_allowed(self, *, pool_available: int | None = None) -> bool:
+        """Return whether daemon-owned background LLM / embedding work can run.
+
+        ``pool_available`` marks the caller as refill traffic and carries the
+        current servable-pool count, so peak-hour deferral can keep an
+        emergency floor. ``None`` means non-refill (maintenance / push).
+        """
         # Pause every background loop while a guided init is active (gui-init
         # D1) — the continuous refresh / soul-pipeline / producer ticks all gate
         # on this, so init's explicit analyze/build/backfill runs uncontended.
@@ -547,7 +557,11 @@ class ContinuousRefreshController:
                     return False
             except Exception:
                 pass
-        allowed = background_llm_work_allowed(self.scheduler_config, self.presence)
+        allowed = background_llm_work_allowed(
+            self.scheduler_config,
+            self.presence,
+            pool_available=pool_available,
+        )
         if allowed != self._last_llm_gate_allowed:
             logger.info(
                 "Background LLM work gate %s",
@@ -555,6 +569,27 @@ class ContinuousRefreshController:
             )
             self._last_llm_gate_allowed = allowed
         return allowed
+
+    def _peak_refill_pool_available(self) -> int:
+        """Return a cached servable-pool count for refill gate admission.
+
+        Only meaningful when peak-hour deferral is enabled; the short TTL
+        keeps the per-loop gate check free of a DB read on every tick.
+        """
+        import time as _time
+
+        now = _time.monotonic()
+        if self._peak_pool_available_at and now - self._peak_pool_available_at < 30:
+            return self._peak_pool_available
+        try:
+            counts = self._pool_readiness_counts()
+            available = int(counts.get("available", 0) or 0)
+        except Exception:
+            logger.debug("peak pool available read failed", exc_info=True)
+            available = 0
+        self._peak_pool_available = available
+        self._peak_pool_available_at = now
+        return available
 
     def _xhs_self_nickname(self) -> str:
         """Return the persisted XHS self nickname for pool guards."""
@@ -723,7 +758,7 @@ class ContinuousRefreshController:
         ``refresh_if_needed`` entry does, so callers reaching it from
         different paths can't double-acquire.
         """
-        if not self._llm_work_allowed():
+        if not self._llm_work_allowed(pool_available=self._peak_refill_pool_available()):
             return {"refreshed": False, "strategies": [], "reason": "llm_paused"}
 
         if self._refresh_lock.locked():
@@ -1463,7 +1498,7 @@ class ContinuousRefreshController:
         executed.
         """
 
-        if not self._llm_work_allowed():
+        if not self._llm_work_allowed(pool_available=self._peak_refill_pool_available()):
             return {
                 "refreshed": False,
                 "strategies": [],
@@ -1758,7 +1793,7 @@ class ContinuousRefreshController:
                     "Init grace period — skipping first refresh tick to let "
                     "Bilibili WBI bucket cool down (next tick will run normally)"
                 )
-            elif not self._llm_work_allowed():
+            elif not self._llm_work_allowed(pool_available=self._peak_refill_pool_available()):
                 await asyncio.sleep(self.check_interval_seconds)
                 continue
             else:
@@ -1786,7 +1821,7 @@ class ContinuousRefreshController:
         by ``_run_refresh_plan`` so no LLM token double-spend.
         """
         while True:
-            if not self._llm_work_allowed():
+            if not self._llm_work_allowed(pool_available=self._peak_refill_pool_available()):
                 await asyncio.sleep(self.check_interval_seconds)
                 continue
             with suppress(Exception):
@@ -1796,7 +1831,7 @@ class ContinuousRefreshController:
     async def _loop_candidate_eval(self) -> None:
         """Drain pending discovery-candidate raw rows independently of refresh plans."""
         while True:
-            if not self._llm_work_allowed():
+            if not self._llm_work_allowed(pool_available=self._peak_refill_pool_available()):
                 logger.debug("candidate eval drain skipped: reason=llm_paused")
                 await asyncio.sleep(self.check_interval_seconds)
                 continue
@@ -1904,7 +1939,7 @@ class ContinuousRefreshController:
         fallback ``topic_group=title[:N]`` (the ugly "屎屎/165/三花"
         debug we saw on 2026-05-05).
         """
-        if not self._llm_work_allowed():
+        if not self._llm_work_allowed(pool_available=self._peak_refill_pool_available()):
             return
         if self._profile_ready_observed:
             return
@@ -1933,6 +1968,7 @@ class ContinuousRefreshController:
     async def _loop_soul_pipeline(self) -> None:
         """Soul profile pipeline — buffer flushes, speculator, cognition."""
         while True:
+            # Maintenance traffic: peak-hour deferral fully blocks it.
             if not self._llm_work_allowed():
                 await asyncio.sleep(self.check_interval_seconds)
                 continue
@@ -1943,7 +1979,7 @@ class ContinuousRefreshController:
     async def _loop_xhs_producer(self) -> None:
         """XHS keyword production — Soul-driven search task generation."""
         while True:
-            if not self._llm_work_allowed():
+            if not self._llm_work_allowed(pool_available=self._peak_refill_pool_available()):
                 await asyncio.sleep(self.check_interval_seconds)
                 continue
             with suppress(Exception):
@@ -1953,7 +1989,7 @@ class ContinuousRefreshController:
     async def _loop_bilibili_producer(self) -> None:
         """Bilibili extension fallback — only enqueues while API search cools down."""
         while True:
-            if not self._llm_work_allowed():
+            if not self._llm_work_allowed(pool_available=self._peak_refill_pool_available()):
                 await asyncio.sleep(self.check_interval_seconds)
                 continue
             with suppress(Exception):
@@ -1963,7 +1999,7 @@ class ContinuousRefreshController:
     async def _loop_douyin_producer(self) -> None:
         """Douyin production — plugin/direct discovery when Douyin is below quota."""
         while True:
-            if not self._llm_work_allowed():
+            if not self._llm_work_allowed(pool_available=self._peak_refill_pool_available()):
                 await asyncio.sleep(self.check_interval_seconds)
                 continue
             with suppress(Exception):
@@ -1973,7 +2009,7 @@ class ContinuousRefreshController:
     async def _loop_youtube_producer(self) -> None:
         """YouTube production — backend-direct discovery when YouTube is below quota."""
         while True:
-            if not self._llm_work_allowed():
+            if not self._llm_work_allowed(pool_available=self._peak_refill_pool_available()):
                 await asyncio.sleep(self.check_interval_seconds)
                 continue
             with suppress(Exception):
@@ -1983,7 +2019,7 @@ class ContinuousRefreshController:
     async def _loop_x_producer(self) -> None:
         """X (Twitter) production — server-side cookie-replay discovery when under quota."""
         while True:
-            if not self._llm_work_allowed():
+            if not self._llm_work_allowed(pool_available=self._peak_refill_pool_available()):
                 await asyncio.sleep(self.check_interval_seconds)
                 continue
             with suppress(Exception):
@@ -1993,7 +2029,7 @@ class ContinuousRefreshController:
     async def _loop_zhihu_producer(self) -> None:
         """Zhihu production — plugin-backed discovery when under quota."""
         while True:
-            if not self._llm_work_allowed():
+            if not self._llm_work_allowed(pool_available=self._peak_refill_pool_available()):
                 await asyncio.sleep(self.check_interval_seconds)
                 continue
             with suppress(Exception):
@@ -2003,7 +2039,7 @@ class ContinuousRefreshController:
     async def _loop_reddit_producer(self) -> None:
         """Reddit production — command-backed discovery when under quota."""
         while True:
-            if not self._llm_work_allowed():
+            if not self._llm_work_allowed(pool_available=self._peak_refill_pool_available()):
                 await asyncio.sleep(self.check_interval_seconds)
                 continue
             with suppress(Exception):
@@ -2013,7 +2049,7 @@ class ContinuousRefreshController:
     async def _loop_bangumi_producer(self) -> None:
         """Bangumi production — official anonymous API discovery when under quota."""
         while True:
-            if not self._llm_work_allowed():
+            if not self._llm_work_allowed(pool_available=self._peak_refill_pool_available()):
                 await asyncio.sleep(self.check_interval_seconds)
                 continue
             with suppress(Exception):
@@ -2023,7 +2059,7 @@ class ContinuousRefreshController:
     async def _loop_linuxdo_producer(self) -> None:
         """Linux.do production — same-origin extension discovery when under quota."""
         while True:
-            if not self._llm_work_allowed():
+            if not self._llm_work_allowed(pool_available=self._peak_refill_pool_available()):
                 await asyncio.sleep(self.check_interval_seconds)
                 continue
             with suppress(Exception):
@@ -2033,7 +2069,7 @@ class ContinuousRefreshController:
     async def _loop_v2ex_producer(self) -> None:
         """V2EX production — anonymous/public discovery with optional PAT."""
         while True:
-            if not self._llm_work_allowed():
+            if not self._llm_work_allowed(pool_available=self._peak_refill_pool_available()):
                 await asyncio.sleep(self.check_interval_seconds)
                 continue
             with suppress(Exception):
@@ -2044,7 +2080,7 @@ class ContinuousRefreshController:
         """Run anonymous Weibo discovery when its source quota is underfilled."""
 
         while True:
-            if not self._llm_work_allowed():
+            if not self._llm_work_allowed(pool_available=self._peak_refill_pool_available()):
                 await asyncio.sleep(self.check_interval_seconds)
                 continue
             with suppress(Exception):
@@ -2070,7 +2106,7 @@ class ContinuousRefreshController:
             if not bool(getattr(planner, "enabled", False)):
                 await asyncio.sleep(poll_seconds)
                 continue
-            if not self._llm_work_allowed():
+            if not self._llm_work_allowed(pool_available=self._peak_refill_pool_available()):
                 await asyncio.sleep(poll_seconds)
                 continue
             with suppress(Exception):
@@ -2088,6 +2124,8 @@ class ContinuousRefreshController:
         contribute notification fatigue.
         """
         while True:
+            # Proactive pushes are maintenance traffic: peak-hour deferral
+            # fully blocks them (delight/probe scoring is not urgent).
             if not self._llm_work_allowed():
                 await asyncio.sleep(self.proactive_push_interval_seconds)
                 continue

--- a/tests/test_presence.py
+++ b/tests/test_presence.py
@@ -4,11 +4,33 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from datetime import datetime, timezone
 from types import SimpleNamespace
 
 import pytest
 
-from openbiliclaw.runtime.presence import PresenceTracker, background_llm_work_allowed
+from openbiliclaw.runtime.presence import (
+    PresenceTracker,
+    background_llm_work_allowed,
+    parse_peak_windows,
+)
+
+
+def _utc(hour: int, minute: int = 0) -> datetime:
+    """Build a UTC datetime whose Beijing wall time is hour:minute (UTC+8)."""
+    return datetime(2026, 1, 1, hour, minute, tzinfo=timezone.utc)
+
+
+def _scheduler(**overrides: object) -> SimpleNamespace:
+    base = {
+        "enabled": True,
+        "pause_on_extension_disconnect": False,
+        "pause_during_peak_hours": True,
+        "peak_hours": "09:00-12:00,14:00-18:00",
+        "peak_refill_floor": 30,
+    }
+    base.update(overrides)
+    return SimpleNamespace(**base)
 
 
 class FakeClock:
@@ -166,3 +188,237 @@ def test_background_llm_work_gate_defaults_invalid_grace_to_90_seconds() -> None
     clock.advance(2)
 
     assert background_llm_work_allowed(scheduler, tracker) is False
+
+
+# ── Peak-hour deferral (DeepSeek off-peak half-price) ──────────────────
+
+
+def test_parse_peak_windows_default_spec() -> None:
+    windows = parse_peak_windows("09:00-12:00,14:00-18:00")
+    assert windows == [(9 * 60, 12 * 60), (14 * 60, 18 * 60)]
+
+
+def test_parse_peak_windows_malformed_specs() -> None:
+    assert parse_peak_windows("") == []
+    assert parse_peak_windows("garbage") == []
+    assert parse_peak_windows("09:00-12:00,not-a-window") == [(9 * 60, 12 * 60)]
+    assert parse_peak_windows("25:00-26:00") == []
+    assert parse_peak_windows("12:00-09:00") == []  # start >= end rejected
+    assert parse_peak_windows("09:00-09:00") == []
+
+
+def test_peak_deferral_disabled_by_default() -> None:
+    """Opt-in only: without pause_during_peak_hours, nothing changes."""
+    clock = FakeClock()
+    tracker = PresenceTracker(now=clock)
+    scheduler = SimpleNamespace(
+        enabled=True,
+        pause_on_extension_disconnect=False,
+        pause_during_peak_hours=False,
+        peak_hours="09:00-12:00,14:00-18:00",
+        peak_refill_floor=30,
+    )
+    # Beijing 10:00 (inside the morning peak) — still allowed when opt-out.
+    assert (
+        background_llm_work_allowed(
+            scheduler, tracker, pool_available=100, now_utc=_utc(2)
+        )
+        is True
+    )
+
+
+def test_peak_deferral_blocks_non_refill_inside_peak() -> None:
+    """Maintenance traffic (pool_available=None) is fully blocked in peak."""
+    clock = FakeClock()
+    tracker = PresenceTracker(now=clock)
+    # Beijing 10:00 = UTC 02:00.
+    assert (
+        background_llm_work_allowed(
+            _scheduler(), tracker, now_utc=_utc(2)
+        )
+        is False
+    )
+    # Beijing 15:00 = UTC 07:00 (afternoon peak).
+    assert (
+        background_llm_work_allowed(
+            _scheduler(), tracker, now_utc=_utc(7)
+        )
+        is False
+    )
+
+
+def test_peak_deferral_allows_outside_peak() -> None:
+    """Non-peak windows (incl. the 12:00-14:00 lunch gap) run normally."""
+    clock = FakeClock()
+    tracker = PresenceTracker(now=clock)
+    # Beijing 08:59 = UTC 00:59.
+    assert (
+        background_llm_work_allowed(
+            _scheduler(), tracker, now_utc=_utc(0, 59)
+        )
+        is True
+    )
+    # Beijing 12:00 = UTC 04:00 — lunch gap, not peak.
+    assert (
+        background_llm_work_allowed(
+            _scheduler(), tracker, now_utc=_utc(4)
+        )
+        is True
+    )
+    # Beijing 18:00 = UTC 10:00 — evening, not peak.
+    assert (
+        background_llm_work_allowed(
+            _scheduler(), tracker, now_utc=_utc(10)
+        )
+        is True
+    )
+    # Beijing 23:00 = UTC 15:00 — night, not peak.
+    assert (
+        background_llm_work_allowed(
+            _scheduler(), tracker, now_utc=_utc(15)
+        )
+        is True
+    )
+
+
+def test_peak_deferral_boundary_minutes() -> None:
+    """Peak starts are inclusive, ends exclusive (09:00 in, 12:00 out)."""
+    clock = FakeClock()
+    tracker = PresenceTracker(now=clock)
+    # Beijing 09:00 = UTC 01:00 — start of morning peak.
+    assert (
+        background_llm_work_allowed(
+            _scheduler(), tracker, now_utc=_utc(1)
+        )
+        is False
+    )
+    # Beijing 08:59 = UTC 00:59 — just before.
+    assert (
+        background_llm_work_allowed(
+            _scheduler(), tracker, now_utc=_utc(0, 59)
+        )
+        is True
+    )
+    # Beijing 11:59 = UTC 03:59 — last minute of morning peak.
+    assert (
+        background_llm_work_allowed(
+            _scheduler(), tracker, now_utc=_utc(3, 59)
+        )
+        is False
+    )
+    # Beijing 12:00 = UTC 04:00 — exactly the end, no longer peak.
+    assert (
+        background_llm_work_allowed(
+            _scheduler(), tracker, now_utc=_utc(4)
+        )
+        is True
+    )
+
+
+def test_peak_deferral_refill_keeps_emergency_floor() -> None:
+    """Refill passes inside peak only when the pool is at/below the floor."""
+    clock = FakeClock()
+    tracker = PresenceTracker(now=clock)
+    peak_now = _utc(2)  # Beijing 10:00, inside morning peak.
+
+    # Pool above the floor → refill deferred.
+    assert (
+        background_llm_work_allowed(
+            _scheduler(), tracker, pool_available=100, now_utc=peak_now
+        )
+        is False
+    )
+    # Pool exactly at the floor → still deferred (defer while >= floor).
+    assert (
+        background_llm_work_allowed(
+            _scheduler(), tracker, pool_available=30, now_utc=peak_now
+        )
+        is False
+    )
+    # Pool below the floor → emergency refill allowed.
+    assert (
+        background_llm_work_allowed(
+            _scheduler(), tracker, pool_available=29, now_utc=peak_now
+        )
+        is True
+    )
+    # Pool empty → emergency refill allowed.
+    assert (
+        background_llm_work_allowed(
+            _scheduler(), tracker, pool_available=0, now_utc=peak_now
+        )
+        is True
+    )
+
+
+def test_peak_deferral_floor_zero_blocks_all_refill_in_peak() -> None:
+    """peak_refill_floor = 0 means peak fully blocks refill too."""
+    clock = FakeClock()
+    tracker = PresenceTracker(now=clock)
+    scheduler = _scheduler(peak_refill_floor=0)
+    peak_now = _utc(2)
+
+    assert (
+        background_llm_work_allowed(
+            scheduler, tracker, pool_available=0, now_utc=peak_now
+        )
+        is False
+    )
+    assert (
+        background_llm_work_allowed(
+            scheduler, tracker, pool_available=5, now_utc=peak_now
+        )
+        is False
+    )
+
+
+def test_peak_deferral_custom_windows() -> None:
+    """A custom peak spec is honoured exactly."""
+    clock = FakeClock()
+    tracker = PresenceTracker(now=clock)
+    scheduler = _scheduler(peak_hours="20:00-23:00")
+    # Beijing 22:00 = UTC 14:00 — inside custom peak.
+    assert (
+        background_llm_work_allowed(
+            scheduler, tracker, now_utc=_utc(14)
+        )
+        is False
+    )
+    # Beijing 19:59 = UTC 11:59 — outside custom peak.
+    assert (
+        background_llm_work_allowed(
+            scheduler, tracker, now_utc=_utc(11, 59)
+        )
+        is True
+    )
+
+
+def test_peak_deferral_ignores_presence_when_disconnect_policy_off() -> None:
+    """Outside peak, the original presence semantics are untouched."""
+    clock = FakeClock()
+    tracker = PresenceTracker(now=clock)
+    scheduler = _scheduler(pause_on_extension_disconnect=False)
+    clock.advance(999)
+
+    assert (
+        background_llm_work_allowed(
+            scheduler, tracker, now_utc=_utc(15)
+        )
+        is True
+    )
+
+
+def test_peak_deferral_composes_with_presence_gate() -> None:
+    """Inside peak, presence cannot override the deferral (blocked either way)."""
+    clock = FakeClock()
+    tracker = PresenceTracker(now=clock)
+    scheduler = _scheduler(pause_on_extension_disconnect=True)
+    tracker.on_connect()
+
+    # Even with an active client, peak still blocks non-refill traffic.
+    assert (
+        background_llm_work_allowed(
+            scheduler, tracker, now_utc=_utc(2)
+        )
+        is False
+    )


### PR DESCRIPTION
## 中文简介

给后台 LLM 调用加了**高峰时段错峰**功能（DeepSeek 官方高峰 9:00-12:00、14:00-18:00 北京时间，其余时段半价）。默认关闭，开启后：

- **补货类**（发现刷新、候选评估、池子预计算、各平台 producer、关键词规划）：高峰时段推迟，但池子跌破 `peak_refill_floor`（默认 30）时仍紧急补货，白天推荐流不断供；
- **维护类**（画像合并、猜测兴趣、主动推送、delight 评分）：高峰时段完全暂停；
- **交互类**（对话、sentiment、配置探测）：**永不错峰**，不受影响。

新增配置项：`scheduler.pause_during_peak_hours`（开关，默认 false）、`scheduler.peak_hours`（高峰窗口，默认 `"09:00-12:00,14:00-18:00"`，北京时间 UTC+8）、`scheduler.peak_refill_floor`（紧急补货水位，默认 30）。

兼容性：默认关闭、纯增量，老配置无需迁移。附 12 个新测试（窗口解析、边界、紧急补货豁免、自定义窗口、旧行为回归）。

---

## Summary

Add an opt-in peak-hour deferral for daemon-owned background LLM work so calls land in cheaper off-peak slots (DeepSeek bills off-peak at half price; official peak hours are Beijing time 09:00-12:00 and 14:00-18:00).

## New scheduler config

| Key | Default | Meaning |
|---|---|---|
| `scheduler.pause_during_peak_hours` | `false` | Opt-in master switch. When true, background LLM calls pause inside `peak_hours`. |
| `scheduler.peak_hours` | `"09:00-12:00,14:00-18:00"` | Peak window spec `"HH:MM-HH:MM,HH:MM-HH:MM"`, Beijing time (UTC+8, fixed offset — no tzdata dependency, safe in the slim runtime image). |
| `scheduler.peak_refill_floor` | `30` | Emergency floor: refill still runs inside a peak window when the servable pool is at/below this count, so the feed never starves. `0` = peak fully blocks refill too. |

## Behavior

- **Refill traffic** (discovery refresh, candidate eval, pool precompute, all platform producers, keyword planner) defers inside peak windows **except** when the servable pool drops to `peak_refill_floor` or below — an emergency top-up keeps the feed alive during peak hours.
- **Maintenance traffic** (profile consolidation, speculation, proactive pushes, delight scoring) is fully deferred inside peak windows.
- **Interactive traffic** (dialogue, sentiment, config probes) is **never** deferred — the existing `_INTERACTIVE_CALLERS` path is untouched.

## Implementation

- `runtime/presence.py`: `background_llm_work_allowed()` gains an optional `pool_available` arg plus Beijing-time peak-window parsing (`parse_peak_windows`). `None` = maintenance (fully blocked in peak); an int = refill with the emergency floor.
- `runtime/refresh.py`: refill loops pass the cached servable-pool count (`_peak_refill_pool_available`, 30s TTL); maintenance loops call the gate without it.
- Config load/render, `SchedulerConfigOut` API model, `config.example.toml`, and `docs/modules/runtime.md` updated.
- 12 new tests in `tests/test_presence.py` cover spec parsing, window boundaries (09:00 in / 12:00 out), emergency-floor bypass, `floor=0`, custom windows, and legacy behavior preservation.

## Compatibility

Fully opt-in (default `false`); legacy configs and scheduler objects without the new fields behave exactly as before. No migration needed.