### PR TITLE
fix(types): 清理既有 MyPy 基线，让 CI 能跑到 pytest

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -16,6 +16,7 @@
 
 - **新增 AtomGit 国内源码镜像**：中英文 README 补充 [AtomGit 项目入口](https://atomgit.com/whiteguo233/OpenBiliClaw)，镜像从 GitHub 自动同步源码，方便国内访问并满足 G-Star 申请的项目链接展示要求。
 
+- **CI 基线清理（MyPy）**：修复 8 个既有 MyPy 报错（`soul/cognition_cycle.py`、`image_service.py`、`worker/main.py`、`api/app.py`），`mypy src/` 恢复 0 error，CI 不再在 MyPy 步骤阻断后续 pytest。改动仅为类型注解 + 一个鸭子类型 Protocol（`_BackgroundTaskHost`）与一个 TypedDict，无运行时行为变化。
 - **发布状态**：后端源码 / 浏览器插件 / 桌面安装包 / Docker 镜像与聚合 Release 统一为 `v0.3.221`；客户端配套版本为移动端 `v0.3.156+2006`。
 
 ## v0.3.220：Windows 推荐进程修复与保存键扩展（2026-09-09）

--- a/src/openbiliclaw/api/app.py
+++ b/src/openbiliclaw/api/app.py
@@ -32,7 +32,7 @@ from contextlib import asynccontextmanager, suppress
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
-from typing import TYPE_CHECKING, Annotated, Any, Literal, NoReturn, cast
+from typing import TYPE_CHECKING, Annotated, Any, Literal, NoReturn, TypedDict, cast
 from urllib.parse import parse_qsl, quote, urlparse, urlsplit, urlunsplit
 from uuid import UUID
 
@@ -271,6 +271,16 @@ if TYPE_CHECKING:
     )
 
 logger = logging.getLogger(__name__)
+
+
+class _GuidedInitTimeoutKwargs(TypedDict, total=False):
+    """Optional per-stage timeout overrides forwarded to ``run_guided_init()``."""
+
+    collection_timeout_seconds: float
+    profile_analysis_timeout_seconds: float
+    profile_build_timeout_seconds: float
+    discovery_timeout_seconds: float
+
 
 # A local Ollama chat probe can spend ~31 seconds in its documented cold-load
 # retry window before the model answers. The previous 30-second API cap killed
