### PR TITLE
feat: 商汤日日新（SenseNova）免费额度 preset，零成本体验本项目（close #193）

### DIFF
--- a/docs/agent-install.md
+++ b/docs/agent-install.md
@@ -305,7 +305,7 @@ user chooses an OpenAI-compatible gateway / preset path.
 | 选项 | 默认模型 | 适合谁 | 是否需要 API Key | 钱 / 速度 |
 |---|---|---|---|---|
 | 1. **DeepSeek** ★第一推荐(极便宜 / 国内可直连) | `deepseek-v4-flash`(可选 `deepseek-v4-pro`;旧 `deepseek-chat`/`deepseek-reasoner` **2026/07/24 弃用**) | 想几毛钱体验完整功能 | ✅ 需要 | ¥0.001 / 千 token,几乎免费 |
-| 2. **★ 中转站 / OpenAI 协议兼容服务** ★第二推荐 | 选 preset 后自动填 | **国内买中转站 / OneAPI Key 的人走这个**;也覆盖 Kimi / MiniMax / 通义 / 智谱 / Yi 官方 + Azure / vLLM / LMStudio | 看服务 | 看服务 |
+| 2. **★ 中转站 / OpenAI 协议兼容服务** ★第二推荐 | 选 preset 后自动填 | **国内买中转站 / OneAPI Key 的人走这个**;也覆盖 Kimi / MiniMax / 通义 / 智谱 / 商汤日日新 / Yi 官方 + Azure / vLLM / LMStudio | 看服务 | 看服务(日日新 / 智谱 GLM-4.7-Flash 有免费额度) |
 | 3. **OpenAI 官方** | `gpt-5-nano`(最便宜的 GPT-5;可选 gpt-5.4-nano / -mini / gpt-5.5 旗舰) | 已有 sk- 开头 Key | ✅ 需要 | $0.05/M(nano) ~ $30/M(5.5-pro) |
 | 4. **Gemini 官方** | `gemini-2.5-flash`(稳定;可选 gemini-3-flash-preview / gemini-3.1-pro-preview 旗舰 Public Preview 需付费项目) | Google AI Studio 申请 Key | ✅ 需要 | 免费档每天 1500 次 |
 | 5. **Claude 官方** | `claude-sonnet-4-6`(1M ctx;可选 claude-haiku-4-5 便宜 / claude-opus-4-7 旗舰) | Anthropic console | ✅ 需要 | $3-$75/M,按 token,质量高 |
@@ -321,7 +321,7 @@ user chooses an OpenAI-compatible gateway / preset path.
 
 **AI agent 决策建议**: **默认引导 #1 DeepSeek**(几毛钱搞定);用户明确说"我有中转站 Key / OneAPI / 通义 / 智谱 / Kimi / MiniMax / Yi / Azure / vLLM 等任何 OpenAI 兼容服务"→ 引导 #2(进子菜单后再细分);用户明确说"用 OpenAI / Gemini / Claude 官方"才走 #3-5;用户提到"OrcaRouter / 一个 Key 跑多家模型 + 安全网关"→ 引导 #7;Ollama 仅在用户明确要求"本地 / 离线"时用显式 `--provider ollama` 走离线路径。
 
-**选项 2 的核心场景:你买了第三方中转站 / OneAPI 的 Key**,想用人民币付钱跑 OpenAI / Claude / 国产模型 —— 这是国内绝大多数用户用这个选项的真正原因。子菜单 9 个 preset 中,**第 1 个就是中转站(默认)**:
+**选项 2 的核心场景:你买了第三方中转站 / OneAPI 的 Key**,想用人民币付钱跑 OpenAI / Claude / 国产模型 —— 这是国内绝大多数用户用这个选项的真正原因。子菜单 10 个 preset 中,**第 1 个就是中转站(默认)**:
 
 | 子菜单# | 服务 | Base URL | 默认模型 / 备选 |
 |---|---|---|---|
