### PR TITLE
feat(bilibili): fill zone ids and add a tag fetcher

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,12 @@
 
 ---
 
+## 未发布
+
+- **B 站视频信息补分区 id，新增标签读取方法（issue #57 / #232 方向 1）**：`get_video_info()` 补填同一 `/x/web-interface/view` 响应里一直存在、但此前被丢弃的 `tid` / `tid_v2`（零额外请求）；新增 `get_video_tags(bvid, limit=20)`，走 `/x/tag/archive/tags`（网页播放器标签行所用的端点）取标签名，匿名 Cookie 亦可读取，响应远轻于 `/x/web-interface/view/detail`（后者会连带 Card / Related / Reply）。**实测纠正**：2026-09-11 在 8 个分区各取 1 个样本（含 plain `/view` 与 WBI `/x/web-interface/wbi/view` 两种变体）确认 —— 该响应**不含 `tag` 数组**，`tname` / `tname_v2` **恒为空字符串**，因此 `VideoInfo.tags` 在这条路径上保持 `None`，标签只能由 `get_video_tags()` 显式获取；`get_video_info()` 的请求数不变（有回归测试锁定）。集成点（把标签喂给评估 prompt、摇摆区视频才拉标签）留待后续按需接入，本次不改变任何发现/推荐链路行为。
+
+---
+
 ## v0.3.221：保存 URL 归一化、B 站视频信息回退与 learned scorer 校准（2026-09-11）
 
 - **修复协议相对封面 URL 导致「稍后再看 / 收藏」422（issue #237）**：B 站等上游常见返回 `//i2.hdslb.com/...` 这类协议相对地址，入站 `SavedItemIn` 的 `content_url` / `cover_url` 在 `_validate_http_url` 校验前统一补全为 `https://...` 再入库；三个图形界面共用同一端点，无需各客户端自行兜底，非 HTTP(S)、带凭据、含空白或控制字符等非法值仍照旧拒绝。真实进程 + 真实 HTTP 回归：未修复的 main 提交返回 422，修复后 200 并落库为绝对地址。

--- a/docs/modules/bilibili.md
+++ b/docs/modules/bilibili.md
@@ -28,6 +28,7 @@
 | 弹幕 fetch outcome | ✅ | `get_danmaku_texts_result()` 区分 `success`（可为空）、`no_data` 与 `transient_failure`；HTTP、XML、限速和网络异常保留原因并交给上层重试。HTTP 200 但根元素不是 B 站 `<i>`（包括 HTML challenge）不会伪装成成功空结果。`get_danmaku_texts()` 继续提供只返回文本列表的兼容包装 |
 | 账户侧同步来源 | ✅ | 已支持 history / favorites / following 三类长期信号，供后台低频同步使用；favorites 会按收藏夹分页补齐到预算上限；同步事件会带 `metadata.signal_strength` 供偏好分析区分证据强弱 |
 | 原生收藏 / 稍后再看写入 | ✅ | `BilibiliAPIClient` 新增认证 form POST、exact-title 收藏夹复用/创建、视频收藏和稍后再看写入；`BilibiliNativeSaveAdapter` 将 B 站 application code 归一化为 saved-sync 状态，并已由 `RuntimeContext` 注册到平台中立 `/api/saved/*`。UI 仍属后续任务；默认关闭自动同步，旧 B 站保存端点仍只写本地。 |
+| 分区 id 与视频标签 | ✅ | `get_video_info()` 从同一 `/x/web-interface/view` 响应补填 `tid` / `tid_v2`（零额外请求）；新增 `get_video_tags(bvid)` 走 `/x/tag/archive/tags` 取标签名（匿名可用，响应远轻于 `/x/web-interface/view/detail`）。**实测（2026-09-11，8 个分区各 1 个样本）**：`/view` 响应**不含 `tag` 数组**，`tname` / `tname_v2` **恒为空字符串** —— 因此该路径下 `VideoInfo.tags` 保持 `None`，标签名只能由 `get_video_tags()` 显式获取。 |
 | 3.3 agent-browser 集成 | ✅ | navigate / get_page_content + CLI browser 命令 |
 
 ### Danmaku outcome API
@@ -116,6 +117,9 @@ following = await client.get_following(page=1, page_size=50)  # list[FollowingUs
 
 # 视频
 video = await client.get_video_info("BV1xx411c7mD")  # VideoInfo
+# video.cid / video.tid / video.tid_v2 都来自同一次 /view 响应（零额外请求）
+# video.tags 在该路径下恒为 None：/view 不返回 tag 数组（实测 2026-09-11）
+tags = await client.get_video_tags("BV1xx411c7mD")  # ["三角洲行动", ...]（匿名可用；失败会抛错）
 related = await client.get_related_videos("BV1xx411c7mD")
 
 # 评论

