### PR TITLE
docs: add AtomGit source mirror links

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@
 
 [项目主页](https://whiteguo233.github.io/OpenBiliClaw/) | [English](README_EN.md) | 中文
 
+国内 AtomGit 托管：[OpenBiliClaw](https://atomgit.com/whiteguo233/OpenBiliClaw)（从 GitHub 自动同步源码）
+
 </div>
 
 > ### 🆕 重要更新：OpenBiliClaw 现在可以装进 DeepSeek Harness

--- a/README_EN.md
+++ b/README_EN.md
@@ -16,6 +16,8 @@
 
 [Homepage](https://whiteguo233.github.io/OpenBiliClaw/) | English | [中文](README.md)
 
+Source mirror in China: [OpenBiliClaw on AtomGit](https://atomgit.com/whiteguo233/OpenBiliClaw) (automatically synced from GitHub).
+
 </div>
 
 > ### 🆕 Big update: OpenBiliClaw now runs inside DeepSeek Harness

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,8 @@
 
 ## v0.3.220：Windows 推荐进程修复与保存键扩展（2026-09-09）
 
+- **新增 AtomGit 国内源码镜像（2026-09-10）**：中英文 README 补充 [AtomGit 项目入口](https://atomgit.com/whiteguo233/OpenBiliClaw)，镜像从 GitHub 自动同步源码，方便国内访问并满足 G-Star 申请的项目链接展示要求。
+
 - **修复 Windows 端 v0.3.219 启动崩溃（issue #234）**：Windows 的 asyncio/uvicorn 不支持 Unix socket，独立推荐进程改为监听 `127.0.0.1:8423` 回环 TCP，主 API 改用 HTTP 代理；POSIX 仍保留 Unix socket。同时为桌面 Web 的 `renderPoolStatus` 增加 `null` 状态保护。
 - **允许 Linux.do 主题类型内容 ID 保存**：saved-item key 校验新增 `linuxdo:topic:<positive-id>` 规范键，与既有知乎 / GitHub typed-content 规则保持一致。
 - **发布状态**：后端源码 / 浏览器插件 / 桌面安装包 / Docker 镜像与聚合 Release 均已发布为 `v0.3.220`；Chrome Web Store 已上传并提交 `0.3.220` 审核；Firefox AMO 已提交 listed `0.3.220`。


### PR DESCRIPTION
OpenBiliClaw 已在 AtomGit 建立公开源码镜像并启用 GitHub → AtomGit Pull 自动同步。中英文 README 增加国内源码入口，满足 G-Star 申请的项目链接展示要求；变更日志同步记录镜像入口。

验证：

- `git diff --check` 通过。
- `pytest -q tests/test_docs_index.py tests/test_docs_saved_sync.py tests/test_docs_source_incremental_sync.py tests/test_install_contract_docs.py tests/test_release_consistency.py tests/test_aggregate_release_workflow.py tests/test_release_script.py`：55 passed。
- 全量 `pytest -q` 运行至 894 passed 后手动中止，转为与此次纯文档变更相关的测试；未宣称全量通过。
- 浏览器确认 AtomGit 仓库公开导入完成，main 提交与 GitHub 一致；Pull 镜像已启用，源地址为 GitHub 公开仓库。

关联：[AtomGit 项目](https://atomgit.com/whiteguo233/OpenBiliClaw)、[G-Star 官方指引](https://atomgit.com/GitCode/G-Star_guiding)。