@@ -330,14 +330,15 @@ user chooses an OpenAI-compatible gateway / preset path.
 | 3 | **MiniMax 官方** | `https://api.minimax.io/v1` | `MiniMax-M2.7`(4/2026 / 228K ctx / $0.30 ~ $1.20 per M) |
 | 4 | **通义千问 (阿里 DashScope) 官方** | `https://dashscope.aliyuncs.com/compatible-mode/v1` | `qwen-plus`(自动跟最新快照,当前 → qwen3.6-plus) / `qwen-flash`(便宜) / `qwen-max`(旗舰) |
 | 5 | **智谱 ChatGLM 官方** | `https://open.bigmodel.cn/api/paas/v4` | `glm-4.7-flash`(1/2026 免费 / 200K ctx) / `glm-5`(2/2026 付费旗舰 / 745B MoE)。注意 base_url 用 `/api/paas/v4` 不是 `/v1` |
-| 6 | **零一万物 (Yi) 官方** | `https://api.lingyiwanwu.com/v1` | `yi-medium` / `yi-spark`(便宜) / `yi-lightning`(快) / `yi-large`(旗舰) |
-| 7 | **Azure OpenAI** | `https://YOUR-RESOURCE.openai.azure.com/openai/deployments/YOUR-DEPLOYMENT` | 用户自填 deployment name(不是底层 gpt-5) |
-| 8 | **自建 vLLM / LMStudio / Ollama 网关** | `http://localhost:8000/v1` | 用户自填 HuggingFace 路径(如 `meta-llama/Llama-3.3-70B-Instruct`) |
-| 9 | **其它(完全手填)** | 用户自填 | 用户自填 |
+| 6 | **商汤日日新 (SenseNova) 官方** | `https://token.sensenova.cn/v1` | `deepseek-v4-flash`(已实测连通)。新用户免费额度，可零成本体验本项目(issue #193)；其它可用模型以控制台清单为准。token 端点未验证 embedding，Phase 3 默认推荐独立 Ollama bge-m3 |
+| 7 | **零一万物 (Yi) 官方** | `https://api.lingyiwanwu.com/v1` | `yi-medium` / `yi-spark`(便宜) / `yi-lightning`(快) / `yi-large`(旗舰) |
+| 8 | **Azure OpenAI** | `https://YOUR-RESOURCE.openai.azure.com/openai/deployments/YOUR-DEPLOYMENT` | 用户自填 deployment name(不是底层 gpt-5) |
+| 9 | **自建 vLLM / LMStudio / Ollama 网关** | `http://localhost:8000/v1` | 用户自填 HuggingFace 路径(如 `meta-llama/Llama-3.3-70B-Instruct`) |
+| 10 | **其它(完全手填)** | 用户自填 | 用户自填 |
 
 > 💡 **AI agent 注意**:
 > - 用户说"我有中转站 / OneAPI / 团队网关 / 公司给的 Key"等(国内最常见)→ 选项 2 子菜单 #1 (relay)
-> - 用户说"我有 Kimi / 通义 / 智谱 / Yi / Moonshot / MiniMax / Qwen / GLM 官方 Key" → 选项 2 子菜单 #2-6 对应 preset
+> - 用户说"我有 Kimi / 通义 / 智谱 / 商汤日日新 / Yi / Moonshot / MiniMax / Qwen / GLM / SenseNova 官方 Key" → 选项 2 子菜单 #2-7 对应 preset
 > - 用户说"Azure OpenAI / 公司 Azure 部署" → 子菜单 #7 (azure)
 > - 用户说"自己跑的 vLLM / LMStudio / Ollama OpenAI 兼容 shim" → 子菜单 #8 (self-hosted)
 >

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,8 @@
 
 ## 未发布
 
+- **新增商汤日日新（SenseNova）免费额度 preset（issue #193）**：OpenAI 协议兼容子菜单新增 `sensenova` preset（第 6 位，总数 9→10）：`base_url=https://token.sensenova.cn/v1`、默认模型 `deepseek-v4-flash`——该端点已按 OpenAI 协议真实请求验证连通（成功调用 + 401 鉴权失败路径均实测），新用户免费额度可零成本体验本项目；`scripts/agent_bootstrap.py --llm-preset sensenova` 同步支持（`LLM_PRESETS` / `HUMAN_OPENAI_COMPAT_PRESETS` / choices 三处同步）。token 推理端点未验证 `/v1/embeddings`，preset 如实标注 `supports_embedding=false` 并引导 Phase 3 独立 Ollama bge-m3。新增 cli↔bootstrap 两张 preset 表的键/顺序同步测试（新增 preset 时同步文档子菜单清单的提醒也固化在断言里）；`docs/agent-install.md` 与 `docs/openclaw-quickstart.md` 子菜单清单已同步为 10 个 preset。
+
 - **新增异常报警（LLM / Embedding 请求异常可视化）**：新顶层模块 `diagnostics_alerts` 维护进程内有界环形缓冲（60s 内同类别/来源/错误码合并为一条并累加计数，上限 100 条），`LLMRegistry` 的限流 / 鉴权失败 / 超时 / 响应异常 / 全部实例失败与 `EmbeddingService` 的单次失败 / 熔断触发都会自动记录（熔断与全部实例失败为 error 级，单次失败为 warning 级）；记录永不抛错、不阻塞热路径。新增只读端点 `GET /api/diagnostics/alerts?since_id=&limit=`（支持增量拉取），新告警同时经 event hub 以 `type="diagnostics.alert"` 实时推送到 `/api/runtime-stream`；桌面 Web 设置页日志 tab 与插件 popup 设置页「日志」tab 均新增「异常报警」区（摘要 + 错误/警告徽标 + 中文错误码说明 + 刷新 + 可见面板时轮询/实时刷新）。**展示面范围**：移动 Web 与 CLI 明确不在本功能范围——移动 Web 没有日志/设置面（views 仅 chat/history/library/login/profile/recommend/saved），CLI 只有 `logs-prune` 等文件维护命令、无运行时 feed 展示面。测试覆盖缓冲合并、快照、发布、LLM 与 embedding 失败钩子，并为插件与桌面 Web 新增异常报警区结构契约测试（`popup-diagnostics-alerts.test.ts` / `test_desktop_web_diagnostics_alerts.py`）；`docs/modules/api.md`、`docs/modules/llm.md` 与 `docs/modules/extension.md` 已同步。
 
 ## v0.3.210：海外代理路由统一修复与来源日期过滤（2026-08-23）

--- a/docs/openclaw-quickstart.md
+++ b/docs/openclaw-quickstart.md
@@ -73,23 +73,24 @@ python3 scripts/agent_bootstrap.py --mode docker --interactive-confirm --wait-fo
 
 1. **Phase 1 — LLM 服务选择(7 项菜单)**: DeepSeek 第一推荐,中转站 / OpenAI 协议兼容第二推荐。每项标注 2026-05 当前默认模型:
    - **1) DeepSeek 官方 ★默认推荐** —— 默认 `deepseek-v4-flash`(可选 `deepseek-v4-pro`;旧 `deepseek-chat` / `deepseek-reasoner` 将于 2026/07/24 弃用)/ ¥0.001/千 token / 国内可直连。**最便宜 + 最容易,新人无脑选这个**
