### PR TITLE
fix(bilibili): make get_video_tags honour a non-positive limit

### DIFF
--- a/src/openbiliclaw/bilibili/api.py
+++ b/src/openbiliclaw/bilibili/api.py
@@ -651,7 +651,8 @@ class BilibiliAPIClient:
 
         Args:
             bvid: Bilibili video BV ID.
-            limit: Maximum number of tag names to return.
+            limit: Maximum number of tag names to return. Non-positive values
+                return an empty list without issuing a request.
 
         Returns:
             Tag names in payload order; blank names are skipped. Returns an
@@ -659,6 +660,9 @@ class BilibiliAPIClient:
             distinguish "no tags" from "fetch failed" must let the
             :class:`BilibiliAPIError` propagate.
         """
+        item_limit = max(0, int(limit))
+        if item_limit == 0:
+            return []
         data = await self._get_json("/x/tag/archive/tags", params={"bvid": bvid})
         tags: list[str] = []
         for item in _json_list(data):
@@ -667,7 +671,7 @@ class BilibiliAPIClient:
             name = str(item.get("tag_name", "") or "").strip()
             if name:
                 tags.append(name)
-            if len(tags) >= max(1, int(limit)):
+            if len(tags) >= item_limit:
                 break
         return tags
 

--- a/tests/test_bilibili_api.py
+++ b/tests/test_bilibili_api.py
@@ -1000,6 +1000,22 @@ async def test_get_video_tags_respects_limit() -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("limit", [0, -1])
+async def test_get_video_tags_non_positive_limit_returns_empty_without_request(
+    limit: int,
+) -> None:
+    """``limit`` is a hard maximum, so non-positive values yield no tags — and
+    short-circuit before any HTTP call, matching the other limit helpers.
+    """
+    client = BilibiliAPIClient(cookie="")
+    fake = FakeAsyncClient({"code": 0, "data": [{"tag_name": "标签0"}]})
+    client._client = fake
+
+    assert await client.get_video_tags("BV1xx", limit=limit) == []
+    assert fake.calls == []
+
+
+@pytest.mark.asyncio
 async def test_get_video_tags_propagates_api_errors() -> None:
     """A failed tag fetch must stay distinguishable from "this video has no
     tags": the error is not swallowed into an empty list.


### PR DESCRIPTION
## 背景

#241 合入后复查发现的一个小边界问题。

## 问题

`get_video_tags()` 里原本是 `max(1, int(limit))`：

```python
if len(tags) >= max(1, int(limit)):
    break
```

于是 `limit=0` 或负数会**返回第一条标签**（而不是空列表），并且仍然发起了 HTTP 请求 —— 这与 docstring 里 "Maximum number of tag names to return" 的契约不符，也和仓库其他 limit 用法（`max(0, int(x))` + `<=0` 提前返回，见 `get_favorites` 等）不一致。

## 改动

- `src/openbiliclaw/bilibili/api.py`：`item_limit = max(0, int(limit))`，`<=0` 时在发请求前直接返回 `[]`；docstring 补充非正值语义。
- `tests/test_bilibili_api.py`：新增参数化回归测试 `limit=0` / `-1`，同时断言结果为 `[]` 且**没有发起请求**。

## 验证

- 修复前跑新测试：`2 failed`（确认是有效回归测试）
- 修复后：
  - `pytest tests/test_bilibili_api.py -q` → **45 passed**
  - `ruff check` / `ruff format --check` → 通过
  - `mypy src/openbiliclaw/bilibili/api.py --platform linux` → Success

## 范围

只修正这一个边界语义，不改变正常 `limit>0` 的行为（`limit=2` 等用例保持通过）。

Refs #241