### PR TITLE
fix(auth): require the CSRF header on the Bilibili next-task claim

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,12 @@
 
 ---
 
+## 未发布
+
+- **补上 B 站扩展任务的 CSRF 门禁**：`GET /api/sources/bili/next-task` 与其它来源的 `next-task` 一样是「pending → in_progress」的领取型 GET，但此前不在 `api/auth.py` 的 `_CSRF_GET_EXACT` 集合里 —— 带 cookie 的跨站顶层导航（`SameSite=Lax` 会随顶层 GET 发送会话 cookie，且 `Sec-Fetch-Site: cross-site` 已使本机免登录 fast path fail-closed）可以在没有 `X-OBC-Auth` 的情况下把一条 pending 的 B 站扩展任务置为 `in_progress`，而扩展永远收不到它，只能等租约回收。现在该路径与其余九个来源一起强制 `X-OBC-Auth`；扩展走 `Authorization: Bearer`（Bearer 豁免 CSRF），不受影响，本机 CLI / 扩展链路无行为变化。同时把 CSRF 回归从手抄路径列表改为**集合相等断言**（`tests/test_api_auth.py`：已注册的 `*/next-task` 路由集合 == `_CSRF_GET_EXACT` 中登记的 claim 路径），后续新增来源漏登记会直接失败，`docs/modules/api-auth.md` 的 CSRF 行同步更正为十个来源。
+
+---
+
 ## v0.3.221：保存 URL 归一化、B 站视频信息回退与 learned scorer 校准（2026-09-11）
 
 - **修复协议相对封面 URL 导致「稍后再看 / 收藏」422（issue #237）**：B 站等上游常见返回 `//i2.hdslb.com/...` 这类协议相对地址，入站 `SavedItemIn` 的 `content_url` / `cover_url` 在 `_validate_http_url` 校验前统一补全为 `https://...` 再入库；三个图形界面共用同一端点，无需各客户端自行兜底，非 HTTP(S)、带凭据、含空白或控制字符等非法值仍照旧拒绝。真实进程 + 真实 HTTP 回归：未修复的 main 提交返回 422，修复后 200 并落库为绝对地址。

--- a/docs/modules/api-auth.md
+++ b/docs/modules/api-auth.md
@@ -21,7 +21,7 @@
 | 记住登录 | ✅ | `session_ttl_hours=0`（默认）签发无 `exp` token + 超长 cookie `Max-Age`，关浏览器 / 重启后端都不失效。 |
 | HttpOnly cookie 凭据 | ✅ | 默认下发 `obc_session`（`HttpOnly; Path=/; SameSite=Lax`，host-only，`Secure` 仅当对外协议为 HTTPS），同源 fetch / `<img>` / WebSocket 自动携带；前端永不持有 token。 |
 | 跨源 Bearer 逃生通道 | ✅ | 仅当 Origin 命中 `allowed_bearer_origins` 且 `ttl>0`，登录才在 body 返回 token（`sessionStorage`）；同源 / 缺 Origin 一律 cookie-only（后端不变量）。 |
-| CSRF 防护 | ✅ | cookie 鉴权的非安全方法（POST/PUT/PATCH/DELETE）强制 `Origin==Host`（`same_origin()`）+ 头 `X-OBC-Auth: 1`；普通安全方法读取豁免，但 seven state-changing GET `/next-task` claim routes（XHS / 抖音 / YouTube / X / 知乎 / Reddit / V2EX）在精确路径集合中强制 `X-OBC-Auth`，因为领取会 claim+lock；Bearer / 可信本机豁免；WebSocket 握手按 `same_origin` 校验。 |
+| CSRF 防护 | ✅ | cookie 鉴权的非安全方法（POST/PUT/PATCH/DELETE）强制 `Origin==Host`（`same_origin()`）+ 头 `X-OBC-Auth: 1`；普通安全方法读取豁免，但十个 state-changing GET `/next-task` claim routes（B 站 / XHS / 抖音 / YouTube / X / 知乎 / Reddit / Linux.do / V2EX / 微博）与 `/api/recommendations` 在精确路径集合中强制 `X-OBC-Auth`，因为领取会 claim+lock / serve 会 bootstrap 写推荐历史；Bearer / 可信本机豁免；WebSocket 握手按 `same_origin` 校验。`tests/test_api_auth.py` 对「已注册的 claim 路由集合」与 `_CSRF_GET_EXACT` 做集合相等断言，新增来源漏登记会直接失败。 |
 | 撤销纪元 | ✅ | `auth_epoch` 存 SQLite `auth_state` 单行，跨进程事务原子自增、验签实时读。改密 / `--logout-all` / `--rotate-secret` / `POST /api/auth/logout?all=true` 都通过它撤销所有设备。 |
 | 改密即撤销（全通道） | ✅ | `password_fingerprint`（`HMAC(session_secret,"pw:"+明文)` 或 `"ph:"+hash`）在启动 / 重载时比对，变化即 `auth_epoch += 1`；scrypt 随机盐不会造成误撤销，永不过期登录跨重启不被误撤销。 |
 | 登录失败限流 | ✅ | 进程内按真实客户端 IP 计数，15 分钟内失败 ≥5 次锁 15 分钟，`POST /api/auth/login` 返回 429。可信本机不计入。 |