-   - **★ 2) 中转站 / OpenAI 协议兼容服务 ★第二推荐** —— **国内用户买中转站 / OneAPI Key 走这个**。也覆盖 Kimi / 通义 / 智谱 / Yi / MiniMax 官方 + Azure / vLLM / LMStudio。选这个进**子菜单(9 个 preset)**:
+   - **★ 2) 中转站 / OpenAI 协议兼容服务 ★第二推荐** —— **国内用户买中转站 / OneAPI Key 走这个**。也覆盖 Kimi / 通义 / 智谱 / 商汤日日新 / Yi / MiniMax 官方 + Azure / vLLM / LMStudio。选这个进**子菜单(10 个 preset)**:
      - **★ a) 中转站 / OneAPI / 公司团队 LLM 网关(大多数人选这个)** —— Base URL 自填 / 默认 `gpt-5-nano`;按你充值的中转站给的模型清单填
      - **b) Kimi (Moonshot AI) 官方** —— `https://api.moonshot.ai/v1` / 默认 `kimi-k2.6`。⚠ 旧 K2-series 2026/05/25 停服
      - **c) MiniMax 官方** —— `https://api.minimax.io/v1` / 默认 `MiniMax-M2.7`(4/2026)
      - **d) 通义千问 (阿里 DashScope) 官方** —— `https://dashscope.aliyuncs.com/compatible-mode/v1` / 默认 `qwen-plus`
      - **e) 智谱 ChatGLM 官方** —— `https://open.bigmodel.cn/api/paas/v4` / 默认 `glm-4.7-flash`(免费档);旗舰 `glm-5`
