### PR TITLE
docs: restore live star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -912,11 +912,13 @@ OpenBiliClaw 的目标是做你的**全网个性化内容入口**——从 B 站
 
 如果 OpenBiliClaw 帮你找回了对推荐流的控制权，[点个 Star](https://github.com/whiteguo233/OpenBiliClaw) 是对「继续适配更多平台」最直接的投票。
 
-<a href="https://github.com/whiteguo233/OpenBiliClaw">
-  <img alt="GitHub Stars" src="https://img.shields.io/github/stars/whiteguo233/OpenBiliClaw?style=flat-square&logo=github&label=Stars" />
+<a href="https://star-history.dera.page/#whiteguo233/OpenBiliClaw&type=date">
+ <picture>
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=whiteguo233/OpenBiliClaw&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=whiteguo233/OpenBiliClaw&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=whiteguo233/OpenBiliClaw&type=date&legend=top-left" />
+ </picture>
 </a>
-
-> ⚠️ 实时 Star 历史图表临时替换为 Star 徽章：GitHub 自 2026-06-30 起将 stargazers API 限制为仅仓库管理员/协作者可读，star-history 图表暂时无法渲染，待上游恢复或配置新的加密 token 后换回。
 
 ## 隐私速览
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -903,11 +903,13 @@ Contributions welcome! See the [Contributing Guide](docs/contributing.md) to get
 
 If OpenBiliClaw gave you back control of your feed, [a star](https://github.com/whiteguo233/OpenBiliClaw) is the most direct vote for "keep adding platforms".
 
-<a href="https://github.com/whiteguo233/OpenBiliClaw">
-  <img alt="GitHub Stars" src="https://img.shields.io/github/stars/whiteguo233/OpenBiliClaw?style=flat-square&logo=github&label=Stars" />
+<a href="https://star-history.dera.page/#whiteguo233/OpenBiliClaw&type=date">
+ <picture>
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=whiteguo233/OpenBiliClaw&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=whiteguo233/OpenBiliClaw&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=whiteguo233/OpenBiliClaw&type=date&legend=top-left" />
+ </picture>
 </a>
-
-> ⚠️ The live Star History chart is temporarily replaced by a star badge: since 2026-06-30 GitHub restricts the stargazers API to a repo's admins and collaborators, so star-history charts cannot render for now. We'll restore the live chart once upstream recovers or a new encrypted token is configured.
 
 ## Privacy at a glance
 


### PR DESCRIPTION
The README star history chart currently points to a dead endpoint and is not rendering, so it was previously swapped for a static badge with a temporary-replacement notice. This restores the live chart in both README.md and README_EN.md using a working data source, and removes the now-unneeded notice.

This fixes the broken star history visualization so visitors can see the project's growth again.