### PR TITLE
fix: 冻结越过自身日期的 temporal 存储测试时钟（main CI 时间炸弹）

### DIFF
--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -56,6 +56,37 @@ def _v2_temporal(**overrides: Any) -> dict[str, Any]:
     return fields
 
 
+def _freeze_storage_clock(monkeypatch: Any, frozen: str = "2026-08-12T00:00:00+00:00") -> None:
+    """把 database 模块的墙钟冻结到固定时刻。
+
+    helper 默认 evaluated_at=2026-08-12，存储层重算 next_review=+14d
+    （2026-08-26）。真实时钟越过该日期后，依赖「重算后仍在未来 →
+    eligible」的测试会翻转成 review_due（2026-08-26 当天 CI 实测爆发）。
+    冻结到 evaluated_at 当天，重算结果永远在冻结时钟的 14 天后，
+    测试回归确定性。
+    """
+    import openbiliclaw.storage.database as database_module
+
+    frozen_dt = datetime.fromisoformat(frozen)
+
+    class _FrozenClock:
+        @classmethod
+        def now(cls, tz: object = None) -> datetime:
+            if tz is None:
+                return frozen_dt
+            return frozen_dt.astimezone(tz)  # type: ignore[arg-type]
+
+        @classmethod
+        def fromisoformat(cls, value: str) -> datetime:
+            return datetime.fromisoformat(value)
+
+        @classmethod
+        def strptime(cls, value: str, fmt: str) -> datetime:
+            return datetime.strptime(value, fmt)
+
+    monkeypatch.setattr(database_module, "datetime", _FrozenClock)
+
+
 class TestDatabase:
     """Test SQLite database operations."""
 
@@ -182,7 +213,10 @@ class TestDatabase:
         assert row["temporal_validity_mode"] == "explicit_deadline"
         assert row["temporal_evidence_complete"] == 1
 
-    def test_v2_storage_recomputes_caller_supplied_review_clock(self, tmp_path: Path) -> None:
+    def test_v2_storage_recomputes_caller_supplied_review_clock(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _freeze_storage_clock(monkeypatch)
         db = Database(tmp_path / "v2-policy-clock.db")
         db.initialize()
 
@@ -483,7 +517,9 @@ class TestDatabase:
     def test_only_complete_non_neutral_review_restores_hold_to_fresh(
         self,
         tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
+        _freeze_storage_clock(monkeypatch)
         db = Database(tmp_path / "v2-review-restore.db")
         db.initialize()
         due = _v2_temporal(
@@ -656,7 +692,9 @@ class TestDatabase:
     def test_final_serve_commit_applies_all_three_temporal_states(
         self,
         tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
+        _freeze_storage_clock(monkeypatch)
         db = Database(tmp_path / "v2-final-serve.db")
         db.initialize()
         common = {
@@ -5183,7 +5221,9 @@ class TestDatabase:
     def test_pool_maintenance_holds_newly_due_fresh_rows_in_writer_transaction(
         self,
         tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
+        _freeze_storage_clock(monkeypatch)
         db = Database(tmp_path / "maintenance-temporal-due.db")
         db.initialize()
         _seed_visible(db, "BVMAINTDUE", source="search", **_v2_temporal())


### PR DESCRIPTION
## 变更摘要

`tests/test_storage.py` 四个用例硬编码的 `temporal_next_review_at`（evaluated_at 2026-08-12 + 14 天重算规则 → **2026-08-26**）在写入时是未来日期，真实时钟今天走到该日后，`cache_content` 按 `datetime.now(UTC)` 重算 disposition，行从 `eligible` 翻转为 `review_due`，CI 与本地同时爆发（`'review_due' == 'eligible'`）。**与任何特性分支无关**——在纯 main 上即可复现。

修复：新增 `_freeze_storage_clock()` helper（monkeypatch database 模块的 `datetime` 为冻结时钟，委托 fromisoformat / strptime），应用到四个受影响用例，恢复其原始确定性意图，而不是把日期改成下一颗时间炸弹。

| 测试 | 失败表现 |
|---|---|
| test_v2_storage_recomputes_caller_supplied_review_clock | `assert 'review_due' == 'eligible'` |
| test_only_complete_non_neutral_review_restores_hold_to_fresh | 同上 |
| test_final_serve_commit_applies_all_three_temporal_states | `assert () == ('BVFINALFRESH',)` |
| test_pool_maintenance_holds_newly_due_fresh_rows_in_writer_transaction | `assert 0 >= 1` |

## 测试命令与结果

```bash
uv run --extra dev pytest tests/test_storage.py   # 180 passed
ruff check / format --check tests/test_storage.py  # 通过
```