-     - **f) 零一万物 (Yi) 官方** —— `https://api.lingyiwanwu.com/v1` / 默认 `yi-medium`
-     - **g) Azure OpenAI** —— `https://YOUR-RESOURCE.openai.azure.com/openai/deployments/YOUR-DEP`
-     - **h) 自建 vLLM / LMStudio / Ollama 网关** —— `http://localhost:8000/v1` / 模型 HuggingFace 路径,强制手填
-     - **i) 其它(完全手填)** —— escape hatch
+     - **f) 商汤日日新 (SenseNova) 官方** —— `https://token.sensenova.cn/v1` / 默认 `deepseek-v4-flash`(已实测连通)。新用户免费额度，零成本体验(issue #193);embedding 未验证，Phase 3 默认独立 Ollama bge-m3
+     - **g) 零一万物 (Yi) 官方** —— `https://api.lingyiwanwu.com/v1` / 默认 `yi-medium`
+     - **h) Azure OpenAI** —— `https://YOUR-RESOURCE.openai.azure.com/openai/deployments/YOUR-DEP`
+     - **i) 自建 vLLM / LMStudio / Ollama 网关** —— `http://localhost:8000/v1` / 模型 HuggingFace 路径,强制手填
+     - **j) 其它(完全手填)** —— escape hatch
    - **3) OpenAI 官方** —— 默认 `gpt-5-nano`(最便宜的 GPT-5);可选 gpt-5.4-nano / gpt-5.4-mini / gpt-5.5(旗舰) / gpt-5.5-pro
    - **4) Gemini 官方** —— 默认 `gemini-2.5-flash`(稳定);免费档每天 1500 次。可选 gemini-3-flash-preview / gemini-3.1-pro-preview(旗舰,Public Preview,需付费项目) / gemini-3.1-flash-lite-preview(最便宜)
    - **5) Claude 官方** —— 默认 `claude-sonnet-4-6`(1M ctx),按 token 付费,质量高。可选 claude-haiku-4-5(便宜) / claude-opus-4-7(旗舰)
    - **6) OpenRouter 聚合** —— 默认 `openai/gpt-5-nano`;格式 `<vendor>/<model>`(如 anthropic/claude-sonnet-4-6 / google/gemini-2.5-flash)
    - **7) OrcaRouter 聚合** —— 默认 `openai/gpt-4o`;格式 `<vendor>/<model>`。一个 Key 跑 150+ 模型,网关级零信任安全
    - **本地 Ollama（完全离线,不在交互菜单里）** —— 默认 `qwen2.5:7b`(中文好);可选 llama3.2 / gemma2 / mistral / deepseek-r1。无 Key / 16GB+ 内存。需要时用 `--provider ollama` 显式选择或到桌面设置页配置
