### PR TITLE
fix(tests): realign doc-consistency tests with architecture overview docs and stub llm_concurrency

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,8 @@
 
 ## 未发布
 
+- **修复 main 分支 CI 自 8 月 20 日起持续红灯的测试问题**：架构总览图迁出 README（80eb6d92）后，文档一致性测试同步改为读取 `docs/architecture-overview(.en).md`；`test_mobile_web_view_models` 修复一处 E501 超长行；`soul_engine` / `web_guided_init` 的测试桩补齐 d8f63745 新增的 `llm_concurrency` 参数。纯测试改动，无运行时行为变化。
+
 - **修复普通视频点击被误记为点踩（issue #205，含真实浏览器 A/B 验证）**：#200 的长度守卫只保护了 textContent，`aria-label`/`title` 路径仍会把标题含“不喜欢/不感兴趣”的普通卡片点击记成 `feedback(dislike)`——真实 bilibili.com 搜索页 A/B 实测：修复前构建点 3 张真实卡片产生 3 条误报，修复后 0 条。中文平台适配器（bilibili/douyin/zhihu）统一改为「≤8 字符短标签 + className token 匹配」（真实控件标签最长 6 字）；英文平台把动词锚定到真实控件——YouTube 控件 aria-label 动词开头（"Like this video…"/“不喜欢此视频”），结果卡片是「标题 by 作者」句式，故 aria 用动词前缀匹配、卡片文案封顶 12 字符；Reddit 投票只认 aria/class 锚定的 downvote/upvote。真实 YouTube A/B：修复前点 3 张标题含 "dislike" 的结果卡片产生 3 条误报（词边界版仍有 13/48 卡片命中，已改锚定后归零），修复后 0 条且 watch 页真实 dislike 控件正向采集正常。kernel 对 DOM 点踩新增按控件的奇偶点击追踪：第二次点击识别为取消（记 `retraction` 而非新 dislike），10 分钟无操作重置计数。awareness 双 system prompt 新增「负反馈一致性」规则：笔记声称点踩时必须引用真实的负反馈事件。`docs/modules/extension.md` 与 `docs/modules/llm.md` 已同步。
 - **修复移动 Web 加载更多推荐时的卡顿感**：`handleAppend()` 不再在插入新卡片前 `await` 整批封面预解码（原来后端返回后还要等最多 3 秒），而是先插入卡片、再后台预热前 4 张封面，其余封面保持 `loading="lazy"` 并交给滚动预热 observer 在接近视口时补拉；`renderCard()` 改为只对列表前 4 张卡使用 eager 封面，避免一次 append 10 张卡同时抢图片代理与解码资源。`appendRecommendations()` 补上 `DEFAULT_READ_TIMEOUT_MS` 请求超时；加载更多失败不再把 `autoAppendExhausted` 永久置为 true，而是在 header 显示「加载更多失败，请稍后重试」并允许下次滚动/点击重试。
 - **新增 Serply 作为 query inspiration 搜索后端**：`[discovery]` 新增 `serply_api_key`，填写后 `SerplyInspirationProvider` 直连 [serply.io](https://serply.io) 的 `GET /v1/search`；`inspiration_search_backends` 默认追加 `serply`，留空 Key 时该后端直接跳过，不影响现有 Exa / You.com / mcporter 链路。

--- a/tests/test_docs_saved_sync.py
+++ b/tests/test_docs_saved_sync.py
@@ -8,8 +8,8 @@ def test_saved_sync_docs_name_default_and_routes() -> None:
     storage_doc = Path("docs/modules/storage.md").read_text()
     architecture_doc = Path("docs/architecture.md").read_text()
     spec_doc = Path("docs/spec.md").read_text()
-    readme = Path("README.md").read_text()
-    readme_en = Path("README_EN.md").read_text()
+    readme = Path("docs/architecture-overview.md").read_text()
+    readme_en = Path("docs/architecture-overview.en.md").read_text()
     docs_index = Path("docs/index.md").read_text()
     e2e_doc = Path("docs/native-save-e2e.md").read_text()
     changelog = Path("docs/changelog.md").read_text()
@@ -72,8 +72,8 @@ def test_saved_sync_docs_register_extension_adapters_and_completed_executors() -
     module = Path("docs/modules/saved-sync.md").read_text(encoding="utf-8")
     storage = Path("docs/modules/storage.md").read_text(encoding="utf-8")
     changelog = Path("docs/changelog.md").read_text(encoding="utf-8")
-    readme = Path("README.md").read_text(encoding="utf-8")
-    readme_en = Path("README_EN.md").read_text(encoding="utf-8")
+    readme = Path("docs/architecture-overview.md").read_text(encoding="utf-8")
+    readme_en = Path("docs/architecture-overview.en.md").read_text(encoding="utf-8")
 
     for text in (architecture, spec, module, changelog, readme, readme_en):
         assert "unsupported_adapter_missing" in text
@@ -99,8 +99,8 @@ def test_saved_sync_docs_explain_truthful_graphical_state_interpretation() -> No
     architecture = Path("docs/architecture.md").read_text(encoding="utf-8")
     spec = Path("docs/spec.md").read_text(encoding="utf-8")
     changelog = Path("docs/changelog.md").read_text(encoding="utf-8")
-    readme = Path("README.md").read_text(encoding="utf-8")
-    readme_en = Path("README_EN.md").read_text(encoding="utf-8")
+    readme = Path("docs/architecture-overview.md").read_text(encoding="utf-8")
+    readme_en = Path("docs/architecture-overview.en.md").read_text(encoding="utf-8")
 
     for text in (saved_sync, extension, architecture, spec, readme, readme_en):
         assert "unsupported_content_type" in text
@@ -120,8 +120,8 @@ def test_six_platform_native_save_docs_define_safe_e2e_contract() -> None:
     integration = Path("docs/platform-source-integration.md").read_text(encoding="utf-8")
     architecture = Path("docs/architecture.md").read_text(encoding="utf-8")
     spec = Path("docs/spec.md").read_text(encoding="utf-8")
-    readme = Path("README.md").read_text(encoding="utf-8")
-    readme_en = Path("README_EN.md").read_text(encoding="utf-8")
+    readme = Path("docs/architecture-overview.md").read_text(encoding="utf-8")
+    readme_en = Path("docs/architecture-overview.en.md").read_text(encoding="utf-8")
     changelog = Path("docs/changelog.md").read_text(encoding="utf-8")
     docs_index = Path("docs/index.md").read_text(encoding="utf-8")
     runbook = Path("docs/testing/six-platform-native-save-e2e.md").read_text(encoding="utf-8")

--- a/tests/test_docs_source_incremental_sync.py
+++ b/tests/test_docs_source_incremental_sync.py
@@ -51,8 +51,8 @@ def test_source_incremental_docs_cover_configuration_and_six_source_staging() ->
 def test_source_incremental_docs_state_online_and_atomic_admission_boundaries() -> None:
     architecture = _read("docs/architecture.md")
     extension_docs = _read("docs/modules/extension.md")
-    readme = _read("README.md")
-    readme_en = _read("README_EN.md")
+    readme = _read("docs/architecture-overview.md")
+    readme_en = _read("docs/architecture-overview.en.md")
 
     assert "BEGIN IMMEDIATE" in architecture
     assert "XHS→抖音→YouTube→知乎→Reddit→Linux.do" in architecture
@@ -61,6 +61,6 @@ def test_source_incremental_docs_state_online_and_atomic_admission_boundaries() 
     assert "source_incremental_enabled=false" in extension_docs
     assert "douyin_incremental_hours=0" in extension_docs
     assert "扩展在线周期回拉" in readme
-    assert "账号周期回拉默认关闭" in readme
+    assert "账号周期回拉默认关闭" in _read("README.md")
     assert "extension-online periodic re-pull" in readme_en.lower()
-    assert "periodic account re-pull is off by default" in readme_en.lower()
+    assert "periodic re-pull (off by default" in readme_en.lower()

--- a/tests/test_extension_native_save_api.py
+++ b/tests/test_extension_native_save_api.py
@@ -444,8 +444,8 @@ def test_native_save_source_api_is_documented() -> None:
         "docs/modules/api-auth.md": "seven state-changing GET `/next-task`",
         "docs/architecture.md": "/api/sources/{xhs,dy,yt,x,zhihu,reddit}",
         "docs/spec.md": "native_save multiplex",
-        "README.md": "七源 source task multiplex",
-        "README_EN.md": "seven-source task multiplex",
+        "docs/architecture-overview.md": "七源 source task multiplex",
+        "docs/architecture-overview.en.md": "seven-source task multiplex",
         "docs/changelog.md": "source task multiplex",
     }
     for path, marker in required.items():

