### PR TITLE
docs: add domestic installer download links

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@
 >
 > 📱 想要原生 App？Flutter 移动端客户端（Android / iOS / Web / 桌面）在独立仓库 [`OpenBiliClaw-mobile`](https://github.com/whiteguo233/OpenBiliClaw-mobile)：推荐、对话、画像、收藏 / 稍后再看 / 30 天历史一应俱全，连接同一本地后端。
 
+> 🇨🇳 **国内下载（当前 v0.3.208）**：超过 Gitee 100 MB 附件上限的 macOS / Windows 大安装包已放到 [123 云盘国内下载](https://4001474255.share.123pan.cn/123pan/IxbZMh-hhhR3)，分享永久有效并支持免登录下载；插件、小安装包和源码可从 [Gitee v0.3.208 发行版](https://gitee.com/whiteguo233/openbiliclaw/releases/tag/openbiliclaw-v0.3.208) 获取。
+
 ## 10 秒看懂 OpenBiliClaw
 
 一个纯本地、私有、开源的自进化跨平台内容发现 Agent：从你的跨平台使用、反馈和对话中持续深化心理画像，带着对你的理解主动去 B 站、小红书、抖音、YouTube、X、知乎、Reddit、Linux.do、Bangumi、V2EX、微博与开放 Web 找内容。
@@ -52,7 +54,7 @@
 普通用户只需四步；Firefox、Docker、脚本和手动部署等备用路径都在 [安装与部署详情](#安装与部署详情)。
 
 1. **装插件** —— [Chrome 应用商店一键安装](https://chromewebstore.google.com/detail/cdfjfkdjjhdaccbldipkjhpibnfbiamg)（自动更新），或从 [Latest Release](https://github.com/whiteguo233/OpenBiliClaw/releases/latest) 下载 zip 手动安装（最新功能先到，商店版可能滞后几天）。
-2. **装后端** —— 从同一个 [Latest Release](https://github.com/whiteguo233/OpenBiliClaw/releases/latest) 下载桌面安装包（macOS `.dmg` / Windows `.exe`，开箱即用、常驻菜单栏/托盘）。每个平台有两种安装包:**精简版**(默认,首启自动下载向量模型 bge-m3)与 **`-with-embedding` 完整版**(已内置 bge-m3 ~1.1GB,离线开箱即用)——网络差 / 想离线的选完整版,其余选精简版。想改源码或深度定制,就把下面这句话粘给 Claude Code / Codex CLI / Cursor 等 AI 编程助手：
+2. **装后端** —— 从同一个 [Latest Release](https://github.com/whiteguo233/OpenBiliClaw/releases/latest) 下载桌面安装包（macOS `.dmg` / Windows `.exe`，开箱即用、常驻菜单栏/托盘）。每个平台有两种安装包:**精简版**(默认,首启自动下载向量模型 bge-m3)与 **`-with-embedding` 完整版**(已内置 bge-m3 ~1.1GB,离线开箱即用)——网络差 / 想离线的选完整版,其余选精简版。**国内用户也可直接从 [123 云盘国内下载（v0.3.208）](https://4001474255.share.123pan.cn/123pan/IxbZMh-hhhR3) 获取 macOS / Windows 大包，免登录即可下载。** 想改源码或深度定制,就把下面这句话粘给 Claude Code / Codex CLI / Cursor 等 AI 编程助手：
 
    ```text
    请按照 https://raw.githubusercontent.com/whiteguo233/OpenBiliClaw/main/docs/agent-install.md 的说明帮我部署 OpenBiliClaw 后端(务必用 Bash 的 curl 下载这个文档,不要用 WebFetch — 会丢关键指令)
@@ -288,6 +290,8 @@ npm run package:firefox        # 额外打成未签名 openbiliclaw-extension-v*
 #### 方式 A：下载桌面安装包（实验性，最省事）
 
 到 [Latest Release](https://github.com/whiteguo233/OpenBiliClaw/releases/latest) 的 `openbiliclaw-v*` 聚合发布页下载对应系统的安装包。这个聚合页会同步展示：
+
+> 🇨🇳 国内网络下载大包时，可使用 [123 云盘国内下载（当前 v0.3.208）](https://4001474255.share.123pan.cn/123pan/IxbZMh-hhhR3)；分享永久有效、免登录，包含 macOS Apple silicon 普通版 / 内置 embedding 版和 Windows 内置 embedding 版。插件、普通 Windows 安装包与源码仍可从上面的 GitHub / [Gitee 发行版](https://gitee.com/whiteguo233/openbiliclaw/releases/tag/openbiliclaw-v0.3.208) 获取。
 
 - 当前后端源码 tag：`backend-v*`
 - 当前插件 release：`extension-v*`，并附 `openbiliclaw-extension-v*.zip` / `openbiliclaw-extension-v*-firefox.zip`（Firefox 临时调试）；启用 AMO signing 时还会附 `openbiliclaw-extension-v*-firefox.xpi`（Firefox 正式安装）

--- a/README_EN.md
+++ b/README_EN.md
@@ -22,6 +22,8 @@
 >
 > 📱 Want a native app? The Flutter mobile client (Android / iOS / Web / desktop) lives in the separate repo [`OpenBiliClaw-mobile`](https://github.com/whiteguo233/OpenBiliClaw-mobile): recommendations, chat, profile, favorites / watch-later / 30-day history — all talking to the same local backend.
 
+> 🇨🇳 **Mainland China downloads (current v0.3.208)**: the large macOS / Windows installers that exceed Gitee's 100 MB attachment limit are available from [123 Cloud domestic download](https://4001474255.share.123pan.cn/123pan/IxbZMh-hhhR3), with a permanent share that supports downloads without signing in; get the extension, smaller installers, and source from the [Gitee v0.3.208 release](https://gitee.com/whiteguo233/openbiliclaw/releases/tag/openbiliclaw-v0.3.208).
+
 ## OpenBiliClaw in 10 Seconds
 
 A local-first AI discovery agent that learns your taste across Bilibili, Xiaohongshu (RedNote), Douyin, YouTube, X, Zhihu, Reddit, Linux.do, Bangumi, V2EX, Weibo, and the open web — without handing your profile to another platform.
@@ -49,7 +51,7 @@ A local-first AI discovery agent that learns your taste across Bilibili, Xiaohon
 Four steps for most users. Firefox, Docker, scripted, and manual setup paths all live in [Setup Details](#setup-details).
 
 1. **Install the extension** — one-click from the [Chrome Web Store](https://chromewebstore.google.com/detail/cdfjfkdjjhdaccbldipkjhpibnfbiamg) (auto-updates), or download the zip from [Latest Release](https://github.com/whiteguo233/OpenBiliClaw/releases/latest) for the newest build (the store listing can lag a few days behind).
-2. **Install the backend** — grab the desktop installer from the same [Latest Release](https://github.com/whiteguo233/OpenBiliClaw/releases/latest) (macOS `.dmg` / Windows `.exe`, works out of the box, lives in the menu bar / tray). Each platform ships two variants: the **lean** installer (default; downloads the bge-m3 embedding model on first launch) and the **`-with-embedding`** installer (bge-m3 baked in, ~1.1GB, offline-ready) — pick with-embedding for a poor / offline network, lean otherwise. Or, to customize or edit the source, paste this into Claude Code / Codex CLI / Cursor or another AI coding agent:
+2. **Install the backend** — grab the desktop installer from the same [Latest Release](https://github.com/whiteguo233/OpenBiliClaw/releases/latest) (macOS `.dmg` / Windows `.exe`, works out of the box, lives in the menu bar / tray). Each platform ships two variants: the **lean** installer (default; downloads the bge-m3 embedding model on first launch) and the **`-with-embedding`** installer (bge-m3 baked in, ~1.1GB, offline-ready) — pick with-embedding for a poor / offline network, lean otherwise. **Mainland China users can also download the large macOS / Windows packages from [123 Cloud (v0.3.208)](https://4001474255.share.123pan.cn/123pan/IxbZMh-hhhR3) without signing in.** Or, to customize or edit the source, paste this into Claude Code / Codex CLI / Cursor or another AI coding agent:
 
    ```text
    Please follow https://raw.githubusercontent.com/whiteguo233/OpenBiliClaw/main/docs/agent-install.md to deploy the OpenBiliClaw backend for me (use Bash `curl` to fetch the document, NOT WebFetch — WebFetch summarises markdown and drops critical commands).
@@ -283,6 +285,8 @@ Most users: the **desktop installer** is the least effort. Want to edit the sour
 #### Option A: Download the desktop installer (experimental, easiest)
 
 Grab the installer for your OS from the `openbiliclaw-v*` aggregate [Latest Release](https://github.com/whiteguo233/OpenBiliClaw/releases/latest). The aggregate page shows:
+
+> 🇨🇳 For large-package downloads from mainland China, use [123 Cloud (current v0.3.208)](https://4001474255.share.123pan.cn/123pan/IxbZMh-hhhR3); the permanent share works without signing in and contains the regular Apple-silicon macOS build, the embedding-enabled Apple-silicon macOS build, and the embedding-enabled Windows build. The extension, regular Windows installer, and source remain available from GitHub / the [Gitee release](https://gitee.com/whiteguo233/openbiliclaw/releases/tag/openbiliclaw-v0.3.208).
 
 - Current backend source tag: `backend-v*`
 - Current extension release: `extension-v*`, with `openbiliclaw-extension-v*.zip` / `openbiliclaw-extension-v*-firefox.zip` (Firefox temporary debugging); AMO signing-enabled releases also include `openbiliclaw-extension-v*-firefox.xpi` (regular Firefox install)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -17,6 +17,7 @@
 
 - **修复 LLM 预算首次告警被系统运行时间误吞**：`_last_llm_budget_warned_at` 初值从 `0` 改为 `-inf`，避免在机器启动不足一个预算窗口时，第一次触发后台 LLM 预算暂停不输出 WARNING。
 - **发布状态**：后端 / 插件 / 桌面安装包 / Docker 镜像与聚合 Release 均已发布为 `v0.3.208`，详情见 [Release](https://github.com/whiteguo233/OpenBiliClaw/releases)。Chrome Web Store 已上传并提交 `0.3.208` 审核；Firefox AMO 已提交 listed `0.3.208`。聚合 Latest Release 已附扩展 ZIP / Safari DMG 与四份桌面安装器。
+- **国内下载入口**：README、GitHub Pages 首页、文档导航与 Gitee v0.3.208 发行说明均补充 123 云盘国内下载入口；当前分享永久有效并支持免登录下载超过 Gitee 100 MB 附件上限的 macOS / Windows 大安装包。
 - **来源周期回拉支持逐源开关（issue #180 相关）**：`[sources.<slug>]` 新增 `incremental_enabled`（默认 `false`），与 `[scheduler].source_incremental_enabled` 总开关组成“总开关 + 每来源开关”两级控制；插件 side panel 与桌面 Web 的「平台源」配置页为 XHS / 抖音 / YouTube / 知乎 / Reddit / Linux.do / V2EX 增加“允许扩展周期回拉”勾选项，调度页暴露总开关。后端只有两级开关都为 `true` 时才入队周期 bootstrap 任务；关闭某来源时其 scheduler-owned pending / stale in-progress 任务会被取消，避免再打开前台标签页。默认所有开关均为关闭，手动初始化、`fetch-*` 与后台 discovery 不受影响。
 - **后台 LLM 自设预算 + Embedding 熔断（issue #188）**：`[scheduler]` 新增 `llm_budget_max_calls`（默认 120 / 小时）与 `llm_budget_window_seconds`（默认 3600），daemon 通过共享 `LLMConcurrencyGate` 统计后台 LLM 请求，窗口内达到上限即暂停自动发现 / 补池 / 画像等循环并打一条 WARNING，避免无人值守时持续烧 DeepSeek 等付费额度；手动 CLI / API 请求不受影响，`0` 可关闭预算。`EmbeddingService` 新增连续失败熔断：默认连续 3 次异常或空向量后冷却 60 秒，冷却期内不再触碰不可达 embedding 端点、不再逐条打 full-traceback WARN，冷却后自动重探。
 - **修复 defer(暂缓) 后假设仍显示在待聊确认（issue #189）**：`/api/chat/pending-confirmations` 现在读取 `memory/dialogue_confirmation_state.json` 中的 `deferred_until`，冷却结束前已 defer 的假设不再出现在待聊列表；冷却到期后自动恢复。用户主动 open 仍按原契约绕过冷却，不会因列表过滤而误 404。

--- a/docs/index.html
+++ b/docs/index.html
@@ -1198,11 +1198,12 @@
           <p class="eyebrow" data-i18n="installEyebrow">Start</p>
           <h2 data-i18n="installTitle">从 Latest 聚合页下载，或把这句话交给 AI 编程助手。</h2>
           <p class="lead" data-i18n="installLead">
-            Latest Release 的 openbiliclaw-v* 聚合页只列出同一版本的后端源码、浏览器插件包和可用桌面安装包；某个 channel 尚未发布时会显示未发布，不会回填上一版资产。先装插件，再选择桌面安装包或让 Claude Code、Codex CLI、Cursor、Windsurf 等 AI 助手部署后端。
+            Latest Release 的 openbiliclaw-v* 聚合页只列出同一版本的后端源码、浏览器插件包和可用桌面安装包；某个 channel 尚未发布时会显示未发布，不会回填上一版资产。国内用户也可用上方 123 云盘入口免登录下载当前 v0.3.208 的大安装包。先装插件，再选择桌面安装包或让 Claude Code、Codex CLI、Cursor、Windsurf 等 AI 助手部署后端。
           </p>
           <div class="hero-actions">
             <a class="btn primary" href="https://chromewebstore.google.com/detail/cdfjfkdjjhdaccbldipkjhpibnfbiamg" data-i18n="installDownload">添加到 Chrome</a>
             <a class="btn" href="https://github.com/whiteguo233/OpenBiliClaw/releases/latest" data-i18n="installDesktop">打开 Latest 聚合页</a>
+            <a class="btn" href="https://4001474255.share.123pan.cn/123pan/IxbZMh-hhhR3" data-i18n="installDomestic">国内大包下载（123 云盘）</a>
             <a class="btn" href="https://github.com/whiteguo233/OpenBiliClaw/releases/latest" data-i18n="installManual">下载插件 zip</a>
             <a class="btn" href="https://github.com/whiteguo233/OpenBiliClaw#readme" data-i18n="installReadme">查看 README</a>
           </div>
@@ -1238,7 +1239,7 @@ docker compose -f docker-compose.prebuilt.yml up -d
           <div class="note">
             <h3 data-i18n="desktopNoteTitle">桌面安装包（最省事）</h3>
             <p data-i18n="desktopNoteText">
-              macOS Apple 芯片下载 OpenBiliClaw-macos-v*-arm64.dmg，Intel 下载 x64 包（如发布页提供）；DMG 内推荐双击「安装并启动 Install OpenBiliClaw.command」，它会校验新包、退出旧实例、原子替换并启动刚安装的版本。Windows 下载 OpenBiliClaw-windows-*-Setup.exe，安装或升级成功后同样会结束旧实例并自动启动新版本。可用安装包都附在 openbiliclaw-v* 聚合 Latest Release 里。当前为 ad-hoc signed、未公证的实验性预发布：Mac 首次打开安装助手或应用时请右键 / Control-click → 打开，或到系统设置 → 隐私与安全性点仍要打开；若提示“已损坏”，确认来源后执行 xattr -dr com.apple.quarantine /Applications/OpenBiliClaw.app。
+              macOS Apple 芯片下载 OpenBiliClaw-macos-v*-arm64.dmg，Intel 下载 x64 包（如发布页提供）；DMG 内推荐双击「安装并启动 Install OpenBiliClaw.command」，它会校验新包、退出旧实例、原子替换并启动刚安装的版本。Windows 下载 OpenBiliClaw-windows-*-Setup.exe，安装或升级成功后同样会结束旧实例并自动启动新版本。可用安装包都附在 openbiliclaw-v* 聚合 Latest Release 里；当前 v0.3.208 的 macOS / Windows 大包也可通过上方 123 云盘按钮免登录下载。当前为 ad-hoc signed、未公证的实验性预发布：Mac 首次打开安装助手或应用时请右键 / Control-click → 打开，或到系统设置 → 隐私与安全性点仍要打开；若提示“已损坏”，确认来源后执行 xattr -dr com.apple.quarantine /Applications/OpenBiliClaw.app。
             </p>
           </div>
 
@@ -1590,9 +1591,10 @@ docker compose -f docker-compose.prebuilt.yml up -d
         nextHint: "Install prompt below",
         installEyebrow: "Start",
         installTitle: "从 Latest 聚合页下载，或把这句话交给 AI 编程助手。",
-        installLead: "Latest Release 的 openbiliclaw-v* 聚合页只列出同一版本的后端源码、浏览器插件包和可用桌面安装包；某个 channel 尚未发布时会显示未发布，不会回填上一版资产。先装插件，再选择桌面安装包或让 Claude Code、Codex CLI、Cursor、Windsurf 等 AI 助手部署后端。",
+        installLead: "Latest Release 的 openbiliclaw-v* 聚合页只列出同一版本的后端源码、浏览器插件包和可用桌面安装包；某个 channel 尚未发布时会显示未发布，不会回填上一版资产。国内用户也可用上方 123 云盘入口免登录下载当前 v0.3.208 的大安装包。先装插件，再选择桌面安装包或让 Claude Code、Codex CLI、Cursor、Windsurf 等 AI 助手部署后端。",
         installDownload: "添加到 Chrome",
         installDesktop: "打开 Latest 聚合页",
+        installDomestic: "国内大包下载（123 云盘）",
         installManual: "下载插件 zip",
         installReadme: "查看 README",
         agentPromptLabel: "一句话安装提示",
@@ -1604,7 +1606,7 @@ docker compose -f docker-compose.prebuilt.yml up -d
         copySuccess: "已复制",
         copyFallback: "手动复制",
         desktopNoteTitle: "桌面安装包（最省事）",
-        desktopNoteText: "macOS Apple 芯片下载 OpenBiliClaw-macos-v*-arm64.dmg，Intel 下载 x64 包（如发布页提供）；DMG 内推荐双击「安装并启动 Install OpenBiliClaw.command」，它会校验新包、退出旧实例、原子替换并启动刚安装的版本。Windows 下载 OpenBiliClaw-windows-*-Setup.exe，安装或升级成功后同样会结束旧实例并自动启动新版本。可用安装包都附在 openbiliclaw-v* 聚合 Latest Release 里。当前为 ad-hoc signed、未公证的实验性预发布：Mac 首次打开安装助手或应用时请右键 / Control-click → 打开，或到系统设置 → 隐私与安全性点仍要打开；若提示“已损坏”，确认来源后执行 xattr -dr com.apple.quarantine /Applications/OpenBiliClaw.app。",
+        desktopNoteText: "macOS Apple 芯片下载 OpenBiliClaw-macos-v*-arm64.dmg，Intel 下载 x64 包（如发布页提供）；DMG 内推荐双击「安装并启动 Install OpenBiliClaw.command」，它会校验新包、退出旧实例、原子替换并启动刚安装的版本。Windows 下载 OpenBiliClaw-windows-*-Setup.exe，安装或升级成功后同样会结束旧实例并自动启动新版本。可用安装包都附在 openbiliclaw-v* 聚合 Latest Release 里；当前 v0.3.208 的 macOS / Windows 大包也可通过上方 123 云盘按钮免登录下载。当前为 ad-hoc signed、未公证的实验性预发布：Mac 首次打开安装助手或应用时请右键 / Control-click → 打开，或到系统设置 → 隐私与安全性点仍要打开；若提示“已损坏”，确认来源后执行 xattr -dr com.apple.quarantine /Applications/OpenBiliClaw.app。",
         pluginNoteTitle: "浏览器插件负责连接平台",
         pluginNoteText: "浏览器插件既是推荐、反馈和聊天入口，也是平台登录态与行为信号的连接层，并为 Linux.do / V2EX / 微博等来源执行有界只读任务；微博公开 discovery 由后端完成，个人初始化才打开微博同源任务页，Cookie 不回传。最新版可从 GitHub Latest Release 下载同版本 Chrome / Firefox 包，或使用审核通过后自动更新的插件市场版本。",
         mobileInstallNoteTitle: "手机桌面快捷入口",
@@ -1751,9 +1753,10 @@ docker compose -f docker-compose.prebuilt.yml up -d
         nextHint: "Install prompt below",
         installEyebrow: "Start",
         installTitle: "Use the aggregate Latest Release, or hand this prompt to an AI coding agent.",
-        installLead: "The openbiliclaw-v* aggregate Latest Release only lists same-version backend source, browser extension packages, and available desktop installers; when a channel has not shipped yet, it is shown as unpublished instead of being backfilled from a previous release. Install the extension first, then use the desktop installer or let Claude Code, Codex CLI, Cursor, or Windsurf deploy the backend.",
+        installLead: "The openbiliclaw-v* aggregate Latest Release only lists same-version backend source, browser extension packages, and available desktop installers; when a channel has not shipped yet, it is shown as unpublished instead of being backfilled from a previous release. Mainland China users can also use the 123 Cloud button above to download the current v0.3.208 large installers without signing in. Install the extension first, then use the desktop installer or let Claude Code, Codex CLI, Cursor, or Windsurf deploy the backend.",
         installDownload: "Add to Chrome",
         installDesktop: "Open Latest Release",
+        installDomestic: "Domestic large installers (123 Cloud)",
         installManual: "Download extension zip",
         installReadme: "View README",
         agentPromptLabel: "One-line install prompt",
@@ -1765,7 +1768,7 @@ docker compose -f docker-compose.prebuilt.yml up -d
         copySuccess: "Copied",
         copyFallback: "Copy manually",
         desktopNoteTitle: "Desktop installer (easiest)",
-        desktopNoteText: "For macOS, Apple silicon uses OpenBiliClaw-macos-v*-arm64.dmg and Intel uses the x64 package when available. In the DMG, double-click 安装并启动 Install OpenBiliClaw.command to verify the new bundle, quit the old instance, atomically replace the app, and launch the installed version. Windows uses OpenBiliClaw-windows-*-Setup.exe and performs the same old-to-new process handoff after a successful install or upgrade. Installers are attached to the openbiliclaw-v* aggregate Latest Release. The Mac build is ad-hoc signed but not notarized: Control-click the helper or app -> Open on first launch, or allow it in System Settings -> Privacy & Security. If macOS says the app is damaged, verify the release source and run xattr -dr com.apple.quarantine /Applications/OpenBiliClaw.app.",
+        desktopNoteText: "For macOS, Apple silicon uses OpenBiliClaw-macos-v*-arm64.dmg and Intel uses the x64 package when available. In the DMG, double-click 安装并启动 Install OpenBiliClaw.command to verify the new bundle, quit the old instance, atomically replace the app, and launch the installed version. Windows uses OpenBiliClaw-windows-*-Setup.exe and performs the same old-to-new process handoff after a successful install or upgrade. Installers are attached to the openbiliclaw-v* aggregate Latest Release; the current v0.3.208 large macOS / Windows packages are also available through the 123 Cloud button above without signing in. The Mac build is ad-hoc signed but not notarized: Control-click the helper or app -> Open on first launch, or allow it in System Settings -> Privacy & Security. If macOS says the app is damaged, verify the release source and run xattr -dr com.apple.quarantine /Applications/OpenBiliClaw.app.",
         pluginNoteTitle: "The browser extension connects platforms",
         pluginNoteText: "The browser extension is both a recommendation, feedback, and chat surface and the connection layer for platform sessions and behavior signals. It also runs bounded read-only tasks for sources including Linux.do, V2EX, and Weibo. Weibo public discovery stays backend-owned; personal init uses a same-origin task tab and never sends cookies to the backend. Download matching Chrome / Firefox packages from the GitHub Latest Release or use the marketplace build after review approval.",
         mobileInstallNoteTitle: "Phone home-screen shortcut",

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,6 +9,7 @@
 - [Flutter 移动客户端](https://github.com/whiteguo233/OpenBiliClaw-mobile) — 独立仓库的原生 App（Android / iOS / Web / 桌面），[Latest Release](https://github.com/whiteguo233/OpenBiliClaw-mobile/releases/latest) 提供 Android 签名 APK 与 iOS 自签名 IPA，连接同一本地后端
 - [常见问题 FAQ](faq.md) — macOS 安全阻挡、插件连不上后端、embedding 配置、跨机器迁移、手机访问等高频问题
 - [GitHub Releases](https://github.com/whiteguo233/OpenBiliClaw/releases/latest) — Latest Release 的 `openbiliclaw-v*` 聚合页，下载浏览器插件 zip / Safari dmg 和桌面安装包；维护者通道仍保留 `extension-v*` / `desktop-v*` / `backend-v*`
+- [国内大包下载（123 云盘）](https://4001474255.share.123pan.cn/123pan/IxbZMh-hhhR3) — 当前 v0.3.208 的 macOS / Windows 大安装包，分享永久有效并支持免登录下载；[Gitee v0.3.208 发行版](https://gitee.com/whiteguo233/openbiliclaw/releases/tag/openbiliclaw-v0.3.208) 提供国内镜像附件与源码入口
 - [隐私权政策](privacy.md) — 插件数据收集披露、本地优先数据流与明文迁移包说明
 - [变更日志](changelog.md) — 各版本交付记录
 - [Docker 部署指南](docker-deployment.md) — 手动 Docker / docker compose 部署步骤


### PR DESCRIPTION
## Summary
- document the verified 123 Cloud mainland download entry for v0.3.208 large installers
- update Chinese and English README, GitHub Pages homepage, docs navigation, and changelog

## Verification
- git diff --check
- verified the 123 Cloud share is permanent and supports unauthenticated downloads