-2. **Phase 2 — 给所选服务填配置**：每个选项只问该选项需要的字段。**所有 provider 在 prompt 模型名前都会显示一行"可选/常见模型"提示**(DeepSeek 列 v4-flash / v4-pro,OpenAI 列 gpt-4o-mini / gpt-4o / gpt-4-turbo,Gemini / Claude / Ollama 同样,OpenAI 协议兼容子菜单见上 9 个 preset),用户主动确认而不是回车跳过一个不知道是啥的字符串。Ollama 不问 Key(自动装 + 拉模型);自建网关 / 其它路径强制手填模型名(写错会 404)。
+2. **Phase 2 — 给所选服务填配置**：每个选项只问该选项需要的字段。**所有 provider 在 prompt 模型名前都会显示一行"可选/常见模型"提示**(DeepSeek 列 v4-flash / v4-pro,OpenAI 列 gpt-4o-mini / gpt-4o / gpt-4-turbo,Gemini / Claude / Ollama 同样,OpenAI 协议兼容子菜单见上 10 个 preset),用户主动确认而不是回车跳过一个不知道是啥的字符串。Ollama 不问 Key(自动装 + 拉模型);自建网关 / 其它路径强制手填模型名(写错会 404)。
 3. **Phase 3 — Embedding（向量化，3 选 1 + 高级）**：默认推荐 **本地 Ollama bge-m3**（免费、离线、效果够用），其次 Gemini（云端、效果最好但要 Key），也可以选择暂不启用。Embedding 与主 LLM 独立，不再默认跟随主 LLM。高级选项里有"自定义 OpenAI 兼容 endpoint"。
 4. **Phase 4 — Per-module 覆盖**（高级，默认跳过）：可单独给 soul / discovery / recommendation / evaluation 指定不同模型。
 

--- a/scripts/agent_bootstrap.py
+++ b/scripts/agent_bootstrap.py
@@ -152,6 +152,10 @@ LLM_PRESETS: dict[str, dict[str, str]] = {
         "base_url": "https://open.bigmodel.cn/api/paas/v4",
         "model": "glm-4.7-flash",
     },