@@ -5605,7 +5615,7 @@ def create_app(
             heartbeat_task = asyncio.create_task(_run_init_heartbeat(coord, run_id))
             enabled = set(ctx.init_prereqs.enabled_platforms())
             effective = _select_init_platforms(enabled, selected_sources)
-            run_guided_init_kwargs: dict[str, float] = {}
+            run_guided_init_kwargs: _GuidedInitTimeoutKwargs = {}
             if init_timeout_minutes is not None and init_timeout_minutes > 0:
                 timeout_seconds = max(1, int(float(init_timeout_minutes) * 60))
                 run_guided_init_kwargs = {
@@ -6870,7 +6880,7 @@ def create_app(
 
             from PIL import Image
 
-            image = Image.open(BytesIO(data))
+            image: Image.Image = Image.open(BytesIO(data))
             if image.width <= 640:
                 return data, content_type
             image.thumbnail((640, 640), Image.Resampling.LANCZOS)
@@ -7491,8 +7501,8 @@ def create_app(
 
         bvid = str(payload.get("bvid", "") or "").strip()
         message = str(payload.get("message", "") or "").strip()
-        root_raw = payload.get("root")
-        parent_raw = payload.get("parent")
+        root_raw: Any = payload.get("root")
+        parent_raw: Any = payload.get("parent")
         if not bvid:
             raise HTTPException(status_code=400, detail="缺少 bvid")
         if not message:
@@ -7535,7 +7545,7 @@ def create_app(
         from openbiliclaw.config import load_config
 
         bvid = str(payload.get("bvid", "") or "").strip()
-        rpid_raw = payload.get("rpid")
+        rpid_raw: Any = payload.get("rpid")
         if not bvid:
             raise HTTPException(status_code=400, detail="缺少 bvid")
         try:
@@ -10992,10 +11002,10 @@ def create_app(
                 )
             )
 
-        async def _event_stream():
+        async def _event_stream() -> AsyncIterator[str]:
             import json as _json
 
-            def sse(event: str, data: dict) -> str:
+            def sse(event: str, data: dict[str, Any]) -> str:
                 return f"event: {event}\ndata: {_json.dumps(data, ensure_ascii=False)}\n\n"
 
             yield sse("phase", {"phase": "thinking", "text": "正在思考…"})

--- a/src/openbiliclaw/api/runtime_context.py
+++ b/src/openbiliclaw/api/runtime_context.py
@@ -29,7 +29,7 @@ import logging
 import os
 from contextlib import suppress
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, Protocol, cast
 
 from openbiliclaw.config import (
     llm_concurrency_from_config as _llm_concurrency_from_config,
@@ -46,8 +46,6 @@ from openbiliclaw.runtime.task_registry import BackgroundTaskRegistry
 if TYPE_CHECKING:
     from collections.abc import Mapping
 
-    from fastapi import FastAPI
-
     from openbiliclaw.config import Config
     from openbiliclaw.soul.dialogue_learn_queue import (
         DialogueDispatcher,
@@ -61,6 +59,17 @@ _BACKGROUND_TASK_CANCEL_TIMEOUT_SECONDS = 1.5
 # timeout in one worker job.  Give it the same 25-minute no-progress envelope
 # as guided preference analysis instead of rolling config.toml back after 30s.
 _DIALOGUE_SETTLEMENT_DRAIN_TIMEOUT_SECONDS = 25 * 60.0
+
+
+class _BackgroundTaskHost(Protocol):
+    """Minimal host object exposing ``.state`` for background-task wiring.
+
+    ``FastAPI`` satisfies this; the headless full worker passes a
+    ``SimpleNamespace`` stand-in because ``restart_background_tasks`` only
+    reads and writes attributes on ``app.state``.
+    """
+
+    state: Any
 
 
 def _pool_source_shares_from_config(config: Any) -> dict[str, int]:
@@ -1836,7 +1845,7 @@ class RuntimeContext:
 
     async def restart_background_tasks(
         self,
-        app: FastAPI,
+        app: _BackgroundTaskHost,
         *,
         run_post_reload_llm_work: bool = True,
     ) -> None:

--- a/src/openbiliclaw/image_service.py
+++ b/src/openbiliclaw/image_service.py
@@ -32,7 +32,7 @@ def _resize_cover_for_mobile(data: bytes, content_type: str) -> tuple[bytes, str
     try:
         from PIL import Image
 
-        image = Image.open(BytesIO(data))
+        image: Image.Image = Image.open(BytesIO(data))
         if image.width <= 640:
             return data, content_type
         image.thumbnail((640, 640), Image.Resampling.LANCZOS)

--- a/src/openbiliclaw/soul/cognition_cycle.py
+++ b/src/openbiliclaw/soul/cognition_cycle.py
@@ -624,7 +624,7 @@ class CognitionCycle:
                 return
             manager = self._confusion_manager()
             rows = db.list_confusions(statuses=["open"], limit=10000)
-            active = [
+            active: list[dict[str, Any]] = [
                 {
                     "id": int(row.get("id", 0) or 0),
                     "status": str(row.get("status", "") or "").strip().lower(),


### PR DESCRIPTION
## 背景

CI 的 `test` job 在 **Run MyPy** 步骤失败（8 errors），导致后面的 `pytest` 根本没跑到。这些错误在本次改动之前就已存在（最近几次 main push 都是红的）。本 PR 只做类型注解修复，**无运行时行为变化**。

## 修复清单

| 位置 | 错误 | 修复 |
|---|---|---|
| `soul/cognition_cycle.py:641` | `int(object)` | 把推导出的 `active` 标注为 `list[dict[str, Any]]` |
| `image_service.py:40` | `Image`/`ImageFile` 赋值 | `image: Image.Image = Image.open(...)` |
| `api/app.py:6878` | 同上 | 同上 |
| `api/app.py:5651` | `**dict[str, float]` 传给显式 kwargs | 新增 `_GuidedInitTimeoutKwargs(TypedDict, total=False)` |
| `api/app.py:10995` | 缺返回注解 | SSE 生成器标注 `-> AsyncIterator[str]` |
| `api/app.py:10998` | `dict` 缺泛型参数 | `data: dict[str, Any]` |
| `api/app.py:11020` | 调用未注解函数 | 由上一行修复 |
| `worker/main.py:234` | `SimpleNamespace` 传给 `app: FastAPI` | 新增鸭子类型 Protocol `_BackgroundTaskHost(state: Any)`（`restart_background_tasks` 只访问 `app.state`），并移除因此未使用的 `FastAPI` import |
| `api/app.py` video comment | 本地 py3.12 下 `int(Any \| None)` | `root_raw` / `parent_raw` / `rpid_raw` 显式标注 `Any`（有 None 守卫） |

## 验证

- `python -m mypy src/` → **Success: no issues found in 279 source files**
- `python -m ruff check src/` → All checks passed
- `pytest tests/test_cognition_cycle.py tests/test_api_image_proxy.py tests/test_image_fetch.py tests/test_api_bili_tasks.py tests/test_refresh_runtime.py` → 248 passed, 4 failed
  - 4 个 `test_image_fetch.py` 失败是本机预存 flaky（`condition was not reached`），在**未改动的 main 上同样失败**，与本 PR 无关
- 同步在 `docs/changelog.md` v0.3.221 块补了一条 CI 基线清理说明

改动仅为注解 / Protocol / TypedDict，运行时行为与 main 一致（本地变量注解不求值、函数注解有 `from __future__ import annotations`）。
