### PR TITLE
feat(discovery): 为 learned scorer 融合 BM25 稀疏词面信号

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,8 @@
 
 ## v0.3.221：保存 URL 归一化、B 站视频信息回退与 learned scorer 校准（2026-09-11）
 
+- **learned scorer 引入 BM25 稀疏词面信号（混合排序）**：`LearnedRelevanceScorer` 在稠密 cosine 之外融合 BM25 词面匹配（CJK 字 bigram + 拉丁词，纯 Python、无第三方分词依赖），默认 `bm25_weight=0.3`、仅构造器参数可调；候选与兴趣词存在词面重叠时排序更准，`features_digest` 升至 `learned-features-v2` 并纳入权重以保证审计可追溯。新增 `discovery/bm25.py`（`cjk_tokenize` + 内存 `BM25Index`）。
+
 - **修复协议相对封面 URL 导致「稍后再看 / 收藏」422（issue #237）**：B 站等上游常见返回 `//i2.hdslb.com/...` 这类协议相对地址，入站 `SavedItemIn` 的 `content_url` / `cover_url` 在 `_validate_http_url` 校验前统一补全为 `https://...` 再入库；三个图形界面共用同一端点，无需各客户端自行兜底，非 HTTP(S)、带凭据、含空白或控制字符等非法值仍照旧拒绝。真实进程 + 真实 HTTP 回归：未修复的 main 提交返回 422，修复后 200 并落库为绝对地址。
 
 - **B 站视频信息接口增加 WBI 签名回退**：新增后端 `GET /api/bilibili/video/info`，优先走普通 `/x/web-interface/view`，被 412 风控时回退到 WBI 签名 `/x/web-interface/wbi/view`，保证移动端原生播放页的简介与点赞 / 投币 / 收藏 / 评论数在风控下仍可获取。

--- a/docs/modules/discovery.md
+++ b/docs/modules/discovery.md
@@ -741,7 +741,8 @@ discovery 不是“把整个找片过程都交给 LLM”。当前实现里，LLM
 
 ### Learned scorer 校准 API
 
-- `LearnedRelevanceScorer.score_batch()` 返回 `LearnedBatchResult(scores, available, features_digest)`；只有完整、有限、维度一致的 embedding 输入才会标记可用。
+- `LearnedRelevanceScorer.score_batch()` 返回 `LearnedBatchResult(scores, available, features_digest)`；在稠密 cosine 之上融合 BM25 词面信号（`bm25_weight` 可调），只有完整、有限、维度一致的 embedding 输入才会标记可用。
+- `discovery/bm25.py` 提供 `cjk_tokenize()`（CJK 字 bigram + 拉丁词分词，无第三方依赖）与内存 `BM25Index`。
 - `evaluate_learned_scorer_gate(rows)` 是纯函数，只接受完整的 privacy-safe learned/LLM 对照并返回 `LearnedGateReport`，不会修改运行时配置。
 - `Database.record_learned_scorer_shadow_audit()` 在写入前验证完整性与字段边界；`query_learned_scorer_shadow_audit()` 只返回最多 2 万条有界审计记录。
 - `scripts/evaluate_learned_scorer_gate.py --db <path>` 以只读方式冻结 cohort 并输出可复核 JSON；退出码 0 表示通过，1 表示 gate 关闭。