--- a/src/openbiliclaw/bilibili/api.py
+++ b/src/openbiliclaw/bilibili/api.py
@@ -112,6 +112,12 @@ class VideoInfo:
     # present in the /x/web-interface/view payload, so reading it costs
     # nothing extra.
     cid: int = 0
+    # Legacy / v2 zone ids from the same payload. NOTE: the payload's text
+    # labels (``tname`` / ``tname_v2``) come back as empty strings on the live
+    # endpoint, so the numeric ids are the only partition signal actually
+    # delivered; ``get_video_tags()`` is the supported way to get tag names.
+    tid: int = 0
+    tid_v2: int = 0
 
 
 @dataclass
@@ -596,7 +602,15 @@ class BilibiliAPIClient:
             bvid: Bilibili video BV ID.
 
         Returns:
-            VideoInfo dataclass.
+            VideoInfo dataclass. Everything is read from the single
+            ``/x/web-interface/view`` payload — including ``cid`` and the
+            ``tid`` / ``tid_v2`` zone ids, so no extra request is issued.
+
+        Note:
+            The live payload does **not** carry a ``tag`` array, and its text
+            zone labels (``tname`` / ``tname_v2``) are empty strings, so
+            ``VideoInfo.tags`` stays ``None`` here. Use
+            :meth:`get_video_tags` when tag names are needed.
         """
         data = await self.get_video_view_data(bvid)
         stat = _json_object(data.get("stat", {}))
@@ -619,7 +633,43 @@ class BilibiliAPIClient:
             danmaku_count=stat.get("danmaku", 0),
             pub_date=data.get("pubdate", ""),
             cid=int(data.get("cid", 0) or 0),
+            tid=int(data.get("tid", 0) or 0),
+            tid_v2=int(data.get("tid_v2", 0) or 0),
         )
+
+    async def get_video_tags(self, bvid: str, *, limit: int = 20) -> list[str]:
+        """Fetch the public tag names of a video, oldest-published first.
+
+        Uses ``/x/tag/archive/tags`` — the endpoint the web player reads for
+        the tag row under a video. It is anonymous-safe (verified without a
+        Cookie) and far lighter than ``/x/web-interface/view/detail``, which
+        would drag in Card / Related / Reply alongside ``Tags``.
+
+        The ``data`` payload is a bare array of tag objects, not an object, so
+        it is coerced with :func:`_json_list` instead of being indexed as a
+        dict.
+
+        Args:
+            bvid: Bilibili video BV ID.
+            limit: Maximum number of tag names to return.
+
+        Returns:
+            Tag names in payload order; blank names are skipped. Returns an
+            empty list when the video has no tags — callers that need to
+            distinguish "no tags" from "fetch failed" must let the
+            :class:`BilibiliAPIError` propagate.
+        """
+        data = await self._get_json("/x/tag/archive/tags", params={"bvid": bvid})
+        tags: list[str] = []
+        for item in _json_list(data):
+            if not isinstance(item, dict):
+                continue
+            name = str(item.get("tag_name", "") or "").strip()
+            if name:
+                tags.append(name)
+            if len(tags) >= max(1, int(limit)):
+                break
+        return tags
 
     async def get_play_info(
         self,

--- a/tests/test_bilibili_api.py
+++ b/tests/test_bilibili_api.py
@@ -883,6 +883,132 @@ async def test_get_video_info_returns_defaults_when_data_is_null() -> None:
     assert info.title == ""
     assert info.up_name == ""
     assert info.view_count == 0
+    assert info.cid == 0
+    assert info.tid == 0
+    assert info.tid_v2 == 0
+    # The live /view payload carries no tag array, so tags stay None here.
+    assert info.tags is None
+
+
+@pytest.mark.asyncio
+async def test_get_video_info_fills_zone_ids_from_the_view_payload() -> None:
+    """``tid`` / ``tid_v2`` ship in ``/x/web-interface/view`` and cost nothing
+    extra; the client must stop dropping them (issue #232, direction 1).
+
+    Live check on 2026-09-11 across eight ranking videos: ``tid`` / ``tid_v2``
+    are always present, while the payload's text labels ``tname`` /
+    ``tname_v2`` are always empty strings and no ``tag`` array exists at all.
+    """
+    client = BilibiliAPIClient(cookie="SESSDATA=abc")
+    client._client = FakeAsyncClient(
+        {
+            "code": 0,
+            "data": {
+                "bvid": "BV1xx",
+                "aid": 1,
+                "cid": 222,
+                "tid": 121,
+                "tid_v2": 2071,
+                "stat": {"view": 10},
+                "owner": {"name": "alice", "mid": 7},
+            },
+        }
+    )
+
+    info = await client.get_video_info("BV1xx")
+
+    assert info.cid == 222
+    assert info.tid == 121
+    assert info.tid_v2 == 2071
+
+
+@pytest.mark.asyncio
+async def test_get_video_info_still_uses_exactly_one_request() -> None:
+    """Filling the extra fields must not add a request: tag names are only
+    fetched by an explicit :meth:`get_video_tags` call, so the hot path
+    (comments, danmaku preheat, play-url) keeps its single ``/view`` round-trip.
+    """
+    client = BilibiliAPIClient(cookie="SESSDATA=abc")
+    fake = FakeAsyncClient({"code": 0, "data": {"bvid": "BV1xx", "tid": 121}})
+    client._client = fake
+
+    await client.get_video_info("BV1xx")
+
+    assert len(fake.calls) == 1
+    assert fake.calls[0][0].endswith("/x/web-interface/view")
+
+
+@pytest.mark.asyncio
+async def test_get_video_tags_parses_bare_array_payload() -> None:
+    """``/x/tag/archive/tags`` returns ``data`` as a bare array of tag objects
+    (unlike most endpoints), so it must be coerced with the list helper and the
+    names returned in payload order.
+    """
+    client = BilibiliAPIClient(cookie="")
+    client._client = FakeAsyncClient(
+        {
+            "code": 0,
+            "data": [
+                {"tag_id": 42642704, "tag_name": "三角洲行动", "type": 1},
+                {"tag_id": 100231797, "tag_name": "三角洲行动二洲年", "type": 3},
+                {"tag_id": 1, "tag_name": "洲彦祖再集结", "type": 3},
+            ],
+        }
+    )
+
+    tags = await client.get_video_tags("BV1eqYx6UE9V")
+
+    assert tags == ["三角洲行动", "三角洲行动二洲年", "洲彦祖再集结"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("payload", "expected"),
+    [
+        ({"code": 0, "data": []}, []),
+        ({"code": 0, "data": None}, []),
+        # Blank / missing / non-string names must not become empty-string tags.
+        (
+            {"code": 0, "data": [{"tag_name": "  "}, {"tag_name": ""}, {}, {"tag_name": None}]},
+            [],
+        ),
+        # Malformed entries are skipped instead of raising mid-payload.
+        (
+            {"code": 0, "data": ["三角洲行动", {"tag_name": "赛博朋克"}, 42]},
+            ["赛博朋克"],
+        ),
+    ],
+)
+async def test_get_video_tags_tolerates_empty_and_malformed_payloads(
+    payload: dict[str, object],
+    expected: list[str],
+) -> None:
+    client = BilibiliAPIClient(cookie="")
+    client._client = FakeAsyncClient(payload)
+
+    assert await client.get_video_tags("BV1xx") == expected
+
+
+@pytest.mark.asyncio
+async def test_get_video_tags_respects_limit() -> None:
+    client = BilibiliAPIClient(cookie="")
+    client._client = FakeAsyncClient(
+        {"code": 0, "data": [{"tag_name": f"标签{index}"} for index in range(6)]}
+    )
+
+    assert await client.get_video_tags("BV1xx", limit=2) == ["标签0", "标签1"]
+
+
+@pytest.mark.asyncio
+async def test_get_video_tags_propagates_api_errors() -> None:
+    """A failed tag fetch must stay distinguishable from "this video has no
+    tags": the error is not swallowed into an empty list.
+    """
+    client = BilibiliAPIClient(cookie="")
+    client._client = FakeAsyncClient({"code": -404, "message": "啥都木有"})
+
+    with pytest.raises(BilibiliAPIError):
+        await client.get_video_tags("BV1xx")
 
 
 def test_client_bypasses_env_and_system_proxies(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -948,9 +1074,7 @@ async def test_post_comment_sends_csrf_and_thread_params() -> None:
     )
     client._client = fake
 
-    result = await client.post_comment(
-        "BV1xx411c7mD", message="  好视频  ", root=12, parent=34
-    )
+    result = await client.post_comment("BV1xx411c7mD", message="  好视频  ", root=12, parent=34)
 
     assert result["rpid"] == 987
     post_url, post_data, _headers = fake.calls[-1]


### PR DESCRIPTION
## 变更摘要

用真实接口核对后，我把这个 PR 的范围**改掉了**：初版按 issue #57 / #232 的描述以为 `/x/web-interface/view` 里有 `data.tag` / `data.tname_v2` 被丢弃，实测**并不存在**（详见下节）。现在提交的是实测确认过的事实版本。

- `VideoInfo` 补 `tid` / `tid_v2`：同一 `/x/web-interface/view` 响应里本来就有、此前被直接丢掉的两个分区 id，**零额外请求**。
- 新增 `get_video_tags(bvid, limit=20) -> list[str]`：走 `/x/tag/archive/tags`（网页播放器标签行用的端点）取标签名。实测匿名 Cookie 也可读取，响应远轻于 `/x/web-interface/view/detail`（后者连带 Card / Related / Reply）。
- 不改变任何发现 / 推荐链路行为：标签**只在显式调用时**才拉取，`get_video_info()` 的请求数不变（新增测试锁定）。

## 实测证据（2026-09-11，本机真实 Cookie，只读）

样本：8 个分区各 1 个视频（rid 0/1/3/4/36/119/129/155/160/168），plain `/x/web-interface/view` 与 WBI `/x/web-interface/wbi/view` 两种变体都试过：

```
BV1eqYx6UE9V  tid=121  tid_v2=2071  tname=''  tname_v2=''  'tag' in payload=False
BV1B8ZJYTEPg  tid= 47  tid_v2=2037  tname=''  tname_v2=''  'tag' in payload=False
BV17VZpY1ENA  tid= 31  tid_v2=2020  tname=''  tname_v2=''  'tag' in payload=False
BV16io9YTEqH  tid=172  tid_v2=2041  tname=''  tname_v2=''  'tag' in payload=False
BV1soZJYUEKd  tid=124  tid_v2=2082  tname=''  tname_v2=''  'tag' in payload=False
BV1nwZEYqE2B  tid= 22  tid_v2=2063  tname=''  tname_v2=''  'tag' in payload=False
BV1ZNfwYWEvZ  tid= 20  tid_v2=2032  tname=''  tname_v2=''  'tag' in payload=False
BV1B3ZnYuEDP  tid=252  tid_v2=2039  tname=''  tname_v2=''  'tag' in payload=False

videos with non-empty tname/tname_v2: 0/8
```

也就是说：**`tag` 数组不存在，`tname` / `tname_v2` 恒为空串，真正在传的是 `tid` / `tid_v2` 两个数字**。标签得另找端点，实测 `/x/tag/archive/tags?bvid=` 可用：

```
BV1eqYx6UE9V -> ['三角洲行动', '三角洲行动二洲年', '洲彦祖再集结']
BV16io9YTEqH -> ['崩坏：星穹铁道', '崩坏星穹铁道', '遐蝶', '崩坏星穹铁道遐蝶', '走过安眠地的花丛', '米哈游', 'miHoYo']
BV1soZJYUEKd -> ['罗布泊无人区', '徒步', '警示教育']
（无 Cookie 的匿名 client 同样返回上述结果）
```

## 主要改动

| 文件 | 改动 |
|---|---|
| `src/openbiliclaw/bilibili/api.py` | `VideoInfo` 增 `tid` / `tid_v2`；`get_video_info()` 填充并在 docstring 写明实测事实；新增 `get_video_tags()` |
| `tests/test_bilibili_api.py` | 分区 id 填充、**请求数仍为 1** 的契约测试、标签解析（裸数组 / 空 / 空白名 / 畸形项 / limit / 错误传播），以及 null payload 补 `cid`/`tid`/`tid_v2` 断言 |
| `docs/modules/bilibili.md` | 能力表新增一行（含实测结论）、公开 API 片段补 `tid`/`tid_v2`/`get_video_tags` |
| `docs/changelog.md` | 「未发布」条目 |

## 测试

- [x] `ruff check src/ tests/` → All checks passed；`ruff format` → 无改动
- [x] `mypy src/`（CI 等价：`--platform linux`）→ Success: no issues found in 279 source files
- [x] `pytest tests/test_bilibili_api.py -q` → **43 passed**
- [x] `pytest tests/test_bilibili_api.py tests/test_danmaku.py tests/test_docs_saved_sync.py tests/test_web_weibo_surfaces.py tests/test_web_guided_init.py -q` → **138 passed**
- [x] 真实接口手工验证（上节）：`tid`/`tid_v2` 已填充、`get_video_tags()` 返回真实标签、匿名可用

## 与初版的差异（便于你 review）

初版提交 `257a737a` 已被本提交 `a8a94fce` 替换（PR 未被 review，用单个干净提交替代；原文在 `notes` 里留了 patch）。差异就是上面那条：去掉了不存在字段的读取逻辑，换成实测存在的字段 + 显式标签方法。

## 不在本次范围

把标签接入评估 prompt（例如只对摇摆区候选拉标签控成本）是后续独立改动，需要你确认成本口径；`/x/tag/archive/tags` 的返回条目里还有 `type` / `count` 等字段，本次只取 `tag_name`。

Refs #57, #232