--- a/tests/test_mobile_web_view_models.py
+++ b/tests/test_mobile_web_view_models.py
@@ -700,7 +700,10 @@ class TestMobileWebViewModels:
         assert "waitForDecode" in recommend_js
         assert "CARD_EAGER_COVER_COUNT" in recommend_js
         assert "eagerCount: CARD_EAGER_COVER_COUNT" in recommend_js
-        assert "void warmRecommendationCovers(newItems, { limit: CARD_EAGER_COVER_COUNT });" in recommend_js
+        assert (
+            "void warmRecommendationCovers(newItems, { limit: CARD_EAGER_COVER_COUNT });"
+            in recommend_js
+        )
         assert 'loading="${esc(imageAttrs.loading)}"' in recommend_js
         assert 'fetchpriority="${esc(imageAttrs.fetchPriority)}"' in recommend_js
         assert "AUTO_APPEND_ROOT_MARGIN" in recommend_js

--- a/tests/test_soul_engine.py
+++ b/tests/test_soul_engine.py
@@ -411,8 +411,9 @@ async def test_init_cognition_context_leaves_preference_and_feeds_profile_build(
         existing_preference: dict[str, object],
         event_chunk_size: int = 0,
         progress_callback: object | None = None,
+        llm_concurrency: int | None = None,
     ) -> dict[str, object]:
-        del events, existing_preference, event_chunk_size, progress_callback
+        del events, existing_preference, event_chunk_size, progress_callback, llm_concurrency
         return {
             "interests": [{"name": "AI 工具链", "category": "科技", "weight": 0.81}],
             "style": {},

--- a/tests/test_web_guided_init.py
+++ b/tests/test_web_guided_init.py
@@ -662,7 +662,9 @@ class _StubEngine:
         self.profile = object()
         self.discover_profiles: list[object] = []
 
-    async def analyze_events(self, events, *, event_chunk_size=0, progress_callback=None):
+    async def analyze_events(
+        self, events, *, event_chunk_size=0, progress_callback=None, llm_concurrency=None
+    ):
         self.received_callback = progress_callback
         if progress_callback is not None:
             for i in range(1, self.chunk_reports + 1):
@@ -884,7 +886,9 @@ async def test_run_guided_init_bounds_hung_preference_analysis(monkeypatch) -> N
             super().__init__()
             self.cancelled = False
 
-        async def analyze_events(self, events, *, event_chunk_size=0, progress_callback=None):
+        async def analyze_events(
+            self, events, *, event_chunk_size=0, progress_callback=None, llm_concurrency=None
+        ):
             try:
                 await asyncio.Event().wait()
             finally:
@@ -1259,7 +1263,9 @@ async def test_run_guided_init_idle_analysis_reports_connectivity_message(monkey
             super().__init__()
             self.cancelled = False
 
-        async def analyze_events(self, events, *, event_chunk_size=0, progress_callback=None):
+        async def analyze_events(
+            self, events, *, event_chunk_size=0, progress_callback=None, llm_concurrency=None
+        ):
             try:
                 await asyncio.Event().wait()
             finally:
@@ -1301,7 +1307,9 @@ async def test_run_guided_init_slow_analysis_completes_past_old_fixed_budget(mon
     ticks = {"n": 0}
 
     class _SlowProgressingEngine(_StubEngine):
-        async def analyze_events(self, events, *, event_chunk_size=0, progress_callback=None):
+        async def analyze_events(
+            self, events, *, event_chunk_size=0, progress_callback=None, llm_concurrency=None
+        ):
             self.received_callback = progress_callback
             for i in range(1, 7):
                 # Each chunk takes longer than the whole old floor budget would


### PR DESCRIPTION
## 变更摘要

修复 main 自 80eb6d92（架构总览图迁出 README，8 月 20 日）起 CI 持续红灯的测试问题：

1. **文档一致性测试（6 个失败）**：`test_docs_saved_sync` / `test_docs_source_incremental_sync` / `test_extension_native_save_api` 原断言架构图 token 存在于 README.md / README_EN.md；80eb6d92 把总览图迁到 `docs/architecture-overview(.en).md` 后这些断言全部落空。改为读取新位置（README 中仍存在的 `账号周期回拉默认关闭` 断言保留在 README）。
2. **Ruff E501（阻塞 Ruff 门禁）**：`test_mobile_web_view_models.py:703` 一行 assert 超长，换行重排。
3. **测试桩签名（9 个失败）**：d8f63745 给 `analyze_events` 新增 `llm_concurrency` 形参，`test_soul_engine` 的 fake 与 `test_web_guided_init` 的 4 处 stub 未同步，补齐默认值。

纯测试改动，无运行时行为变化。

## 测试命令与结果

模拟 CI 全新安装（uv venv + `pip install -e ".[dev,x]"`）：

```
pytest tests/test_docs_saved_sync.py tests/test_docs_source_incremental_sync.py \
  tests/test_extension_native_save_api.py tests/test_soul_engine.py \
  tests/test_web_guided_init.py tests/test_mobile_web_view_models.py
→ 280 passed（pin/修前：docs 6 failed + guided_init 8 failed + soul_engine 1 failed）
ruff check src/ tests/
→ All checks passed!
```

## 关联

- 发版前置修复（main CI 红灯，自 80eb6d92 起连续失败）
- 依赖侧的 httpx2 问题由 #207 单独处理