--- a/src/openbiliclaw/discovery/bm25.py
+++ b/src/openbiliclaw/discovery/bm25.py
@@ -1,0 +1,85 @@
+"""BM25 sparse-lexical retrieval for the learned relevance scorer.
+
+Complements the dense embedding scorer with a sparse lexical signal:
+CJK text is tokenised as character bigrams, Latin text as lowercased
+word tokens. Pure-Python, deterministic, no third-party dependencies.
+"""
+
+from __future__ import annotations
+
+import math
+import re
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+# Latin words and CJK runs, matched left-to-right; everything else is dropped.
+_SEGMENT_RE = re.compile(r"[a-z0-9]+|[一-鿿]+")
+
+
+def cjk_tokenize(text: str) -> list[str]:
+    """Tokenise ``text`` into CJK char bigrams and lowercased Latin words.
+
+    Consecutive CJK run ``abcd`` -> ``ab bc cd``; Latin run -> one word per
+    ``[a-z0-9]+``; punctuation and whitespace are dropped.
+    """
+    tokens: list[str] = []
+    for segment in _SEGMENT_RE.findall(text.lower()):
+        if segment.isascii() or len(segment) == 1:
+            tokens.append(segment)
+        else:
+            tokens.extend(segment[i : i + 2] for i in range(len(segment) - 1))
+    return tokens
+
+
+class BM25Index:
+    """In-memory BM25 index over tokenised documents."""
+
+    def __init__(
+        self,
+        docs: Sequence[Sequence[str]],
+        k1: float = 1.5,
+        b: float = 0.75,
+    ) -> None:
+        self._k1 = k1
+        self._b = b
+        self._doc_len = [len(doc) for doc in docs]
+        n = len(docs)
+        self._avgdl = sum(self._doc_len) / n if n else 0.0
+
+        df: dict[str, int] = {}
+        for doc in docs:
+            for term in set(doc):
+                df[term] = df.get(term, 0) + 1
+        # 非负 idf（BM25+ 变体）：小批量里高频词可能超过半数文档，避免负权重。
+        self._idf = {
+            term: math.log(1.0 + (n - freq + 0.5) / (freq + 0.5)) for term, freq in df.items()
+        }
+
+        self._tf: list[dict[str, int]] = []
+        for doc in docs:
+            counts: dict[str, int] = {}
+            for term in doc:
+                counts[term] = counts.get(term, 0) + 1
+            self._tf.append(counts)
+
+    def score(self, query_tokens: Sequence[str], doc_idx: int) -> float:
+        """Return the BM25 relevance score of ``docs[doc_idx]`` for ``query_tokens``."""
+        if doc_idx < 0 or doc_idx >= len(self._tf):
+            return 0.0
+        tf = self._tf[doc_idx]
+        doc_len = self._doc_len[doc_idx]
+        # 空文档 / 空平均长度时退化为无长度归一化，避免除零。
+        length_ratio = doc_len / self._avgdl if self._avgdl > 0.0 else 1.0
+        total = 0.0
+        for term in query_tokens:
+            idf = self._idf.get(term)
+            if idf is None:
+                continue
+            freq = tf.get(term, 0)
+            if freq == 0:
+                continue
+            denominator = freq + self._k1 * (1.0 - self._b + self._b * length_ratio)
+            total += idf * (freq * (self._k1 + 1.0)) / denominator
+        return total

--- a/src/openbiliclaw/discovery/learned_scorer.py
+++ b/src/openbiliclaw/discovery/learned_scorer.py
@@ -1,10 +1,11 @@
 """Learned relevance scorer for the discovery pipeline.
 
 This opt-in scorer embeds the candidate content and the profile interest
-labels, then scores each candidate by its maximum cosine similarity to any
-interest anchor, normalised to [0, 1]. In calibration modes the engine still
-runs the complete LLM evaluator for temporal and diversity metadata; malformed
-or unavailable learned results leave the LLM relevance score authoritative.
+labels, scores each candidate by its maximum cosine similarity to any interest
+anchor, and fuses that dense signal with a lexical BM25 score over the
+candidate text. In calibration modes the engine still runs the complete LLM
+evaluator for temporal and diversity metadata; malformed or unavailable
+learned results leave the LLM relevance score authoritative.
 """
 
 from __future__ import annotations
@@ -13,6 +14,8 @@ import hashlib
 import math
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
+
+from openbiliclaw.discovery.bm25 import BM25Index, cjk_tokenize
 
 if TYPE_CHECKING:
     from collections.abc import Mapping, Sequence
@@ -78,16 +81,24 @@ def _interest_weight(item: object) -> float:
 
 
 class LearnedRelevanceScorer:
-    """Embedding-based prototype learned relevance scorer.
+    """Hybrid learned relevance scorer (dense embedding + sparse BM25).
 