+    "sensenova": {
+        "base_url": "https://token.sensenova.cn/v1",
+        "model": "deepseek-v4-flash",
+    },
     "yi": {
         "base_url": "https://api.lingyiwanwu.com/v1",
         "model": "yi-medium",
@@ -196,6 +200,7 @@ HUMAN_OPENAI_COMPAT_PRESETS: tuple[str, ...] = (
     "minimax",
     "qwen",
     "zhipu",
+    "sensenova",
     "yi",
     "azure",
     "self-hosted",
@@ -904,6 +909,7 @@ def build_arg_parser() -> argparse.ArgumentParser:
             "minimax",
             "qwen",
             "zhipu",
+            "sensenova",
             "yi",
             "self-hosted",
             "relay",
@@ -918,8 +924,8 @@ def build_arg_parser() -> argparse.ArgumentParser:
             "Implies --provider=openai_compatible. --llm-base-url / --llm-model still "
             "override the preset on a per-field basis. Presets: "
             "kimi (Moonshot), minimax (M2.7), qwen (DashScope), zhipu (GLM), "
-            "yi (零一万物), self-hosted (vLLM/LMStudio), relay (中转站/OneAPI), "
-            "azure (Azure OpenAI), custom (no preset)."
+            "sensenova (商汤日日新, 免费额度), yi (零一万物), self-hosted (vLLM/LMStudio), "
+            "relay (中转站/OneAPI), azure (Azure OpenAI), custom (no preset)."
         ),
     )
     parser.add_argument(
@@ -2589,9 +2595,7 @@ def apply_module_overrides(project_dir: Path, specs: list[str]) -> dict[str, Any
         )
         effective_provider = provider or default_provider
         instance_id = (
-            _llm_instance_id_for_provider(data, effective_provider, model=model)
-            if model
-            else ""
+            _llm_instance_id_for_provider(data, effective_provider, model=model) if model else ""
         )
         if not instance_id:
             instance_id = _llm_instance_id_for_provider(data, effective_provider)

--- a/src/openbiliclaw/cli.py
+++ b/src/openbiliclaw/cli.py
@@ -1832,6 +1832,31 @@ _OPENAI_COMPAT_PRESETS: tuple[tuple[str, dict[str, str]], ...] = (
         },
     ),
     (
+        "sensenova",
+        {
+            "label": "商汤日日新 (SenseNova) 官方",
+            "description": (
+                "商汤日日新开放平台,新用户有免费额度,可以零成本体验本项目"
+                "(issue #193)。token 推理端点已按 OpenAI 协议实测连通"
+                "(deepseek-v4-flash 真实请求验证)"
+            ),
+            "signup_url": (
+                "https://console.sensecore.cn （日日新开放平台控制台申请 API Key,"
+                "免费额度以官方页面为准）"
+            ),
+            "supports_embedding": "false",
+            "base_url": "https://token.sensenova.cn/v1",
+            "default_model": "deepseek-v4-flash",
+            "hint": (
+                "deepseek-v4-flash (默认 / 已实测) / 其它可用模型以控制台模型清单为准。"
+                "免费额度适合试用与轻度使用;重度使用建议充值或换 DeepSeek 官方"
+            ),
+            "embedding_alt": (
+                "token 推理端点未验证 /v1/embeddings,Phase 3 默认推荐独立 Ollama bge-m3"
+            ),
+        },
+    ),
+    (
         "yi",
         {
             "label": "零一万物 (Yi) 官方",

--- a/tests/test_llm_openai_compat_presets.py
+++ b/tests/test_llm_openai_compat_presets.py
@@ -1,0 +1,64 @@
+"""OpenAI 协议兼容 preset 一致性测试（cli 交互子菜单 ↔ agent_bootstrap --llm-preset）。
+
+重点覆盖 issue #193 的商汤日日新（sensenova）免费额度 preset：
+- 两张 preset 表键与顺序完全同步（文档按同一顺序展示）
+- sensenova 的 base_url / 默认模型与真实环境实测值一致
+- ``--llm-preset sensenova`` 解析为 openai_compatible + 实测 endpoint
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+
+import agent_bootstrap as bootstrap  # noqa: E402
+
+from openbiliclaw.cli import _OPENAI_COMPAT_PRESETS  # noqa: E402
+
+
+def _cli_preset_keys() -> list[str]:
+    return [key for key, _ in _OPENAI_COMPAT_PRESETS]
+
+
+def test_cli_and_bootstrap_preset_keys_stay_in_sync() -> None:
+    """交互子菜单与 --llm-preset 的键集合、顺序必须一致（文档按此顺序展示）。"""
+    cli_keys = _cli_preset_keys()
+    bootstrap_keys = list(bootstrap.HUMAN_OPENAI_COMPAT_PRESETS)
+    # cli 的 "custom" 对应 bootstrap 的 "custom"（同为完全手填 escape hatch）。
+    assert cli_keys == bootstrap_keys, f"preset 表漂移: cli={cli_keys} bootstrap={bootstrap_keys}"
+    assert len(cli_keys) == 10, (
+        "新增 preset 时记得同步 docs 里的子菜单清单（agent-install / openclaw-quickstart）"
+    )
+
+
+def test_sensenova_preset_matches_validated_endpoint() -> None:
+    """sensenova preset 的 endpoint / 模型与真实环境实测值一致（issue #193）。"""
+    presets = dict(_OPENAI_COMPAT_PRESETS)
+    assert "sensenova" in presets
+    preset = presets["sensenova"]
+    assert preset["base_url"] == "https://token.sensenova.cn/v1"
+    assert preset["default_model"] == "deepseek-v4-flash"
+    # token 推理端点未验证 /v1/embeddings —— 必须如实标注，引导独立 Ollama bge-m3。
+    assert preset["supports_embedding"] == "false"
+    assert "bge-m3" in preset["embedding_alt"]
+    # 免费额度是该 preset 的存在理由（issue #193），文案必须提及。
+    assert "免费" in preset["description"]
+
+
+def test_sensenova_in_bootstrap_llm_presets() -> None:
+    assert bootstrap.LLM_PRESETS["sensenova"] == {
+        "base_url": "https://token.sensenova.cn/v1",
+        "model": "deepseek-v4-flash",
+    }
+
+
+def test_llm_preset_sensenova_resolves_openai_compatible(tmp_path: Path) -> None:
+    args = bootstrap.build_arg_parser().parse_args(
+        ["--project-dir", str(tmp_path), "--llm-preset", "sensenova"]
+    )
+    assert bootstrap.apply_llm_preset_args(args) is None
+    assert args.provider == "openai_compatible"
+    assert args.llm_base_url == "https://token.sensenova.cn/v1"
+    assert args.llm_model == "deepseek-v4-flash"


### PR DESCRIPTION
# feat: 商汤日日新（SenseNova）免费额度 preset（close #193）

## 变更摘要

落实 #193：让新用户可以用商汤日日新的免费 LLM 额度**零成本**体验本项目。

- **OpenAI 协议兼容子菜单新增 `sensenova` preset**（第 6 位，总数 9 → 10）：
  - `base_url = https://token.sensenova.cn/v1`，默认模型 `deepseek-v4-flash`
  - 该端点已按 OpenAI 协议**真实请求验证连通**（成功调用 ≈2s 返回；错误 key 走真实 401 `{"code":16,"message":"Forbidden"}` 鉴权失败路径）——验证过程见 #214 的 E2E 评论
  - `supports_embedding=false` 如实标注（token 推理端点未验证 `/v1/embeddings`），`embedding_alt` 引导 Phase 3 独立 Ollama bge-m3
- **`scripts/agent_bootstrap.py --llm-preset sensenova`**：`LLM_PRESETS` / `HUMAN_OPENAI_COMPAT_PRESETS` / parser choices 三处同步，AI agent 非交互安装一句话接入
- **新增 `tests/test_llm_openai_compat_presets.py`**：钉住 cli 交互子菜单 ↔ bootstrap 两张 preset 表的键/顺序同步（新增 preset 未同步文档子菜单清单会直接挂测试），以及 sensenova 的实测 endpoint/模型值
- **文档**：`docs/agent-install.md` 与 `docs/openclaw-quickstart.md` 子菜单清单更新为 10 个 preset，AI-agent 决策提示新增 日日新 / SenseNova 关键词；`docs/changelog.md` 未发布小节已加条目

## 关联

- Closes #193
- 端点实测数据来自 #214 的真实环境验证（同一台机器、同一凭据体系）

## 测试命令与结果

```bash
uv run --extra dev pytest tests/test_llm_openai_compat_presets.py   # 4 passed
uv run --extra dev pytest tests/test_agent_bootstrap.py             # 81 passed（含 preset 全部用例）
ruff check src/openbiliclaw/cli.py scripts/agent_bootstrap.py tests/test_llm_openai_compat_presets.py  # 通过
ruff format --check 同上                                                                             # 通过
mypy src/openbiliclaw/cli.py                                        # 通过
```

## 手动验证建议

1. `uv run openbiliclaw init` → LLM 菜单选「中转站 / OpenAI 协议兼容」→ 子菜单第 6 项应为「商汤日日新 (SenseNova) 官方」，回车后 Base URL / 模型自动填好，只需粘贴 Key。
2. `python scripts/agent_bootstrap.py --project-dir /tmp/x --llm-preset sensenova` 应写入 `provider_type="openai_compatible"` 实例并置顶 default_chain。