--- a/src/openbiliclaw/api/auth.py
+++ b/src/openbiliclaw/api/auth.py
@@ -46,6 +46,7 @@ _UNSAFE_METHODS = frozenset({"POST", "PUT", "PATCH", "DELETE"})
 # paths. See review r2#2 / r3#2.
 _CSRF_GET_EXACT = frozenset(
     {
+        "/api/sources/bili/next-task",
         "/api/sources/xhs/next-task",
         "/api/sources/dy/next-task",
         "/api/sources/yt/next-task",

--- a/tests/test_api_auth.py
+++ b/tests/test_api_auth.py
@@ -11,6 +11,7 @@ from uvicorn.middleware.proxy_headers import ProxyHeadersMiddleware
 
 from openbiliclaw import auth_core as ac
 from openbiliclaw.api.app import create_app
+from openbiliclaw.api.auth import _CSRF_GET_EXACT
 from openbiliclaw.storage.database import Database
 
 if TYPE_CHECKING:
@@ -311,6 +312,38 @@ def test_cookie_unsafe_method_requires_csrf(tmp_path, monkeypatch) -> None:
     assert ok.status_code == 200
 
 
+def _claim_route_paths(app: object) -> list[str]:
+    """Registered claim GETs (``*/next-task``), derived from the app itself.
+
+    Reading the routes instead of hand-copying a list keeps this regression
+    honest when a source is added later: a new ``next-task`` route appears here
+    automatically and must already be covered by the CSRF set.
+    """
+    return sorted(
+        path
+        for path in (str(getattr(route, "path", "")) for route in getattr(app, "routes", []))
+        if path.endswith("/next-task")
+    )
+
+
+def test_csrf_get_set_covers_every_registered_claim_route(tmp_path, monkeypatch) -> None:
+    """Set equality between the exact CSRF paths and the live claim routes.
+
+    Every ``next-task`` endpoint claims (pending → in_progress) and is therefore
+    write-shaped; a source that registers one without listing it in
+    ``_CSRF_GET_EXACT`` would ship an uncovered state change, and a stale entry
+    for a removed route would keep a dead path protected. Both directions fail
+    here.
+    """
+    app, _ = _build_app(tmp_path, monkeypatch)
+
+    registered = set(_claim_route_paths(app))
+    declared = {path for path in _CSRF_GET_EXACT if path.endswith("/next-task")}
+
+    assert registered, "the app under test registers no claim route"
+    assert declared == registered
+
+
 def test_mutating_get_task_claim_requires_csrf(tmp_path, monkeypatch) -> None:
     # /api/sources/*/next-task are GETs that claim+lock a task, so they
     # must be CSRF-protected for cookie auth (review r2#2). The middleware rejects
@@ -319,14 +352,7 @@ def test_mutating_get_task_claim_requires_csrf(tmp_path, monkeypatch) -> None:
     client = _remote(app)
     client.post("/api/auth/login", json={"password": "hunter2"}, headers={"origin": _ORIGIN})
     for path in (
-        "/api/sources/xhs/next-task",
-        "/api/sources/dy/next-task",
-        "/api/sources/yt/next-task",
-        "/api/sources/x/next-task",
-        "/api/sources/zhihu/next-task",
-        "/api/sources/reddit/next-task",
-        "/api/sources/linuxdo/next-task",
-        "/api/sources/v2ex/next-task",
+        *_claim_route_paths(app),
         "/api/recommendations",  # serve() bootstrap-writes rows
         "/api/chat/turns/abc123",  # GET resumes a pending turn
     ):

--- a/tests/test_extension_native_save_api.py
+++ b/tests/test_extension_native_save_api.py
@@ -444,7 +444,7 @@ def test_native_save_source_api_is_documented() -> None:
         "docs/modules/runtime.md": "extension_native_save_broker",
         "docs/modules/saved-sync.md": "global native ownership",
         "docs/modules/init.md": "legacy discovery/bootstrap queues",
-        "docs/modules/api-auth.md": "seven state-changing GET `/next-task`",
+        "docs/modules/api-auth.md": "十个 state-changing GET `/next-task`",
         "docs/architecture.md": "/api/sources/{xhs,dy,yt,x,zhihu,reddit}",
         "docs/spec.md": "native_save multiplex",
         "docs/architecture-overview.md": "八来源 source task multiplex",


### PR DESCRIPTION
## 变更摘要

`GET /api/sources/bili/next-task` 是「pending → in_progress」的**领取型 GET**（`app.py:14964`，`BiliTaskQueue.next_pending()` 会 claim + lock），和 XHS / 抖音 / YouTube / X / 知乎 / Reddit / Linux.do / V2EX / 微博 九个来源的 `next-task` 语义完全相同，但它此前**不在** `api/auth.py::_CSRF_GET_EXACT` 里。

后果（仅影响 cookie 鉴权路径）：

- 一个带 `Sec-Fetch-Site: cross-site` 的跨站**顶层导航**会让 `is_trusted_local()` fail-closed（不会走本机免登录 fast path），随后 `SameSite=Lax` 的 `obc_session` cookie 会随顶层 GET 发出并通过 token 校验；
- 由于 `_is_mutating_get("/api/sources/bili/next-task")` 返回 `False`，中间件不做 `X-OBC-Auth` 校验 → 该请求在**没有 CSRF 头**的情况下把一条 pending 的 B 站扩展任务置为 `in_progress`；
- 真实扩展再也领不到这条任务（它只会在租约到期后被回收），影响是任务饿死 / 桥接扰动，**不涉及数据外泄**。

九个已登记来源在同一场景下返回 `403 {"error": "csrf"}`，所以这是一处与 `docs/modules/api-auth.md` 已声明不变量不一致的漏登记。

## 主要改动

| 文件 | 改动 |
|---|---|
| `src/openbiliclaw/api/auth.py` | `_CSRF_GET_EXACT` 增加 `/api/sources/bili/next-task`（现共十个来源 + `/api/recommendations`） |
| `tests/test_api_auth.py` | 新增 `test_csrf_get_set_covers_every_registered_claim_route`：对「`app.routes` 中已注册的 `*/next-task` 路径集合」与「`_CSRF_GET_EXACT` 中登记的 claim 路径集合」做**集合相等**断言（双向：漏登记 / 已删路由的残留都会失败）；原 `test_mutating_get_task_claim_requires_csrf` 的手抄路径列表改为从已注册路由派生，新增来源会自动纳入 403 断言 |
| `docs/modules/api-auth.md` | CSRF 行从「seven state-changing GET」更正为十个来源，并记录集合相等测试 |
| `docs/changelog.md` | 新增「未发布」条目 |

## 测试

- [x] `ruff check src/ tests/` → All checks passed
- [x] `ruff format --check` → 2 files already formatted
- [x] `mypy src/`（CI 等价：`--platform linux`）→ Success: no issues found in 279 source files
- [x] `pytest tests/test_api_auth.py -q` → **69 passed**
- [x] `pytest tests/test_api_bili_tasks.py -q` → **8 passed**
- [x] **新增测试的有效性已验证**：把 `auth.py` 的这一行改动 `git stash` 掉后重跑，两个用例都失败
  ```
  FAILED tests/test_api_auth.py::test_csrf_get_set_covers_every_registered_claim_route
  FAILED tests/test_api_auth.py::test_mutating_get_task_claim_requires_csrf
  ```

## 为什么不影响扩展与本机链路

- 扩展的 `bili-task-dispatcher.ts:153` 走 `authenticatedFetch`（`shared/auth.ts:93`）→ 携带 `Authorization: Bearer`，中间件对「同时带有效 Bearer」的请求显式跳过 CSRF（`auth.py:358-367`）；
- 本机 CLI / 可信本机请求仍然走 `is_trusted_local()` 直接放行，行为不变；
- 本仓库 `tests/test_api_bili_tasks.py` 的调用方是可信本机 client，不受影响（已实测 8 passed）。

## 一个小请求

`docs/changelog.md` 的条目放在「未发布」段；如果与其它在途 PR 在同一位置冲突，麻烦以主线为准取舍，我这边可以随时 rebase。