### PR TITLE
fix(tests): make weibo changelog boundary check survive release commits

### DIFF
--- a/tests/test_web_weibo_surfaces.py
+++ b/tests/test_web_weibo_surfaces.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import re
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -80,7 +81,11 @@ def test_weibo_current_docs_store_metadata_and_release_boundary_are_in_sync() ->
     assert "微博" in docker
     assert "微博" in listing
     assert "七平台内容发现 AI Agent" not in listing
-    assert changelog.index("## 未发布") < changelog.index("## v0.3.201")
+    # The newest version section must sit above the v0.3.201 boundary; do not
+    # anchor on "## 未发布" so the check survives release commits.
+    newest_version_heading = re.search(r"(?m)^## v\d+\.\d+\.\d+", changelog)
+    assert newest_version_heading is not None
+    assert newest_version_heading.start() < changelog.index("## v0.3.201")
     assert "微博" in changelog.split("## v0.3.201", 1)[0]
     assert "Weibo" in amo["description"]["en-US"]
     assert "微博" in amo["description"]["zh-CN"]


### PR DESCRIPTION
## 变更摘要

`test_weibo_current_docs_store_metadata_and_release_boundary_are_in_sync` 用 `## 未发布` 标题做锚点断言 changelog 顺序；发版 commit（`chore: release 0.3.209`）把该标题改名为版本号后，main CI 的 pytest 立即失败（ValueError: substring not found）。改为动态取最新的 `## vX.Y.Z` 标题做顺序断言，微博覆盖断言保持不变，后续发版不再需要同步改测试。

## 测试命令与结果

```
pytest tests/test_web_weibo_surfaces.py tests/test_docs_saved_sync.py
→ 9 passed
ruff check tests/test_web_weibo_surfaces.py → All checks passed!
```

## 关联

- 发版 v0.3.209 期间发现的最后一颗发版耦合测试地雷