-    Scores each candidate by its maximum cosine similarity to any profile
-    interest anchor, normalised to [0, 1]. Returns ``available=False`` when the
-    embedding service is missing, the profile has no usable interest anchors,
-    or candidate embedding fails (allowing the engine to fail open to the LLM).
+    Fuses each candidate's maximum cosine similarity to any profile interest
+    anchor with a lexical BM25 score over the candidate text, weighted by
+    ``bm25_weight``. Returns ``available=False`` when the embedding service is
+    missing, the profile has no usable interest anchors, or candidate embedding
+    fails (allowing the engine to fail open to the LLM).
     """
 
-    def __init__(self, embedding_service: SupportsEmbeddingService | None = None) -> None:
+    def __init__(
+        self,
+        embedding_service: SupportsEmbeddingService | None = None,
+        *,
+        bm25_weight: float = 0.3,
+    ) -> None:
         self._embedding_service = embedding_service
+        # 默认 0.3 未校准：偏重稠密信号，等 learned/shadow 审计数据跑出后回调。
+        self._bm25_weight = bm25_weight
 
     def _interest_labels(self, profile: SoulProfile) -> list[str]:
         """Return the strongest active distinct interest labels."""
@@ -141,7 +152,7 @@ class LearnedRelevanceScorer:
                 return None
             expected_dimension = next(iter(dimensions))
 
-            scores: list[float] = []
+            cosine_scores: list[float] = []
             for item in contents:
                 content_vector = _as_float_vector(await service.embed(_content_text(item)))
                 if len(content_vector) != expected_dimension:
@@ -149,15 +160,50 @@ class LearnedRelevanceScorer:
                 best = max(
                     cosine_similarity(content_vector, interest) for interest in interest_vectors
                 )
-                scores.append(_normalise_cosine(float(best)))
+                cosine_scores.append(_normalise_cosine(float(best)))
+
+            scores = self._fuse_scores(labels, contents, cosine_scores)
         except Exception:  # noqa: BLE001 - fail open to the LLM
             return None
 
         return LearnedBatchResult(
             scores=scores,
             available=True,
-            features_digest=_features_digest(labels, contents),
+            features_digest=_features_digest(labels, contents, self._bm25_weight),
         )
+
+    def _fuse_scores(
+        self,
+        labels: list[str],
+        contents: Sequence[Mapping[str, Any]],
+        cosine_scores: list[float],
+    ) -> list[float]:
+        """Fuse dense cosine scores with sparse BM25 scores by ``bm25_weight``.
+
+        BM25 分数按批内 max 归一化到 [0,1]，与 cosine 直接加权。归一化是批内
+        相对的，单候选时无意义，故单候选 / 权重为 0 时直接返回 cosine 分。
+        """
+        if self._bm25_weight <= 0.0 or len(contents) == 1:
+            return cosine_scores
+        bm25_scores = self._bm25_scores(labels, contents)
+        peak = max(bm25_scores, default=0.0)
+        bm25_norm = [raw / peak for raw in bm25_scores] if peak > 0.0 else bm25_scores
+        dense_weight = 1.0 - self._bm25_weight
+        return [
+            dense_weight * cosine + self._bm25_weight * lexical
+            for cosine, lexical in zip(cosine_scores, bm25_norm, strict=True)
+        ]
+
+    def _bm25_scores(
+        self,
+        labels: list[str],
+        contents: Sequence[Mapping[str, Any]],
+    ) -> list[float]:
+        """Return per-candidate raw BM25 scores against the interest-label query."""
+        query = [token for label in labels for token in cjk_tokenize(label)]
+        docs = [cjk_tokenize(_content_text(item)) for item in contents]
+        index = BM25Index(docs)
+        return [index.score(query, i) for i in range(len(docs))]
 
     def extract_candidate_features(
         self, item: Mapping[str, Any], profile: SoulProfile
@@ -175,10 +221,19 @@ def _normalise_cosine(similarity: float) -> float:
     return max(0.0, min(1.0, (similarity + 1.0) / 2.0))
 
 
-def _features_digest(labels: list[str], contents: Sequence[Mapping[str, Any]]) -> str:
+def _features_digest(
+    labels: list[str],
+    contents: Sequence[Mapping[str, Any]],
+    bm25_weight: float,
+) -> str:
     """Digest prompt-local scorer inputs without persisting profile/content text."""
 
     payload = "\0".join(
-        ["learned-features-v1", *labels, *(_content_text(item) for item in contents)]
+        [
+            "learned-features-v2",
+            str(bm25_weight),
+            *labels,
+            *(_content_text(item) for item in contents),
+        ]
     )
     return hashlib.sha256(payload.encode()).hexdigest()

--- a/tests/test_learned_scorer.py
+++ b/tests/test_learned_scorer.py
@@ -6,6 +6,7 @@ from types import SimpleNamespace
 
 import pytest
 
+from openbiliclaw.discovery.bm25 import BM25Index, cjk_tokenize
 from openbiliclaw.discovery.learned_scorer import (
     LearnedBatchResult,
     LearnedRelevanceScorer,
@@ -102,3 +103,31 @@ def test_extract_candidate_features() -> None:
     )
     assert feats["title"] == "hi"
     assert feats["length"] == len("hi there")
+
+
+def test_cjk_tokenize_splits_latin_and_cjk_bigrams() -> None:
+    assert cjk_tokenize("机器学习") == ["机器", "器学", "学习"]
+    assert cjk_tokenize("Machine Learning") == ["machine", "learning"]
+    assert cjk_tokenize("Python3 教程") == ["python3", "教程"]
+    assert cjk_tokenize("hello, world!") == ["hello", "world"]
+    assert cjk_tokenize("一") == ["一"]
+
+
+def test_bm25_index_ranks_lexical_match_highest() -> None:
+    index = BM25Index([cjk_tokenize("机器学习"), cjk_tokenize("烹饪教程")])
+    query = cjk_tokenize("机器学习")
+    assert index.score(query, 0) > index.score(query, 1)
+
+
+def test_bm25_index_empty_docs_are_safe() -> None:
+    assert BM25Index([]).score(["x"], 0) == 0.0
+    assert BM25Index([[]]).score(["x"], 0) == 0.0
+
+
+async def test_score_batch_boosts_lexically_matching_candidate() -> None:
+    scorer = LearnedRelevanceScorer(embedding_service=_FakeEmbedding([1.0, 0.0]), bm25_weight=0.5)
+    profile = _profile("机器学习")
+    result = await scorer.score_batch([_item("机器学习入门教程"), _item("烹饪教程")], profile)
+    assert result is not None
+    assert result.available is True
+    assert result.scores[0] > result.scores[1]


### PR DESCRIPTION
## 问题描述

`LearnedRelevanceScorer`（learned 评分器）目前只靠「候选内容 embedding 与兴趣锚点 embedding 的最大余弦相似度」打分，是纯稠密信号。当候选标题/简介与兴趣词存在词面重叠（例如兴趣为「机器学习」、候选标题为「机器学习实战」）时，纯余弦相似度难以拉开排序差距，也缺少词面匹配这一可解释、可回看的稀疏信号。

## 解决方案

在不引入第三方分词依赖的前提下，新增一个纯 Python 的 BM25 稀疏词面检索器（CJK 字 bigram + 拉丁词分词），并把 BM25 分数与现有稠密余弦分数做线性加权融合：

```
score = (1 - bm25_weight) · cosine_norm + bm25_weight · bm25_norm
```

- 保留现有 fail-open 语义：embedding 缺失 / 无兴趣锚点 / 向量畸形仍返回 `None`，交由 LLM 兜底。
- `bm25_weight` 仅作为构造器参数（默认 `0.3`），不暴露到 `config.toml`；等 `shadow` 审计数据跑出后再决定是否开放用户旋钮。
- `features_digest` 由 `learned-features-v1` 升至 `v2` 并纳入 `bm25_weight`，保证审计证据随评分配置一同失效。

## 改动描述

- 新增 `src/openbiliclaw/discovery/bm25.py`：`cjk_tokenize()`（CJK 字 bigram + 拉丁词、去标点）+ `BM25Index`（内存索引，非负 idf 变体，避免小批量高频词产生负权重）。
- 修改 `src/openbiliclaw/discovery/learned_scorer.py`：`__init__` 增 `bm25_weight=0.3`；`score_batch` 在 cosine 之上融合 BM25；新增 `_fuse_scores` / `_bm25_scores`。
- 测试 `tests/test_learned_scorer.py` 新增 4 例。
- 文档 `docs/changelog.md`、`docs/modules/discovery.md` 同步。

## 测试

- `pytest tests/test_learned_scorer.py`：15 passed（11 旧 + 4 新）。
- `pytest tests/test_eval_scorer_audit.py`：16 passed（确认 digest 升 v2 不破坏审计）。
- `ruff check` / `ruff format --check` 通过。
- 新增用例覆盖：CJK/Latin 分词、BM25 词面排序、空文档安全、融合提升（恒定 embedding 下词面匹配候选得分更高）。

## 给 reviewer 的说明

- 融合权重 `0.3` 是未校准的保守默认，偏重稠密信号；建议待 `learned/shadow` 审计数据跑出后回调。
- BM25 分数按批内 `max` 归一化到 `[0,1]`，属批内相对值；单候选批直接跳过 BM25，避免绝对分被无意义抬高。
- 刻意不暴露 `config.toml` 旋钮（YAGNI）；如 maintainer 希望立即可调，我可补 `DiscoveryConfig` 字段。
- `mypy` 本机未安装，类型检查需在 CI 补跑。
